### PR TITLE
MOUNT: support multiple exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "anstream"
@@ -80,15 +80,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "byteorder"
@@ -119,9 +119,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
@@ -312,15 +312,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags",
  "libc",
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -345,28 +345,28 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -446,9 +446,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -481,9 +481,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "beef09f85ae72cea1ef96ba6870c51e6382ebfa4f0e85b643459331f3daa5be0"
 dependencies = [
  "unicode-ident",
 ]
@@ -499,18 +499,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "scopeguard"
@@ -529,27 +529,24 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -569,9 +566,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -580,12 +577,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -632,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -643,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -696,9 +692,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "winapi"
@@ -727,15 +723,6 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,59 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "async-trait"
@@ -30,15 +80,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -46,14 +96,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "byteorder"
@@ -69,9 +119,54 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.5.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1f056bae57e3e54c3375c41ff79619ddd13460a17d7438712bd0d83fda4ff8"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "filetime"
@@ -82,7 +177,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -181,6 +276,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "intaglio"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,15 +312,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags",
  "libc",
@@ -222,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -238,28 +345,28 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -268,6 +375,8 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "byteorder",
+ "clap",
+ "clap_derive",
  "filetime",
  "futures",
  "intaglio",
@@ -275,7 +384,6 @@ dependencies = [
  "num-traits",
  "tokio",
  "tracing",
- "tracing-attributes",
  "tracing-subscriber",
 ]
 
@@ -325,6 +433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,9 +446,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -342,15 +456,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -367,9 +481,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.96"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beef09f85ae72cea1ef96ba6870c51e6382ebfa4f0e85b643459331f3daa5be0"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -385,18 +499,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "scopeguard"
@@ -415,24 +529,27 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
@@ -441,14 +558,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.104"
+name = "strsim"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -457,11 +580,12 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -481,7 +605,7 @@ dependencies = [
  "slab",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -508,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -519,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -559,6 +683,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,9 +696,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
@@ -593,12 +723,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -607,14 +761,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -624,10 +795,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -636,10 +819,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -648,10 +843,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -660,7 +867,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ num-derive = "0.4"
 num-traits = "0.2"
 tokio = { version = "1.47", features = ["full", "time"] }
 tracing = "0.1.41"
-tracing-attributes = "0.1.3"
 
 [dev-dependencies]
+clap = "4.5.41"
+clap_derive = "4.5.41"
 intaglio = { version = "1.6" }
 tracing-subscriber = { version = "0.3", features = ["tracing-log"] }
 

--- a/examples/demo_fs/main.rs
+++ b/examples/demo_fs/main.rs
@@ -1,3 +1,6 @@
+use clap::Parser;
+use clap_derive::Parser;
+
 use nfs_mamont::tcp::{NFSTcp, NFSTcpListener};
 
 /// Implements the core file system functionality
@@ -10,6 +13,12 @@ mod fs_entry;
 /// Port number on which the NFS server will listen
 const HOSTPORT: u32 = 11111;
 
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long)]
+    multi_export: bool,
+}
+
 /// Demo NFS server implementation using the nfs-mamont library.
 /// Shows how to create a simple in-memory file system that supports NFS operations.
 #[tokio::main]
@@ -19,10 +28,19 @@ async fn main() {
         .with_writer(std::io::stderr)
         .init();
 
-    println!("Starting NFS server on 0.0.0.0:{HOSTPORT}");
-    println!("You can mount it with: sudo mount -o proto=tcp,port={HOSTPORT},mountport={HOSTPORT},nolock,addr=127.0.0.1 127.0.0.1:/ /mnt/nfs");
+    let args = Args::parse();
 
-    let listener =
-        NFSTcpListener::bind(&format!("0.0.0.0:{HOSTPORT}"), fs::DemoFS::default()).await.unwrap();
+    println!("Starting NFS server on 0.0.0.0:{HOSTPORT}");
+
+    let mut listener = NFSTcpListener::bind(&format!("0.0.0.0:{HOSTPORT}")).await.unwrap();
+    if !args.multi_export {
+        let fs = fs::DemoFS::default();
+        listener.register_export(fs).await.unwrap();
+    } else {
+        let fs_one = fs::DemoFS::default();
+        let fs_two = fs::DemoFS::default();
+        listener.register_export_with_name(fs_one, "one").await.unwrap();
+        listener.register_export_with_name(fs_two, "two").await.unwrap();
+    }
     listener.handle_forever().await.unwrap();
 }

--- a/examples/demo_fs/main.rs
+++ b/examples/demo_fs/main.rs
@@ -35,7 +35,7 @@ async fn main() {
     let mut listener = NFSTcpListener::bind(&format!("0.0.0.0:{HOSTPORT}")).await.unwrap();
     if !args.multi_export {
         let fs = fs::DemoFS::default();
-        listener.register_export(fs).await.unwrap();
+        listener.register_root_export(fs).await.unwrap();
     } else {
         let fs_one = fs::DemoFS::default();
         let fs_two = fs::DemoFS::default();

--- a/examples/demo_fs/readme.md
+++ b/examples/demo_fs/readme.md
@@ -1,0 +1,32 @@
+### Simple NFS Export Example
+
+This is a default behavior of the example. It creates a single NFS export using the simple in-memory filesystem.
+
+You can run it with:
+```shell
+cargo run --example demofs
+```
+
+And mount with:
+```shell
+sudo mount -o proto=tcp,port=11111,mountport=11111,nolock,addr=127.0.0.1,vers=3 127.0.0.1:/ /mnt/nfs
+```
+
+
+### Multiple NFS Exports Example
+
+This example demonstrates how to set up multiple NFS exports.
+
+It creates two exports, `/one` and `/two`, both using DemoFS from the previous example.
+
+You can run it with:
+```shell
+cargo run --example demofs -- --multi-export
+```
+
+And mount with:
+```shell
+sudo mount -o proto=tcp,port=11111,mountport=11111,nolock,addr=127.0.0.1,vers=3 127.0.0.1:/one /mnt/nfs_one
+sudo mount -o proto=tcp,port=11111,mountport=11111,nolock,addr=127.0.0.1,vers=3 127.0.0.1:/two /mnt/nfs_two
+```
+

--- a/examples/mirror_fs/main.rs
+++ b/examples/mirror_fs/main.rs
@@ -26,6 +26,7 @@ async fn main() {
     let path = PathBuf::from(path);
 
     let fs = fs::MirrorFS::new(path);
-    let listener = NFSTcpListener::bind(&format!("127.0.0.1:{HOSTPORT}"), fs).await.unwrap();
+    let mut listener = NFSTcpListener::bind(&format!("127.0.0.1:{HOSTPORT}")).await.unwrap();
+    listener.register_export(fs).await.unwrap();
     listener.handle_forever().await.unwrap();
 }

--- a/examples/mirror_fs/main.rs
+++ b/examples/mirror_fs/main.rs
@@ -27,6 +27,6 @@ async fn main() {
 
     let fs = fs::MirrorFS::new(path);
     let mut listener = NFSTcpListener::bind(&format!("127.0.0.1:{HOSTPORT}")).await.unwrap();
-    listener.register_export(fs).await.unwrap();
+    listener.register_root_export(fs).await.unwrap();
     listener.handle_forever().await.unwrap();
 }

--- a/src/protocol/nfs/mount/export.rs
+++ b/src/protocol/nfs/mount/export.rs
@@ -30,10 +30,9 @@ pub async fn mountproc3_export(
     context: &rpc::Context,
 ) -> io::Result<()> {
     debug!("mountproc3_export({:?}) ", xid);
-    let export_table = context.export_table.read().await;
     xdr::rpc::make_success_reply(xid).serialize(output)?;
     // Serialize each export entry
-    for mount_entry in export_table.values() {
+    for mount_entry in context.export_table.iter() {
         true.serialize(output)?;
         // Dirpath of the export
         mount_entry.export_name.as_bytes().serialize(output)?;

--- a/src/protocol/nfs/mount/export.rs
+++ b/src/protocol/nfs/mount/export.rs
@@ -15,8 +15,6 @@ use crate::protocol::xdr::{self, Serialize};
 /// Function returns a list of all the exported file
 /// systems and which clients are allowed to mount each one.
 ///
-/// TODO: Currently function returns only one mount point in the list without groups.
-///
 /// # Arguments
 ///
 /// * `xid` - RPC transaction ID
@@ -26,19 +24,23 @@ use crate::protocol::xdr::{self, Serialize};
 /// # Returns
 ///
 /// * `io::Result<()>` - Ok(()) on success or an error
-pub fn mountproc3_export(
+pub async fn mountproc3_export(
     xid: u32,
     output: &mut impl Write,
     context: &rpc::Context,
 ) -> io::Result<()> {
     debug!("mountproc3_export({:?}) ", xid);
+    let export_table = context.export_table.read().await;
     xdr::rpc::make_success_reply(xid).serialize(output)?;
-    true.serialize(output)?;
-    // Dirpath of one export
-    context.export_name.as_bytes().serialize(output)?;
-    // No groups
-    false.serialize(output)?;
-    // No next exports
+    // Serialize each export entry
+    for mount_entry in export_table.values() {
+        true.serialize(output)?;
+        // Dirpath of the export
+        mount_entry.export_name.as_bytes().serialize(output)?;
+        // No groups
+        false.serialize(output)?;
+    }
+    // No more exports
     false.serialize(output)?;
     Ok(())
 }

--- a/src/protocol/nfs/mount/mnt.rs
+++ b/src/protocol/nfs/mount/mnt.rs
@@ -16,9 +16,6 @@ use crate::protocol::xdr::{self, deserialize, mount, Serialize};
 /// Function returns file handle for the requested
 /// mount point and supported authentication flavors.
 ///
-/// TODO: Currently there is only one mount point, to support
-/// full functionality we need to extend support for multiple mount points.
-///
 /// # Arguments
 ///
 /// * `xid` - RPC transaction ID
@@ -36,31 +33,55 @@ pub async fn mountproc3_mnt(
     context: &rpc::Context,
 ) -> io::Result<()> {
     let path = deserialize::<Vec<u8>>(input)?;
+
+    if path.len() > mount::MNTPATHLEN as usize {
+        debug!("{:?} --> MNT3ERR_NAMETOOLONG", xid);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        mount::mountstat3::MNT3ERR_NAMETOOLONG.serialize(output)?;
+        return Ok(());
+    }
+
     let utf8path = std::str::from_utf8(&path).unwrap_or_default();
     debug!("mountproc3_mnt({:?},{:?}) ", xid, utf8path);
-    let path = if let Some(path) = utf8path.strip_prefix(context.export_name.as_str()) {
-        let path = path.trim_start_matches('/').trim_end_matches('/').trim().as_bytes();
-        let mut new_path = Vec::with_capacity(path.len() + 1);
-        new_path.push(b'/');
-        new_path.extend_from_slice(path);
-        new_path
-    } else {
+
+    let export_table = context.export_table.read().await;
+
+    // Find the matching export
+    let Some((&fs_id, mount_entry)) =
+        export_table.iter().find(|(_fs_id, entry)| utf8path.starts_with(&entry.export_name))
+    else {
         // invalid export
         debug!("{:?} --> no matching export", xid);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         mount::mountstat3::MNT3ERR_NOENT.serialize(output)?;
         return Ok(());
     };
-    if let Ok(fileid) = context.vfs.path_to_id(&path).await {
+
+    let vfs = mount_entry.vfs.clone();
+
+    let path = {
+        let path = utf8path
+            .strip_prefix(mount_entry.export_name.as_str())
+            .unwrap()
+            .trim_matches('/')
+            .trim()
+            .as_bytes();
+        let mut new_path = Vec::with_capacity(path.len() + 1);
+        new_path.push(b'/');
+        new_path.extend_from_slice(path);
+        new_path
+    };
+
+    if let Ok(fileid) = vfs.path_to_id(&path).await {
         let response = mount::mountres3_ok {
-            fhandle: context.vfs.id_to_fh(fileid).data,
+            fhandle: vfs.id_to_fh(fileid, fs_id),
             auth_flavors: vec![
                 xdr::rpc::auth_flavor::AUTH_NULL.to_u32().unwrap(),
                 xdr::rpc::auth_flavor::AUTH_UNIX.to_u32().unwrap(),
             ],
         };
         debug!("{:?} --> {:?}", xid, response);
-        if let Some(ref chan) = context.mount_signal {
+        if let Some(ref chan) = mount_entry.mount_signal {
             let _ = chan.send(true).await;
         }
         xdr::rpc::make_success_reply(xid).serialize(output)?;

--- a/src/protocol/nfs/mount/mnt.rs
+++ b/src/protocol/nfs/mount/mnt.rs
@@ -86,7 +86,7 @@ pub async fn mountproc3_mnt(
             ],
         };
         debug!("{:?} --> {:?}", xid, response);
-        if let Some(ref chan) = mount_entry.mount_signal {
+        if let Some(chan) = &mount_entry.mount_signal {
             let _ = chan.send(true).await;
         }
         xdr::rpc::make_success_reply(xid).serialize(output)?;

--- a/src/protocol/nfs/mount/mnt.rs
+++ b/src/protocol/nfs/mount/mnt.rs
@@ -11,6 +11,8 @@ use tracing::{debug, warn};
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, mount, Serialize};
 
+use super::matches_export_path;
+
 /// Handles `MOUNTPROC3_MNT` procedure.
 ///
 /// Function returns file handle for the requested
@@ -52,8 +54,9 @@ pub async fn mountproc3_mnt(
     let export_table = context.export_table.read().await;
 
     // Find the matching export
-    let Some((&fs_id, mount_entry)) =
-        export_table.iter().find(|(_fs_id, entry)| utf8path.starts_with(&entry.export_name))
+    let Some((&fs_id, mount_entry)) = export_table
+        .iter()
+        .find(|(_fs_id, entry)| matches_export_path(utf8path, &entry.export_name))
     else {
         // invalid export
         debug!("{:?} --> no matching export", xid);

--- a/src/protocol/nfs/mount/mnt.rs
+++ b/src/protocol/nfs/mount/mnt.rs
@@ -51,12 +51,9 @@ pub async fn mountproc3_mnt(
     };
     debug!("mountproc3_mnt({:?},{:?}) ", xid, utf8path);
 
-    let export_table = context.export_table.read().await;
-
     // Find the matching export
-    let Some((&fs_id, mount_entry)) = export_table
-        .iter()
-        .find(|(_fs_id, entry)| matches_export_path(utf8path, &entry.export_name))
+    let Some(mount_entry) =
+        context.export_table.iter().find(|entry| matches_export_path(utf8path, &entry.export_name))
     else {
         // invalid export
         debug!("{:?} --> no matching export", xid);
@@ -82,7 +79,7 @@ pub async fn mountproc3_mnt(
 
     if let Ok(fileid) = vfs.path_to_id(&path).await {
         let response = mount::mountres3_ok {
-            fhandle: vfs.id_to_fh(fileid, fs_id),
+            fhandle: vfs.id_to_fh(fileid, *mount_entry.key()),
             auth_flavors: vec![
                 xdr::rpc::auth_flavor::AUTH_NULL.to_u32().unwrap(),
                 xdr::rpc::auth_flavor::AUTH_UNIX.to_u32().unwrap(),

--- a/src/protocol/nfs/mount/mnt.rs
+++ b/src/protocol/nfs/mount/mnt.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::io::{Read, Write};
 
 use num_traits::cast::ToPrimitive;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, mount, Serialize};
@@ -41,7 +41,12 @@ pub async fn mountproc3_mnt(
         return Ok(());
     }
 
-    let utf8path = std::str::from_utf8(&path).unwrap_or_default();
+    let Ok(utf8path) = std::str::from_utf8(&path) else {
+        warn!("Invalid UTF-8 path in umnt: {:?}", path);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        mount::mountstat3::MNT3ERR_NOENT.serialize(output)?;
+        return Ok(());
+    };
     debug!("mountproc3_mnt({:?},{:?}) ", xid, utf8path);
 
     let export_table = context.export_table.read().await;

--- a/src/protocol/nfs/mount/mod.rs
+++ b/src/protocol/nfs/mount/mod.rs
@@ -21,6 +21,31 @@ use null::mountproc3_null;
 use umnt::mountproc3_umnt;
 use umnt_all::mountproc3_umnt_all;
 
+/// Checks if a requested path matches an export path with proper path separator handling.
+///
+/// This function prevents incorrect matches like `/data2/file` matching `/data` export
+/// by ensuring that after the export name prefix, we either have the end of the string
+/// or a path separator (`/`).
+///
+/// # Arguments
+///
+/// * `requested_path` - The path being requested by the client
+/// * `export_name` - The export path to match against
+///
+/// # Returns
+///
+/// * `bool` - true if the requested path properly matches the export
+fn matches_export_path(requested_path: &str, export_name: &str) -> bool {
+    if requested_path == export_name {
+        true
+    } else if requested_path.starts_with(export_name) {
+        // Check that the character after the export name is a path separator
+        requested_path.chars().nth(export_name.len()) == Some('/')
+    } else {
+        false
+    }
+}
+
 /// Main handler for `MOUNT` procedures of version 3 protocol.
 ///
 /// TODO: `MOUNTPROC3_DUMP` function is not implemented.

--- a/src/protocol/nfs/mount/mod.rs
+++ b/src/protocol/nfs/mount/mod.rs
@@ -36,14 +36,9 @@ use umnt_all::mountproc3_umnt_all;
 ///
 /// * `bool` - true if the requested path properly matches the export
 fn matches_export_path(requested_path: &str, export_name: &str) -> bool {
-    if requested_path == export_name {
-        true
-    } else if requested_path.starts_with(export_name) {
-        // Check that the character after the export name is a path separator
-        requested_path.chars().nth(export_name.len()) == Some('/')
-    } else {
-        false
-    }
+    requested_path == export_name
+        || (requested_path.starts_with(export_name)
+            && requested_path.chars().nth(export_name.len()) == Some('/'))
 }
 
 /// Main handler for `MOUNT` procedures of version 3 protocol.

--- a/src/protocol/nfs/mount/mod.rs
+++ b/src/protocol/nfs/mount/mod.rs
@@ -54,7 +54,7 @@ pub async fn handle_mount(
         mount::MountProgram::MOUNTPROC3_UMNTALL => {
             mountproc3_umnt_all(xid, output, context).await?;
         }
-        mount::MountProgram::MOUNTPROC3_EXPORT => mountproc3_export(xid, output, context)?,
+        mount::MountProgram::MOUNTPROC3_EXPORT => mountproc3_export(xid, output, context).await?,
         _ => xdr::rpc::proc_unavail_reply_message(xid).serialize(output)?,
     }
     Ok(())

--- a/src/protocol/nfs/mount/umnt.rs
+++ b/src/protocol/nfs/mount/umnt.rs
@@ -5,7 +5,7 @@
 use std::io;
 use std::io::{Read, Write};
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, mount, Serialize};
@@ -40,7 +40,10 @@ pub async fn mountproc3_umnt(
     context: &rpc::Context,
 ) -> io::Result<()> {
     let path = deserialize::<Vec<_>>(input)?;
-    let utf8path = std::str::from_utf8(&path).unwrap_or_default();
+    let Ok(utf8path) = std::str::from_utf8(&path) else {
+        warn!("Invalid UTF-8 path in umnt: {:?}", path);
+        return Ok(());
+    };
     debug!("mountproc3_umnt({:?},{:?}) ", xid, utf8path);
 
     let export_table = context.export_table.read().await;

--- a/src/protocol/nfs/mount/umnt.rs
+++ b/src/protocol/nfs/mount/umnt.rs
@@ -52,7 +52,7 @@ pub async fn mountproc3_umnt(
     if let Some(mount_entry) =
         export_table.values().find(|entry| matches_export_path(utf8path, &entry.export_name))
     {
-        if let Some(ref chan) = mount_entry.mount_signal {
+        if let Some(chan) = &mount_entry.mount_signal {
             let _ = chan.send(false).await;
         }
     }

--- a/src/protocol/nfs/mount/umnt.rs
+++ b/src/protocol/nfs/mount/umnt.rs
@@ -15,9 +15,6 @@ use crate::protocol::xdr::{self, deserialize, mount, Serialize};
 /// Function removes the mount entry from the mount list for
 /// the requested diretory.
 ///
-/// TODO: Currently directory path is not used and only single
-/// mount point is removed. Need to extend functionality.
-///
 /// # Arguments
 ///
 /// * `xid` - RPC transaction ID
@@ -28,6 +25,14 @@ use crate::protocol::xdr::{self, deserialize, mount, Serialize};
 /// # Returns
 ///
 /// * `io::Result<()>` - Ok(()) on success or an error
+///
+/// # Notes
+///
+/// Clients not always call `umnt` when unmounting a filesystem.
+///
+/// - Unmounting with 'umount' from 'util-linux' package doesn't call 'umnt'.
+///
+/// - Unmounting with 'umount.nfs' from 'nfs-utils' package does call 'umnt'.
 pub async fn mountproc3_umnt(
     xid: u32,
     input: &mut impl Read,
@@ -37,8 +42,14 @@ pub async fn mountproc3_umnt(
     let path = deserialize::<Vec<_>>(input)?;
     let utf8path = std::str::from_utf8(&path).unwrap_or_default();
     debug!("mountproc3_umnt({:?},{:?}) ", xid, utf8path);
-    if let Some(ref chan) = context.mount_signal {
-        let _ = chan.send(false).await;
+
+    let export_table = context.export_table.read().await;
+    if let Some(mount_entry) =
+        export_table.values().find(|entry| utf8path.starts_with(&entry.export_name))
+    {
+        if let Some(ref chan) = mount_entry.mount_signal {
+            let _ = chan.send(false).await;
+        }
     }
     xdr::rpc::make_success_reply(xid).serialize(output)?;
     mount::mountstat3::MNT3_OK.serialize(output)?;

--- a/src/protocol/nfs/mount/umnt.rs
+++ b/src/protocol/nfs/mount/umnt.rs
@@ -10,6 +10,8 @@ use tracing::{debug, warn};
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, mount, Serialize};
 
+use super::matches_export_path;
+
 /// Handles `MOUNTPROC3_UMNT` procedure.
 ///
 /// Function removes the mount entry from the mount list for
@@ -48,7 +50,7 @@ pub async fn mountproc3_umnt(
 
     let export_table = context.export_table.read().await;
     if let Some(mount_entry) =
-        export_table.values().find(|entry| utf8path.starts_with(&entry.export_name))
+        export_table.values().find(|entry| matches_export_path(utf8path, &entry.export_name))
     {
         if let Some(ref chan) = mount_entry.mount_signal {
             let _ = chan.send(false).await;

--- a/src/protocol/nfs/mount/umnt.rs
+++ b/src/protocol/nfs/mount/umnt.rs
@@ -48,9 +48,8 @@ pub async fn mountproc3_umnt(
     };
     debug!("mountproc3_umnt({:?},{:?}) ", xid, utf8path);
 
-    let export_table = context.export_table.read().await;
     if let Some(mount_entry) =
-        export_table.values().find(|entry| matches_export_path(utf8path, &entry.export_name))
+        context.export_table.iter().find(|entry| matches_export_path(utf8path, &entry.export_name))
     {
         if let Some(chan) = &mount_entry.mount_signal {
             let _ = chan.send(false).await;

--- a/src/protocol/nfs/mount/umnt_all.rs
+++ b/src/protocol/nfs/mount/umnt_all.rs
@@ -31,7 +31,7 @@ pub async fn mountproc3_umnt_all(
 ) -> io::Result<()> {
     debug!("mountproc3_umnt_all({:?}) ", xid);
 
-    for mount_entry in context.export_table.read().await.values() {
+    for mount_entry in context.export_table.iter() {
         // Notify the mount signal channel if it exists
         if let Some(chan) = &mount_entry.mount_signal {
             let _ = chan.send(false).await;

--- a/src/protocol/nfs/mount/umnt_all.rs
+++ b/src/protocol/nfs/mount/umnt_all.rs
@@ -15,9 +15,6 @@ use crate::protocol::xdr::{self, mount, Serialize};
 /// Function removes all of the mount entries for
 /// this client previously recorded by calls to MNT.
 ///
-/// TODO: Currently we have only one mount point,
-/// if there will be more, we need to extend functionality.
-///
 /// # Arguments
 ///
 /// * `xid` - RPC transaction ID
@@ -33,8 +30,12 @@ pub async fn mountproc3_umnt_all(
     context: &rpc::Context,
 ) -> io::Result<()> {
     debug!("mountproc3_umnt_all({:?}) ", xid);
-    if let Some(ref chan) = context.mount_signal {
-        let _ = chan.send(false).await;
+
+    for mount_entry in context.export_table.read().await.values() {
+        // Notify the mount signal channel if it exists
+        if let Some(ref chan) = mount_entry.mount_signal {
+            let _ = chan.send(false).await;
+        }
     }
     xdr::rpc::make_success_reply(xid).serialize(output)?;
     mount::mountstat3::MNT3_OK.serialize(output)?;

--- a/src/protocol/nfs/mount/umnt_all.rs
+++ b/src/protocol/nfs/mount/umnt_all.rs
@@ -33,7 +33,7 @@ pub async fn mountproc3_umnt_all(
 
     for mount_entry in context.export_table.read().await.values() {
         // Notify the mount signal channel if it exists
-        if let Some(ref chan) = mount_entry.mount_signal {
+        if let Some(chan) = &mount_entry.mount_signal {
             let _ = chan.send(false).await;
         }
     }

--- a/src/protocol/nfs/portmap/dump.rs
+++ b/src/protocol/nfs/portmap/dump.rs
@@ -22,8 +22,8 @@ use crate::xdr::Serialize;
 ///    - RPC reply header (success/failure)
 ///    - pmaplist (linked list of mappings)
 /// 2. Empty list is represented by zero-length array
-pub fn pmapproc_dump(xid: u32, output: &mut impl Write, context: &Context) -> io::Result<()> {
-    let binding = context.portmap_table.read().unwrap();
+pub async fn pmapproc_dump(xid: u32, output: &mut impl Write, context: &Context) -> io::Result<()> {
+    let binding = context.portmap_table.read().await;
     let entries: Vec<mapping> = binding
         .table
         .iter()

--- a/src/protocol/nfs/portmap/get_port.rs
+++ b/src/protocol/nfs/portmap/get_port.rs
@@ -37,7 +37,7 @@ use crate::protocol::xdr::{self, deserialize, portmap::mapping, Serialize};
 ///    - Returns 0 if no mapping exists
 ///    - Returns the port number if mapping exists
 /// 4. Sends RPC success reply with the result
-pub fn pmapproc_getport(
+pub async fn pmapproc_getport(
     xid: u32,
     read: &mut impl Read,
     output: &mut impl Write,
@@ -45,7 +45,7 @@ pub fn pmapproc_getport(
 ) -> io::Result<()> {
     let mapping = deserialize::<mapping>(read)?;
     let entry = PortmapKey { prog: mapping.prog, vers: mapping.vers, prot: mapping.prot };
-    let port = get_port(context, &entry);
+    let port = get_port(context, &entry).await;
     let result = match port {
         None => 0_u32,
         Some(port) => port as u32,

--- a/src/protocol/nfs/portmap/mod.rs
+++ b/src/protocol/nfs/portmap/mod.rs
@@ -57,7 +57,7 @@ pub struct PortmapKey {
 /// # Returns
 ///
 /// * `io::Result<()>` - Ok(()) on success or an error
-pub fn handle_portmap(
+pub async fn handle_portmap(
     xid: u32,
     call: &xdr::rpc::call_body,
     input: &mut impl Read,
@@ -74,10 +74,16 @@ pub fn handle_portmap(
 
     match prog {
         portmap::PortmapProgram::PMAPPROC_NULL => pmapproc_null(xid, output)?,
-        portmap::PortmapProgram::PMAPPROC_GETPORT => pmapproc_getport(xid, input, output, context)?,
-        portmap::PortmapProgram::PMAPPROC_SET => pmapproc_setport(xid, input, output, context)?,
-        portmap::PortmapProgram::PMAPPROC_DUMP => pmapproc_dump(xid, output, context)?,
-        portmap::PortmapProgram::PMAPPROC_UNSET => pmapproc_unsetport(xid, input, output, context)?,
+        portmap::PortmapProgram::PMAPPROC_GETPORT => {
+            pmapproc_getport(xid, input, output, context).await?
+        }
+        portmap::PortmapProgram::PMAPPROC_SET => {
+            pmapproc_setport(xid, input, output, context).await?
+        }
+        portmap::PortmapProgram::PMAPPROC_DUMP => pmapproc_dump(xid, output, context).await?,
+        portmap::PortmapProgram::PMAPPROC_UNSET => {
+            pmapproc_unsetport(xid, input, output, context).await?
+        }
         _ => {
             xdr::rpc::proc_unavail_reply_message(xid).serialize(output)?;
         }
@@ -86,7 +92,7 @@ pub fn handle_portmap(
 }
 
 /// Looks up a port in the Portmap table using the specified entry
-fn get_port(context: &Context, entry: &PortmapKey) -> Option<u16> {
-    let binding = context.portmap_table.read().unwrap();
+async fn get_port(context: &Context, entry: &PortmapKey) -> Option<u16> {
+    let binding = context.portmap_table.read().await;
     binding.table.get(entry).copied()
 }

--- a/src/protocol/nfs/portmap/mod.rs
+++ b/src/protocol/nfs/portmap/mod.rs
@@ -72,22 +72,15 @@ pub async fn handle_portmap(
     let prog =
         portmap::PortmapProgram::from_u32(call.proc).unwrap_or(portmap::PortmapProgram::INVALID);
 
+    #[rustfmt::skip]
     match prog {
         portmap::PortmapProgram::PMAPPROC_NULL => pmapproc_null(xid, output)?,
-        portmap::PortmapProgram::PMAPPROC_GETPORT => {
-            pmapproc_getport(xid, input, output, context).await?
-        }
-        portmap::PortmapProgram::PMAPPROC_SET => {
-            pmapproc_setport(xid, input, output, context).await?
-        }
+        portmap::PortmapProgram::PMAPPROC_GETPORT => pmapproc_getport(xid, input, output, context).await?,
+        portmap::PortmapProgram::PMAPPROC_SET => pmapproc_setport(xid, input, output, context).await?,
         portmap::PortmapProgram::PMAPPROC_DUMP => pmapproc_dump(xid, output, context).await?,
-        portmap::PortmapProgram::PMAPPROC_UNSET => {
-            pmapproc_unsetport(xid, input, output, context).await?
-        }
-        _ => {
-            xdr::rpc::proc_unavail_reply_message(xid).serialize(output)?;
-        }
-    }
+        portmap::PortmapProgram::PMAPPROC_UNSET => pmapproc_unsetport(xid, input, output, context).await?,
+        _ =>  xdr::rpc::proc_unavail_reply_message(xid).serialize(output)?
+    };
     Ok(())
 }
 

--- a/src/protocol/nfs/portmap/set_port.rs
+++ b/src/protocol/nfs/portmap/set_port.rs
@@ -23,7 +23,7 @@ use crate::xdr::{deserialize, Serialize};
 /// 2. Checks if the mapping already exists
 /// 3. If not exists, adds the new mapping
 /// 4. Sends success response with boolean result (true = added, false = existed)
-pub fn pmapproc_setport(
+pub async fn pmapproc_setport(
     xid: u32,
     read: &mut impl Read,
     output: &mut impl Write,
@@ -31,7 +31,7 @@ pub fn pmapproc_setport(
 ) -> io::Result<()> {
     let mapping = deserialize::<mapping>(read)?;
     let entry = PortmapKey { prog: mapping.prog, vers: mapping.vers, prot: mapping.prot };
-    let mut binding = context.portmap_table.write().unwrap();
+    let mut binding = context.portmap_table.write().await;
     let port = binding.table.get(&entry).copied();
     let result = match port {
         None => {

--- a/src/protocol/nfs/portmap/unset_port.rs
+++ b/src/protocol/nfs/portmap/unset_port.rs
@@ -26,14 +26,14 @@ use crate::xdr::{deserialize, Serialize};
 ///   - RPC success header (via `make_success_reply`).
 ///   - Boolean `true` if at least one port was removed, `false` otherwise.
 /// - `std::io::Error` on deserialization or serialization failures.
-pub fn pmapproc_unsetport(
+pub async fn pmapproc_unsetport(
     xid: u32,
     read: &mut impl Read,
     output: &mut impl Write,
     context: &Context,
 ) -> io::Result<()> {
     let mapping = deserialize::<mapping>(read)?;
-    let mut binding = context.portmap_table.write().unwrap();
+    let mut binding = context.portmap_table.write().await;
     let tcp_removed = binding
         .table
         .remove(&PortmapKey { prog: mapping.prog, vers: mapping.vers, prot: IPPROTO_TCP })

--- a/src/protocol/nfs/v3/access.rs
+++ b/src/protocol/nfs/v3/access.rs
@@ -57,8 +57,7 @@ pub async fn nfsproc3_access(
     debug!("nfsproc3_access({:?},{:?},{:?})", xid, handle, access);
 
     let fs_id = handle.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/access.rs
+++ b/src/protocol/nfs/v3/access.rs
@@ -15,7 +15,7 @@
 use std::io;
 use std::io::{Read, Write};
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, nfs3, Serialize};
@@ -56,7 +56,17 @@ pub async fn nfsproc3_access(
     let access = deserialize::<u32>(input)?;
     debug!("nfsproc3_access({:?},{:?},{:?})", xid, handle, access);
 
-    let id = context.vfs.fh_to_id(&handle);
+    let fs_id = handle.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::post_op_attr::None.serialize(output)?;
+        return Ok(());
+    };
+
+    let id = export.vfs.fh_to_id(&handle);
     // Fail if unable to convert file handle
     if let Err(stat) = id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
@@ -67,7 +77,7 @@ pub async fn nfsproc3_access(
     let id = id.unwrap();
 
     // Get object attributes
-    let obj_attr = match context.vfs.getattr(id).await {
+    let obj_attr = match export.vfs.getattr(id).await {
         Ok(v) => nfs3::post_op_attr::Some(v),
         Err(stat) => {
             // If we can't get attributes, return an error
@@ -108,7 +118,7 @@ pub async fn nfsproc3_access(
     match attr.ftype {
         nfs3::ftype3::NF3REG => {
             // For regular files
-            if !matches!(context.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
+            if !matches!(export.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
                 // If the file system is read-only, allow only reading
                 if access & (nfs3::ACCESS3_READ | nfs3::ACCESS3_EXECUTE) != 0 {
                     granted_access |= access & (nfs3::ACCESS3_READ | nfs3::ACCESS3_EXECUTE);
@@ -124,7 +134,7 @@ pub async fn nfsproc3_access(
         }
         nfs3::ftype3::NF3DIR => {
             // For directories
-            if !matches!(context.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
+            if !matches!(export.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
                 // If the file system is read-only, allow only reading
                 if access & nfs3::ACCESS3_READ != 0 {
                     granted_access |= nfs3::ACCESS3_READ;

--- a/src/protocol/nfs/v3/commit.rs
+++ b/src/protocol/nfs/v3/commit.rs
@@ -72,12 +72,7 @@ pub async fn nfsproc3_commit(
     let id = id.unwrap();
 
     // get the object attributes before the commit
-    let pre_obj_attr = export
-        .vfs
-        .getattr(id)
-        .await
-        .map(|v| nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime })
-        .ok();
+    let pre_obj_attr = export.vfs.getattr(id).await.map(nfs3::wcc_attr::from).ok();
 
     // Call VFS commit method
     match export.vfs.commit(id, args.offset, args.count).await {

--- a/src/protocol/nfs/v3/commit.rs
+++ b/src/protocol/nfs/v3/commit.rs
@@ -21,7 +21,7 @@
 use std::io;
 use std::io::{Read, Write};
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, nfs3, Serialize};
@@ -51,7 +51,17 @@ pub async fn nfsproc3_commit(
     let args = deserialize::<nfs3::file::COMMIT3args>(input)?;
     debug!("nfsproc3_commit({:?}, {:?}) ", xid, args);
 
-    let id = context.vfs.fh_to_id(&args.file);
+    let fs_id = args.file.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        return Ok(());
+    };
+
+    let id = export.vfs.fh_to_id(&args.file);
     // fail if unable to convert file handle
     if let Err(stat) = id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
@@ -62,7 +72,7 @@ pub async fn nfsproc3_commit(
     let id = id.unwrap();
 
     // get the object attributes before the commit
-    let pre_obj_attr = context
+    let pre_obj_attr = export
         .vfs
         .getattr(id)
         .await
@@ -70,13 +80,13 @@ pub async fn nfsproc3_commit(
         .ok();
 
     // Call VFS commit method
-    match context.vfs.commit(id, args.offset, args.count).await {
+    match export.vfs.commit(id, args.offset, args.count).await {
         Ok(fattr) => {
             let post_obj_attr = nfs3::post_op_attr::Some(fattr);
 
             let res = nfs3::file::COMMIT3resok {
                 file_wcc: nfs3::wcc_data { before: pre_obj_attr, after: post_obj_attr },
-                verf: context.vfs.server_id(),
+                verf: export.vfs.server_id(),
             };
 
             debug!("nfsproc3_commit success");
@@ -85,7 +95,7 @@ pub async fn nfsproc3_commit(
             res.serialize(output)?;
         }
         Err(stat) => {
-            let post_obj_attr = context.vfs.getattr(id).await.ok();
+            let post_obj_attr = export.vfs.getattr(id).await.ok();
 
             let wcc_data = nfs3::wcc_data { before: pre_obj_attr, after: post_obj_attr };
 

--- a/src/protocol/nfs/v3/commit.rs
+++ b/src/protocol/nfs/v3/commit.rs
@@ -52,8 +52,7 @@ pub async fn nfsproc3_commit(
     debug!("nfsproc3_commit({:?}, {:?}) ", xid, args);
 
     let fs_id = args.file.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/create.rs
+++ b/src/protocol/nfs/v3/create.rs
@@ -50,8 +50,23 @@ pub async fn nfsproc3_create(
     output: &mut impl Write,
     context: &rpc::Context,
 ) -> io::Result<()> {
+    let dir_ops = deserialize::<nfs3::diropargs3>(input)?;
+    let create_mode = deserialize::<nfs3::createmode3>(input)?;
+
+    debug!("nfsproc3_create({:?}, {:?}, {:?}) ", xid, dir_ops, create_mode);
+
+    let fs_id = dir_ops.dir.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        return Ok(());
+    };
+
     // if we do not have write capabilities
-    if !matches!(context.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
+    if !matches!(export.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
         warn!("No write capabilities.");
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_ROFS.serialize(output)?;
@@ -59,14 +74,9 @@ pub async fn nfsproc3_create(
         return Ok(());
     }
 
-    let dirops = deserialize::<nfs3::diropargs3>(input)?;
-    let createhow = deserialize::<nfs3::createmode3>(input)?;
-
-    debug!("nfsproc3_create({:?}, {:?}, {:?}) ", xid, dirops, createhow);
-
     // find the directory we are supposed to create the
     // new file in
-    let dirid = context.vfs.fh_to_id(&dirops.dir);
+    let dirid = export.vfs.fh_to_id(&dir_ops.dir);
     if let Err(stat) = dirid {
         // directory does not exist
         xdr::rpc::make_success_reply(xid).serialize(output)?;
@@ -79,7 +89,7 @@ pub async fn nfsproc3_create(
     let dirid = dirid.unwrap();
 
     // get the object attributes before the write
-    let pre_dir_attr = match context.vfs.getattr(dirid).await {
+    let pre_dir_attr = match export.vfs.getattr(dirid).await {
         Ok(v) => {
             let wccattr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
             nfs3::pre_op_attr::Some(wccattr)
@@ -94,7 +104,7 @@ pub async fn nfsproc3_create(
     };
     let mut target_attributes = nfs3::sattr3::default();
 
-    match createhow {
+    match create_mode {
         nfs3::createmode3::UNCHECKED => {
             target_attributes.deserialize(input)?;
             debug!("create unchecked {:?}", target_attributes);
@@ -102,11 +112,11 @@ pub async fn nfsproc3_create(
         nfs3::createmode3::GUARDED => {
             target_attributes.deserialize(input)?;
             debug!("create guarded {:?}", target_attributes);
-            if context.vfs.lookup(dirid, &dirops.name).await.is_ok() {
+            if export.vfs.lookup(dirid, &dir_ops.name).await.is_ok() {
                 // file exists. Fail with NFS3ERR_EXIST.
                 // Re-read dir attributes
                 // for post op attr
-                let post_dir_attr = context.vfs.getattr(dirid).await.ok();
+                let post_dir_attr = export.vfs.getattr(dirid).await.ok();
 
                 xdr::rpc::make_success_reply(xid).serialize(output)?;
                 nfs3::nfsstat3::NFS3ERR_EXIST.serialize(output)?;
@@ -122,20 +132,20 @@ pub async fn nfsproc3_create(
     let fid: Result<nfs3::fileid3, nfs3::nfsstat3>;
     let postopattr: nfs3::post_op_attr;
     // fill in the fid and post op attr here
-    if matches!(createhow, nfs3::createmode3::EXCLUSIVE) {
+    if matches!(create_mode, nfs3::createmode3::EXCLUSIVE) {
         // the API for exclusive is very slightly different
         // We are not returning a post op attribute
-        fid = context.vfs.create_exclusive(dirid, &dirops.name).await;
+        fid = export.vfs.create_exclusive(dirid, &dir_ops.name).await;
         postopattr = nfs3::post_op_attr::None;
     } else {
         // create!
-        let res = context.vfs.create(dirid, &dirops.name, target_attributes).await;
+        let res = export.vfs.create(dirid, &dir_ops.name, target_attributes).await;
         fid = res.map(|x| x.0);
         postopattr = res.map(|(_, fattr)| fattr).ok();
     }
 
     // Re-read dir attributes for post op attr
-    let post_dir_attr = context.vfs.getattr(dirid).await.ok();
+    let post_dir_attr = export.vfs.getattr(dirid).await.ok();
     let wcc_res = nfs3::wcc_data { before: pre_dir_attr, after: post_dir_attr };
 
     match fid {
@@ -144,7 +154,7 @@ pub async fn nfsproc3_create(
             xdr::rpc::make_success_reply(xid).serialize(output)?;
             nfs3::nfsstat3::NFS3_OK.serialize(output)?;
             // serialize CREATE3resok
-            let fh = context.vfs.id_to_fh(fid);
+            let fh = export.vfs.id_to_fh(fid, fs_id);
             nfs3::post_op_fh3::Some(fh).serialize(output)?;
             postopattr.serialize(output)?;
             wcc_res.serialize(output)?;

--- a/src/protocol/nfs/v3/create.rs
+++ b/src/protocol/nfs/v3/create.rs
@@ -56,8 +56,7 @@ pub async fn nfsproc3_create(
     debug!("nfsproc3_create({:?}, {:?}, {:?}) ", xid, dir_ops, create_mode);
 
     let fs_id = dir_ops.dir.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/create.rs
+++ b/src/protocol/nfs/v3/create.rs
@@ -90,10 +90,7 @@ pub async fn nfsproc3_create(
 
     // get the object attributes before the write
     let pre_dir_attr = match export.vfs.getattr(dirid).await {
-        Ok(v) => {
-            let wccattr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
-            nfs3::pre_op_attr::Some(wccattr)
-        }
+        Ok(v) => nfs3::pre_op_attr::Some(v.into()),
         Err(stat) => {
             error!("Cannot stat directory");
             xdr::rpc::make_success_reply(xid).serialize(output)?;

--- a/src/protocol/nfs/v3/fsinfo.rs
+++ b/src/protocol/nfs/v3/fsinfo.rs
@@ -19,7 +19,7 @@
 use std::io;
 use std::io::{Read, Write};
 
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, nfs3, Serialize};
@@ -49,7 +49,17 @@ pub async fn nfsproc3_fsinfo(
     let handle = deserialize::<nfs3::nfs_fh3>(input)?;
     debug!("nfsproc3_fsinfo({:?},{:?}) ", xid, handle);
 
-    let id = context.vfs.fh_to_id(&handle);
+    let fs_id = handle.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::post_op_attr::None.serialize(output)?;
+        return Ok(());
+    };
+
+    let id = export.vfs.fh_to_id(&handle);
     // fail if unable to convert file handle
     if let Err(stat) = id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
@@ -60,7 +70,7 @@ pub async fn nfsproc3_fsinfo(
 
     let id = id.unwrap();
 
-    match context.vfs.fsinfo(id).await {
+    match export.vfs.fsinfo(id).await {
         Ok(fsinfo) => {
             debug!(" {:?} --> {:?}", xid, fsinfo);
             xdr::rpc::make_success_reply(xid).serialize(output)?;
@@ -71,6 +81,7 @@ pub async fn nfsproc3_fsinfo(
             error!("nfsproc3_fsinfo error {:?} --> {:?}", xid, stat);
             xdr::rpc::make_success_reply(xid).serialize(output)?;
             stat.serialize(output)?;
+            nfs3::post_op_attr::None.serialize(output)?;
         }
     }
 

--- a/src/protocol/nfs/v3/fsinfo.rs
+++ b/src/protocol/nfs/v3/fsinfo.rs
@@ -50,8 +50,7 @@ pub async fn nfsproc3_fsinfo(
     debug!("nfsproc3_fsinfo({:?},{:?}) ", xid, handle);
 
     let fs_id = handle.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/fsstat.rs
+++ b/src/protocol/nfs/v3/fsstat.rs
@@ -53,8 +53,7 @@ pub async fn nfsproc3_fsstat(
     debug!("nfsproc3_fsstat({:?},{:?}) ", xid, handle);
 
     let fs_id = handle.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/fsstat.rs
+++ b/src/protocol/nfs/v3/fsstat.rs
@@ -22,7 +22,7 @@
 use std::io;
 use std::io::{Read, Write};
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, nfs3, Serialize};
@@ -51,7 +51,18 @@ pub async fn nfsproc3_fsstat(
 ) -> io::Result<()> {
     let handle = deserialize::<nfs3::nfs_fh3>(input)?;
     debug!("nfsproc3_fsstat({:?},{:?}) ", xid, handle);
-    let id = context.vfs.fh_to_id(&handle);
+
+    let fs_id = handle.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::post_op_attr::None.serialize(output)?;
+        return Ok(());
+    };
+
+    let id = export.vfs.fh_to_id(&handle);
     // fail if unable to convert file handle
     if let Err(stat) = id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
@@ -61,7 +72,7 @@ pub async fn nfsproc3_fsstat(
     }
     let id = id.unwrap();
 
-    let obj_attr = context.vfs.getattr(id).await.ok();
+    let obj_attr = export.vfs.getattr(id).await.ok();
     let res = nfs3::fs::FSSTAT3resok {
         obj_attributes: obj_attr,
         tbytes: 1024 * 1024 * 1024 * 1024,

--- a/src/protocol/nfs/v3/getattr.rs
+++ b/src/protocol/nfs/v3/getattr.rs
@@ -43,8 +43,7 @@ pub async fn nfsproc3_getattr(
     debug!("nfsproc3_getattr({:?},{:?}) ", xid, handle);
 
     let fs_id = handle.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/getattr.rs
+++ b/src/protocol/nfs/v3/getattr.rs
@@ -13,7 +13,7 @@
 use std::io;
 use std::io::{Read, Write};
 
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, nfs3, Serialize};
@@ -42,15 +42,25 @@ pub async fn nfsproc3_getattr(
     let handle = deserialize::<nfs3::nfs_fh3>(input)?;
     debug!("nfsproc3_getattr({:?},{:?}) ", xid, handle);
 
-    let id = context.vfs.fh_to_id(&handle);
+    let fs_id = handle.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        return Ok(());
+    };
+
+    let id = export.vfs.fh_to_id(&handle);
     // fail if unable to convert file handle
     if let Err(stat) = id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
         return Ok(());
     }
-    let id = id.unwrap();
-    match context.vfs.getattr(id).await {
+    let file_id = id.unwrap();
+
+    match export.vfs.getattr(file_id).await {
         Ok(fh) => {
             debug!(" {:?} --> {:?}", xid, fh);
             xdr::rpc::make_success_reply(xid).serialize(output)?;

--- a/src/protocol/nfs/v3/link.rs
+++ b/src/protocol/nfs/v3/link.rs
@@ -104,12 +104,7 @@ pub async fn nfsproc3_link(
     let dir_id = dir_id.unwrap();
 
     // Get the directory attributes before the operation
-    let pre_dir_attr = export
-        .vfs
-        .getattr(dir_id)
-        .await
-        .map(|v| nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime })
-        .ok();
+    let pre_dir_attr = export.vfs.getattr(dir_id).await.map(nfs3::wcc_attr::from).ok();
 
     // Call VFS link method
     match export.vfs.link(file_id, dir_id, &args.link.name).await {

--- a/src/protocol/nfs/v3/link.rs
+++ b/src/protocol/nfs/v3/link.rs
@@ -61,8 +61,7 @@ pub async fn nfsproc3_link(
         return Ok(());
     }
 
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&file_fs_id) else {
+    let Some(export) = context.export_table.get(&file_fs_id) else {
         warn!("No export found for fs_id: {}", file_fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/link.rs
+++ b/src/protocol/nfs/v3/link.rs
@@ -47,8 +47,32 @@ pub async fn nfsproc3_link(
     output: &mut impl Write,
     context: &rpc::Context,
 ) -> io::Result<()> {
+    let args = deserialize::<nfs3::file::LINK3args>(input)?;
+    debug!("nfsproc3_link({:?}, {:?}) ", xid, args);
+
+    let file_fs_id = args.file.fs_id;
+    let link_fs_id = args.link.dir.fs_id;
+
+    if file_fs_id != link_fs_id {
+        warn!("Trying to hard link across different file systems");
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_XDEV.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        return Ok(());
+    }
+
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&file_fs_id) else {
+        warn!("No export found for fs_id: {}", file_fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::post_op_attr::None.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        return Ok(());
+    };
+
     // if we do not have write capabilities
-    if !matches!(context.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
+    if !matches!(export.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
         warn!("No write capabilities.");
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_ROFS.serialize(output)?;
@@ -57,47 +81,44 @@ pub async fn nfsproc3_link(
         return Ok(());
     }
 
-    let args = deserialize::<nfs3::file::LINK3args>(input)?;
-    debug!("nfsproc3_link({:?}, {:?}) ", xid, args);
-
     // Get the file id
-    let fileid = context.vfs.fh_to_id(&args.file);
-    if let Err(stat) = fileid {
+    let file_id = export.vfs.fh_to_id(&args.file);
+    if let Err(stat) = file_id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
         nfs3::post_op_attr::None.serialize(output)?;
         nfs3::wcc_data::default().serialize(output)?;
         return Ok(());
     }
-    let fileid = fileid.unwrap();
+    let file_id = file_id.unwrap();
 
     // Get the directory id
-    let dirid = context.vfs.fh_to_id(&args.link.dir);
-    if let Err(stat) = dirid {
+    let dir_id = export.vfs.fh_to_id(&args.link.dir);
+    if let Err(stat) = dir_id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
         nfs3::post_op_attr::None.serialize(output)?;
         nfs3::wcc_data::default().serialize(output)?;
         return Ok(());
     }
-    let dirid = dirid.unwrap();
+    let dir_id = dir_id.unwrap();
 
     // Get the directory attributes before the operation
-    let pre_dir_attr = context
+    let pre_dir_attr = export
         .vfs
-        .getattr(dirid)
+        .getattr(dir_id)
         .await
         .map(|v| nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime })
         .ok();
 
     // Call VFS link method
-    match context.vfs.link(fileid, dirid, &args.link.name).await {
+    match export.vfs.link(file_id, dir_id, &args.link.name).await {
         Ok(fattr) => {
             // Get file attributes
             let file_attr = nfs3::post_op_attr::Some(fattr);
 
             // Get the directory attributes after the operation
-            let post_dir_attr = context.vfs.getattr(dirid).await.ok();
+            let post_dir_attr = export.vfs.getattr(dir_id).await.ok();
 
             let wcc_res = nfs3::wcc_data { before: pre_dir_attr, after: post_dir_attr };
 
@@ -109,10 +130,10 @@ pub async fn nfsproc3_link(
         }
         Err(stat) => {
             // Get file attributes
-            let file_attr = context.vfs.getattr(fileid).await.ok();
+            let file_attr = export.vfs.getattr(file_id).await.ok();
 
             // Get the directory attributes after the operation (unchanged)
-            let post_dir_attr = context.vfs.getattr(dirid).await.ok();
+            let post_dir_attr = export.vfs.getattr(dir_id).await.ok();
 
             let wcc_res = nfs3::wcc_data { before: pre_dir_attr, after: post_dir_attr };
 

--- a/src/protocol/nfs/v3/lookup.rs
+++ b/src/protocol/nfs/v3/lookup.rs
@@ -15,7 +15,7 @@
 use std::io;
 use std::io::{Read, Write};
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, nfs3, Serialize};
@@ -42,36 +42,45 @@ pub async fn nfsproc3_lookup(
     output: &mut impl Write,
     context: &rpc::Context,
 ) -> io::Result<()> {
-    let dirops = deserialize::<nfs3::diropargs3>(input)?;
-    debug!("nfsproc3_lookup({:?},{:?}) ", xid, dirops);
+    let dir_ops = deserialize::<nfs3::diropargs3>(input)?;
+    debug!("nfsproc3_lookup({:?},{:?}) ", xid, dir_ops);
 
-    let dirid = context.vfs.fh_to_id(&dirops.dir);
+    let fs_id = dir_ops.dir.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::post_op_attr::None.serialize(output)?;
+        return Ok(());
+    };
+
+    let dir_id = export.vfs.fh_to_id(&dir_ops.dir);
 
     // fail if unable to convert file handle
-    if let Err(stat) = dirid {
+    if let Err(stat) = dir_id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
         nfs3::post_op_attr::None.serialize(output)?;
         return Ok(());
     }
 
-    let dirid = dirid.unwrap();
+    let dirid = dir_id.unwrap();
 
-    let dir_attr = context.vfs.getattr(dirid).await.ok();
+    let dir_attr = export.vfs.getattr(dirid).await.ok();
 
-    match context.vfs.lookup(dirid, &dirops.name).await {
+    match export.vfs.lookup(dirid, &dir_ops.name).await {
         Ok(fid) => {
-            let obj_attr = context.vfs.getattr(fid).await.ok();
-
+            let obj_attr = export.vfs.getattr(fid).await.ok();
             debug!("nfsproc3_lookup success {:?} --> {:?}", xid, obj_attr);
             xdr::rpc::make_success_reply(xid).serialize(output)?;
             nfs3::nfsstat3::NFS3_OK.serialize(output)?;
-            context.vfs.id_to_fh(fid).serialize(output)?;
+            export.vfs.id_to_fh(fid, fs_id).serialize(output)?;
             obj_attr.serialize(output)?;
             dir_attr.serialize(output)?;
         }
         Err(stat) => {
-            debug!("nfsproc3_lookup error {:?}({:?}) --> {:?}", xid, dirops.name, stat);
+            debug!("nfsproc3_lookup error {:?}({:?}) --> {:?}", xid, dir_ops.name, stat);
             xdr::rpc::make_success_reply(xid).serialize(output)?;
             stat.serialize(output)?;
             dir_attr.serialize(output)?;

--- a/src/protocol/nfs/v3/lookup.rs
+++ b/src/protocol/nfs/v3/lookup.rs
@@ -46,8 +46,7 @@ pub async fn nfsproc3_lookup(
     debug!("nfsproc3_lookup({:?},{:?}) ", xid, dir_ops);
 
     let fs_id = dir_ops.dir.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/mkdir.rs
+++ b/src/protocol/nfs/v3/mkdir.rs
@@ -84,10 +84,7 @@ pub async fn nfsproc3_mkdir(
 
     // get the object attributes before the write
     let pre_dir_attr = match export.vfs.getattr(dir_id).await {
-        Ok(v) => {
-            let wccattr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
-            nfs3::pre_op_attr::Some(wccattr)
-        }
+        Ok(v) => nfs3::pre_op_attr::Some(v.into()),
         Err(stat) => {
             error!("Cannot stat directory");
             xdr::rpc::make_success_reply(xid).serialize(output)?;

--- a/src/protocol/nfs/v3/mkdir.rs
+++ b/src/protocol/nfs/v3/mkdir.rs
@@ -46,22 +46,32 @@ pub async fn nfsproc3_mkdir(
     output: &mut impl Write,
     context: &rpc::Context,
 ) -> io::Result<()> {
+    let args = deserialize::<nfs3::dir::MKDIR3args>(input)?;
+    debug!("nfsproc3_mkdir({:?}, {:?}) ", xid, args);
+
+    let fs_id = args.dirops.dir.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        return Ok(());
+    };
+
     // if we do not have write capabilities
-    if !matches!(context.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
+    if !matches!(export.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
         warn!("No write capabilities.");
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_ROFS.serialize(output)?;
         nfs3::wcc_data::default().serialize(output)?;
         return Ok(());
     }
-    let args = deserialize::<nfs3::dir::MKDIR3args>(input)?;
-
-    debug!("nfsproc3_mkdir({:?}, {:?}) ", xid, args);
 
     // find the directory we are supposed to create the
     // new file in
-    let dirid = context.vfs.fh_to_id(&args.dirops.dir);
-    if let Err(stat) = dirid {
+    let dir_id = export.vfs.fh_to_id(&args.dirops.dir);
+    if let Err(stat) = dir_id {
         // directory does not exist
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
@@ -70,10 +80,10 @@ pub async fn nfsproc3_mkdir(
         return Ok(());
     }
     // found the directory, get the attributes
-    let dirid = dirid.unwrap();
+    let dir_id = dir_id.unwrap();
 
     // get the object attributes before the write
-    let pre_dir_attr = match context.vfs.getattr(dirid).await {
+    let pre_dir_attr = match export.vfs.getattr(dir_id).await {
         Ok(v) => {
             let wccattr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
             nfs3::pre_op_attr::Some(wccattr)
@@ -87,10 +97,10 @@ pub async fn nfsproc3_mkdir(
         }
     };
 
-    let res = context.vfs.mkdir(dirid, &args.dirops.name).await;
+    let res = export.vfs.mkdir(dir_id, &args.dirops.name).await;
 
     // Re-read dir attributes for post op attr
-    let post_dir_attr = context.vfs.getattr(dirid).await.ok();
+    let post_dir_attr = export.vfs.getattr(dir_id).await.ok();
     let wcc_res = nfs3::wcc_data { before: pre_dir_attr, after: post_dir_attr };
 
     match res {
@@ -99,7 +109,7 @@ pub async fn nfsproc3_mkdir(
             xdr::rpc::make_success_reply(xid).serialize(output)?;
             nfs3::nfsstat3::NFS3_OK.serialize(output)?;
             // serialize CREATE3resok
-            let fh = context.vfs.id_to_fh(fid);
+            let fh = export.vfs.id_to_fh(fid, fs_id);
             nfs3::post_op_fh3::Some(fh).serialize(output)?;
             nfs3::post_op_attr::Some(fattr).serialize(output)?;
             wcc_res.serialize(output)?;

--- a/src/protocol/nfs/v3/mkdir.rs
+++ b/src/protocol/nfs/v3/mkdir.rs
@@ -50,8 +50,7 @@ pub async fn nfsproc3_mkdir(
     debug!("nfsproc3_mkdir({:?}, {:?}) ", xid, args);
 
     let fs_id = args.dirops.dir.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/mknod.rs
+++ b/src/protocol/nfs/v3/mknod.rs
@@ -50,8 +50,21 @@ pub async fn nfsproc3_mknod(
     output: &mut impl Write,
     context: &rpc::Context,
 ) -> io::Result<()> {
+    let args = deserialize::<nfs3::dir::MKNOD3args>(input)?;
+    debug!("nfsproc3_mknod({:?}, {:?}) ", xid, args);
+
+    let fs_id = args.where_dir.dir.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        return Ok(());
+    };
+
     // if we do not have write capabilities
-    if !matches!(context.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
+    if !matches!(export.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
         warn!("No write capabilities.");
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_ROFS.serialize(output)?;
@@ -59,12 +72,9 @@ pub async fn nfsproc3_mknod(
         return Ok(());
     }
 
-    let args = deserialize::<nfs3::dir::MKNOD3args>(input)?;
-    debug!("nfsproc3_mknod({:?}, {:?}) ", xid, args);
-
     // find the directory we are supposed to create the special file in
-    let dirid = context.vfs.fh_to_id(&args.where_dir.dir);
-    if let Err(stat) = dirid {
+    let dir_id = export.vfs.fh_to_id(&args.where_dir.dir);
+    if let Err(stat) = dir_id {
         // directory does not exist
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
@@ -73,12 +83,12 @@ pub async fn nfsproc3_mknod(
         return Ok(());
     }
     // found the directory, get the attributes
-    let dirid = dirid.unwrap();
+    let dir_id = dir_id.unwrap();
 
     // get the object attributes before the operation
-    let pre_dir_attr = context
+    let pre_dir_attr = export
         .vfs
-        .getattr(dirid)
+        .getattr(dir_id)
         .await
         .map(|v| nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime })
         .ok();
@@ -87,23 +97,23 @@ pub async fn nfsproc3_mknod(
     let attr = nfs3::sattr3::default();
 
     // Call VFS mknod method
-    match context
+    match export
         .vfs
-        .mknod(dirid, &args.where_dir.name, args.what.mknod_type, args.what.device.device, &attr)
+        .mknod(dir_id, &args.where_dir.name, args.what.mknod_type, args.what.device.device, &attr)
         .await
     {
         Ok((fid, fattr)) => {
             debug!("nfsproc3_mknod success --> {:?}, {:?}", fid, fattr);
 
             // Get the directory attributes after the operation
-            let post_dir_attr = context.vfs.getattr(dirid).await.ok();
+            let post_dir_attr = export.vfs.getattr(dir_id).await.ok();
 
             let wcc_res = nfs3::wcc_data { before: pre_dir_attr, after: post_dir_attr };
 
             xdr::rpc::make_success_reply(xid).serialize(output)?;
             nfs3::nfsstat3::NFS3_OK.serialize(output)?;
             // serialize MKNOD3resok
-            let fh = context.vfs.id_to_fh(fid);
+            let fh = export.vfs.id_to_fh(fid, fs_id);
             nfs3::post_op_fh3::Some(fh).serialize(output)?;
             nfs3::post_op_attr::Some(fattr).serialize(output)?;
             wcc_res.serialize(output)?;
@@ -112,7 +122,7 @@ pub async fn nfsproc3_mknod(
             debug!("nfsproc3_mknod error --> {:?}", stat);
 
             // Get the directory attributes after the operation (unchanged)
-            let post_dir_attr = context.vfs.getattr(dirid).await.ok();
+            let post_dir_attr = export.vfs.getattr(dir_id).await.ok();
 
             let wcc_res = nfs3::wcc_data { before: pre_dir_attr, after: post_dir_attr };
 

--- a/src/protocol/nfs/v3/mknod.rs
+++ b/src/protocol/nfs/v3/mknod.rs
@@ -54,8 +54,7 @@ pub async fn nfsproc3_mknod(
     debug!("nfsproc3_mknod({:?}, {:?}) ", xid, args);
 
     let fs_id = args.where_dir.dir.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/mknod.rs
+++ b/src/protocol/nfs/v3/mknod.rs
@@ -86,12 +86,7 @@ pub async fn nfsproc3_mknod(
     let dir_id = dir_id.unwrap();
 
     // get the object attributes before the operation
-    let pre_dir_attr = export
-        .vfs
-        .getattr(dir_id)
-        .await
-        .map(|v| nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime })
-        .ok();
+    let pre_dir_attr = export.vfs.getattr(dir_id).await.map(nfs3::wcc_attr::from).ok();
 
     // Create default attributes if necessary
     let attr = nfs3::sattr3::default();

--- a/src/protocol/nfs/v3/pathconf.rs
+++ b/src/protocol/nfs/v3/pathconf.rs
@@ -52,8 +52,7 @@ pub async fn nfsproc3_pathconf(
     debug!("nfsproc3_pathconf({:?},{:?})", xid, handle);
 
     let fs_id = handle.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/pathconf.rs
+++ b/src/protocol/nfs/v3/pathconf.rs
@@ -21,7 +21,7 @@
 use std::io;
 use std::io::{Read, Write};
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, nfs3, Serialize};
@@ -51,7 +51,17 @@ pub async fn nfsproc3_pathconf(
     let handle = deserialize::<nfs3::nfs_fh3>(input)?;
     debug!("nfsproc3_pathconf({:?},{:?})", xid, handle);
 
-    let id = context.vfs.fh_to_id(&handle);
+    let fs_id = handle.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::post_op_attr::None.serialize(output)?;
+        return Ok(());
+    };
+
+    let id = export.vfs.fh_to_id(&handle);
     // fail if unable to convert file handle
     if let Err(stat) = id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
@@ -61,7 +71,7 @@ pub async fn nfsproc3_pathconf(
     }
     let id = id.unwrap();
 
-    let obj_attr = context.vfs.getattr(id).await.ok();
+    let obj_attr = export.vfs.getattr(id).await.ok();
     let res = nfs3::fs::PATHCONF3resok {
         obj_attributes: obj_attr,
         linkmax: 0,

--- a/src/protocol/nfs/v3/read.rs
+++ b/src/protocol/nfs/v3/read.rs
@@ -16,7 +16,7 @@
 use std::io;
 use std::io::{Read, Write};
 
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, nfs3, Serialize};
@@ -46,7 +46,17 @@ pub async fn nfsproc3_read(
     let args = deserialize::<nfs3::file::READ3args>(input)?;
     debug!("nfsproc3_read({:?},{:?}) ", xid, args);
 
-    let id = context.vfs.fh_to_id(&args.file);
+    let fs_id = args.file.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::post_op_attr::None.serialize(output)?;
+        return Ok(());
+    };
+
+    let id = export.vfs.fh_to_id(&args.file);
     if let Err(stat) = id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
@@ -55,8 +65,8 @@ pub async fn nfsproc3_read(
     }
     let id = id.unwrap();
 
-    let obj_attr = context.vfs.getattr(id).await.ok();
-    match context.vfs.read(id, args.offset, args.count).await {
+    let obj_attr = export.vfs.getattr(id).await.ok();
+    match export.vfs.read(id, args.offset, args.count).await {
         Ok((bytes, eof)) => {
             let res = nfs3::file::READ3resok {
                 file_attributes: obj_attr,

--- a/src/protocol/nfs/v3/read.rs
+++ b/src/protocol/nfs/v3/read.rs
@@ -47,8 +47,7 @@ pub async fn nfsproc3_read(
     debug!("nfsproc3_read({:?},{:?}) ", xid, args);
 
     let fs_id = args.file.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/readdir.rs
+++ b/src/protocol/nfs/v3/readdir.rs
@@ -53,8 +53,7 @@ pub async fn nfsproc3_readdir(
     debug!("nfsproc3_readdirplus({:?},{:?}) ", xid, args);
 
     let fs_id = args.dir.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/readdir.rs
+++ b/src/protocol/nfs/v3/readdir.rs
@@ -22,7 +22,7 @@
 use std::io;
 use std::io::{Read, Write};
 
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, warn};
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, nfs3, Serialize};
@@ -52,20 +52,30 @@ pub async fn nfsproc3_readdir(
     let args = deserialize::<nfs3::dir::READDIR3args>(input)?;
     debug!("nfsproc3_readdirplus({:?},{:?}) ", xid, args);
 
-    let dirid = context.vfs.fh_to_id(&args.dir);
+    let fs_id = args.dir.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::post_op_attr::None.serialize(output)?;
+        return Ok(());
+    };
+
+    let dir_id = export.vfs.fh_to_id(&args.dir);
     // fail if unable to convert file handle
-    if let Err(stat) = dirid {
+    if let Err(stat) = dir_id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
         nfs3::post_op_attr::None.serialize(output)?;
         return Ok(());
     }
-    let dirid = dirid.unwrap();
-    let dir_attr_maybe = context.vfs.getattr(dirid).await;
+    let dir_id = dir_id.unwrap();
+    let dir_attr_maybe = export.vfs.getattr(dir_id).await;
 
     let dir_attr = dir_attr_maybe.ok();
 
-    let dirversion = if let Ok(ref dir_attr) = dir_attr_maybe {
+    let dir_version = if let Ok(ref dir_attr) = dir_attr_maybe {
         let cvf_version =
             ((dir_attr.mtime.seconds as u64) << 32) | (dir_attr.mtime.nseconds as u64);
         cvf_version.to_be_bytes()
@@ -73,7 +83,7 @@ pub async fn nfsproc3_readdir(
         nfs3::cookieverf3::default()
     };
     debug!(" -- Dir attr {:?}", dir_attr);
-    debug!(" -- Dir version {:?}", dirversion);
+    debug!(" -- Dir version {:?}", dir_version);
     let has_version = args.cookieverf != nfs3::cookieverf3::default();
     // subtract off the final entryplus* field (which must be false) and the eof
     let max_bytes_allowed = args.dircount as usize - 128;
@@ -82,7 +92,7 @@ pub async fn nfsproc3_readdir(
     let estimated_max_results = args.dircount / 16;
     let mut ctr = 0;
 
-    match context.vfs.readdir_simple(dirid, args.cookie, estimated_max_results as usize).await {
+    match export.vfs.readdir_simple(dir_id, args.cookie, estimated_max_results as usize).await {
         Ok(result) => {
             // we count dir_count seperately as it is just a subset of fields
             let mut accumulated_dircount: usize = 0;
@@ -95,7 +105,7 @@ pub async fn nfsproc3_readdir(
             xdr::rpc::make_success_reply(xid).serialize(&mut counting_output)?;
             nfs3::nfsstat3::NFS3_OK.serialize(&mut counting_output)?;
             dir_attr.serialize(&mut counting_output)?;
-            dirversion.serialize(&mut counting_output)?;
+            dir_version.serialize(&mut counting_output)?;
             for entry in result.entries {
                 let entry = nfs3::dir::entry3 {
                     fileid: entry.fileid,
@@ -144,7 +154,7 @@ pub async fn nfsproc3_readdir(
             }
             debug!(
                 "readir {}, has_version {},  start at {}, flushing {} entries, complete {}",
-                dirid, has_version, args.cookie, ctr, all_entries_written
+                dir_id, has_version, args.cookie, ctr, all_entries_written
             );
         }
         Err(stat) => {

--- a/src/protocol/nfs/v3/readdir.rs
+++ b/src/protocol/nfs/v3/readdir.rs
@@ -75,7 +75,7 @@ pub async fn nfsproc3_readdir(
 
     let dir_attr = dir_attr_maybe.ok();
 
-    let dir_version = if let Ok(ref dir_attr) = dir_attr_maybe {
+    let dir_version = if let Ok(dir_attr) = dir_attr_maybe {
         let cvf_version =
             ((dir_attr.mtime.seconds as u64) << 32) | (dir_attr.mtime.nseconds as u64);
         cvf_version.to_be_bytes()

--- a/src/protocol/nfs/v3/readdirplus.rs
+++ b/src/protocol/nfs/v3/readdirplus.rs
@@ -26,7 +26,7 @@
 use std::io;
 use std::io::{Read, Write};
 
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, warn};
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, nfs3, Serialize};
@@ -56,20 +56,30 @@ pub async fn nfsproc3_readdirplus(
     let args = deserialize::<nfs3::dir::READDIRPLUS3args>(input)?;
     debug!("nfsproc3_readdirplus({:?},{:?}) ", xid, args);
 
-    let dirid = context.vfs.fh_to_id(&args.dir);
+    let fs_id = args.dir.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::post_op_attr::None.serialize(output)?;
+        return Ok(());
+    };
+
+    let dir_id = export.vfs.fh_to_id(&args.dir);
     // fail if unable to convert file handle
-    if let Err(stat) = dirid {
+    if let Err(stat) = dir_id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
         nfs3::post_op_attr::None.serialize(output)?;
         return Ok(());
     }
-    let dirid = dirid.unwrap();
-    let dir_attr_maybe = context.vfs.getattr(dirid).await;
+    let dir_id = dir_id.unwrap();
+    let dir_attr_maybe = export.vfs.getattr(dir_id).await;
 
     let dir_attr = dir_attr_maybe.ok();
 
-    let dirversion = if let Ok(ref dir_attr) = dir_attr_maybe {
+    let dir_version = if let Ok(ref dir_attr) = dir_attr_maybe {
         let cvf_version =
             ((dir_attr.mtime.seconds as u64) << 32) | (dir_attr.mtime.nseconds as u64);
         cvf_version.to_be_bytes()
@@ -77,7 +87,7 @@ pub async fn nfsproc3_readdirplus(
         nfs3::cookieverf3::default()
     };
     debug!(" -- Dir attr {:?}", dir_attr);
-    debug!(" -- Dir version {:?}", dirversion);
+    debug!(" -- Dir version {:?}", dir_version);
     let has_version = args.cookieverf != nfs3::cookieverf3::default();
     // initial call should hve empty cookie verf
     // subsequent calls should have cvf_version as defined above
@@ -149,7 +159,7 @@ pub async fn nfsproc3_readdirplus(
     let estimated_max_results = args.dircount / 16;
     let max_dircount_bytes = args.dircount as usize;
     let mut ctr = 0;
-    match context.vfs.readdir(dirid, args.cookie, estimated_max_results as usize).await {
+    match export.vfs.readdir(dir_id, args.cookie, estimated_max_results as usize).await {
         Ok(result) => {
             // we count dir_count seperately as it is just a subset of fields
             let mut accumulated_dircount: usize = 0;
@@ -162,10 +172,10 @@ pub async fn nfsproc3_readdirplus(
             xdr::rpc::make_success_reply(xid).serialize(&mut counting_output)?;
             nfs3::nfsstat3::NFS3_OK.serialize(&mut counting_output)?;
             dir_attr.serialize(&mut counting_output)?;
-            dirversion.serialize(&mut counting_output)?;
+            dir_version.serialize(&mut counting_output)?;
             for entry in result.entries {
                 let obj_attr = entry.attr;
-                let handle = nfs3::post_op_fh3::Some(context.vfs.id_to_fh(entry.fileid));
+                let handle = nfs3::post_op_fh3::Some(export.vfs.id_to_fh(entry.fileid, fs_id));
 
                 let entry = nfs3::dir::entryplus3 {
                     fileid: entry.fileid,
@@ -219,7 +229,7 @@ pub async fn nfsproc3_readdirplus(
             }
             debug!(
                 "readir {}, has_version {},  start at {}, flushing {} entries, complete {}",
-                dirid, has_version, args.cookie, ctr, all_entries_written
+                dir_id, has_version, args.cookie, ctr, all_entries_written
             );
         }
         Err(stat) => {

--- a/src/protocol/nfs/v3/readdirplus.rs
+++ b/src/protocol/nfs/v3/readdirplus.rs
@@ -79,7 +79,7 @@ pub async fn nfsproc3_readdirplus(
 
     let dir_attr = dir_attr_maybe.ok();
 
-    let dir_version = if let Ok(ref dir_attr) = dir_attr_maybe {
+    let dir_version = if let Ok(dir_attr) = dir_attr_maybe {
         let cvf_version =
             ((dir_attr.mtime.seconds as u64) << 32) | (dir_attr.mtime.nseconds as u64);
         cvf_version.to_be_bytes()

--- a/src/protocol/nfs/v3/readdirplus.rs
+++ b/src/protocol/nfs/v3/readdirplus.rs
@@ -57,8 +57,7 @@ pub async fn nfsproc3_readdirplus(
     debug!("nfsproc3_readdirplus({:?},{:?}) ", xid, args);
 
     let fs_id = args.dir.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/readlink.rs
+++ b/src/protocol/nfs/v3/readlink.rs
@@ -19,7 +19,7 @@
 use std::io;
 use std::io::{Read, Write};
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, deserialize, nfs3, Serialize};
@@ -56,17 +56,28 @@ pub async fn nfsproc3_readlink(
     let handle = deserialize::<nfs3::nfs_fh3>(input)?;
     debug!("nfsproc3_readlink({:?},{:?}) ", xid, handle);
 
-    let id = context.vfs.fh_to_id(&handle);
+    let fs_id = handle.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::post_op_attr::None.serialize(output)?;
+        return Ok(());
+    };
+
+    let id = export.vfs.fh_to_id(&handle);
     // fail if unable to convert file handle
     if let Err(stat) = id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
+        nfs3::post_op_attr::None.serialize(output)?;
         return Ok(());
     }
 
     let id = id.unwrap();
     // if the id does not exist, we fail
-    let symlink_attr = match context.vfs.getattr(id).await {
+    let symlink_attr = match export.vfs.getattr(id).await {
         Ok(v) => nfs3::post_op_attr::Some(v),
         Err(stat) => {
             xdr::rpc::make_success_reply(xid).serialize(output)?;
@@ -76,7 +87,7 @@ pub async fn nfsproc3_readlink(
         }
     };
 
-    match context.vfs.readlink(id).await {
+    match export.vfs.readlink(id).await {
         Ok(path) => {
             debug!(" {:?} --> {:?}", xid, path);
             xdr::rpc::make_success_reply(xid).serialize(output)?;

--- a/src/protocol/nfs/v3/readlink.rs
+++ b/src/protocol/nfs/v3/readlink.rs
@@ -57,8 +57,7 @@ pub async fn nfsproc3_readlink(
     debug!("nfsproc3_readlink({:?},{:?}) ", xid, handle);
 
     let fs_id = handle.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/remove.rs
+++ b/src/protocol/nfs/v3/remove.rs
@@ -64,8 +64,21 @@ pub async fn nfsproc3_remove(
     output: &mut impl Write,
     context: &rpc::Context,
 ) -> io::Result<()> {
+    let dir_ops = deserialize::<nfs3::diropargs3>(input)?;
+    debug!("nfsproc3_remove({:?}, {:?}) ", xid, dir_ops);
+
+    let fs_id = dir_ops.dir.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        return Ok(());
+    };
+
     // if we do not have write capabilities
-    if !matches!(context.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
+    if !matches!(export.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
         warn!("No write capabilities.");
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_ROFS.serialize(output)?;
@@ -73,13 +86,9 @@ pub async fn nfsproc3_remove(
         return Ok(());
     }
 
-    let dirops = deserialize::<nfs3::diropargs3>(input)?;
-
-    debug!("nfsproc3_remove({:?}, {:?}) ", xid, dirops);
-
     // find the directory with the file
-    let dirid = context.vfs.fh_to_id(&dirops.dir);
-    if let Err(stat) = dirid {
+    let dir_id = export.vfs.fh_to_id(&dir_ops.dir);
+    if let Err(stat) = dir_id {
         // directory does not exist
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
@@ -87,10 +96,10 @@ pub async fn nfsproc3_remove(
         error!("Directory does not exist");
         return Ok(());
     }
-    let dirid = dirid.unwrap();
+    let dir_id = dir_id.unwrap();
 
     // get the object attributes before the write
-    let pre_dir_attr = match context.vfs.getattr(dirid).await {
+    let pre_dir_attr = match export.vfs.getattr(dir_id).await {
         Ok(v) => {
             let wccattr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
             nfs3::pre_op_attr::Some(wccattr)
@@ -105,10 +114,10 @@ pub async fn nfsproc3_remove(
     };
 
     // delete!
-    let res = context.vfs.remove(dirid, &dirops.name).await;
+    let res = export.vfs.remove(dir_id, &dir_ops.name).await;
 
     // Re-read dir attributes for post op attr
-    let post_dir_attr = context.vfs.getattr(dirid).await.ok();
+    let post_dir_attr = export.vfs.getattr(dir_id).await.ok();
     let wcc_res = nfs3::wcc_data { before: pre_dir_attr, after: post_dir_attr };
 
     match res {

--- a/src/protocol/nfs/v3/remove.rs
+++ b/src/protocol/nfs/v3/remove.rs
@@ -100,10 +100,7 @@ pub async fn nfsproc3_remove(
 
     // get the object attributes before the write
     let pre_dir_attr = match export.vfs.getattr(dir_id).await {
-        Ok(v) => {
-            let wccattr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
-            nfs3::pre_op_attr::Some(wccattr)
-        }
+        Ok(v) => nfs3::pre_op_attr::Some(nfs3::wcc_attr::from(v)),
         Err(stat) => {
             error!("Cannot stat directory");
             xdr::rpc::make_success_reply(xid).serialize(output)?;

--- a/src/protocol/nfs/v3/remove.rs
+++ b/src/protocol/nfs/v3/remove.rs
@@ -68,8 +68,7 @@ pub async fn nfsproc3_remove(
     debug!("nfsproc3_remove({:?}, {:?}) ", xid, dir_ops);
 
     let fs_id = dir_ops.dir.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/rename.rs
+++ b/src/protocol/nfs/v3/rename.rs
@@ -129,10 +129,7 @@ pub async fn nfsproc3_rename(
 
     // get the object attributes before the write
     let pre_from_dir_attr = match export.vfs.getattr(from_dir_id).await {
-        Ok(v) => {
-            let wccattr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
-            nfs3::pre_op_attr::Some(wccattr)
-        }
+        Ok(v) => nfs3::pre_op_attr::Some(v.into()),
         Err(stat) => {
             error!("Cannot stat directory");
             xdr::rpc::make_success_reply(xid).serialize(output)?;
@@ -145,10 +142,7 @@ pub async fn nfsproc3_rename(
 
     // get the object attributes before the write
     let pre_to_dir_attr = match export.vfs.getattr(to_dir_id).await {
-        Ok(v) => {
-            let wcc_attr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
-            nfs3::pre_op_attr::Some(wcc_attr)
-        }
+        Ok(v) => nfs3::pre_op_attr::Some(v.into()),
         Err(stat) => {
             error!("Cannot stat directory");
             xdr::rpc::make_success_reply(xid).serialize(output)?;

--- a/src/protocol/nfs/v3/rename.rs
+++ b/src/protocol/nfs/v3/rename.rs
@@ -59,48 +59,76 @@ pub async fn nfsproc3_rename(
     output: &mut impl Write,
     context: &rpc::Context,
 ) -> io::Result<()> {
-    // if we do not have write capabilities
-    if !matches!(context.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
-        warn!("No write capabilities.");
+    let from_dir_ops = deserialize::<nfs3::diropargs3>(input)?;
+    let to_dir_ops = deserialize::<nfs3::diropargs3>(input)?;
+    debug!("nfsproc3_rename({:?}, {:?}, {:?}) ", xid, from_dir_ops, to_dir_ops);
+
+    let from_fs_id = from_dir_ops.dir.fs_id;
+    let to_fs_id = to_dir_ops.dir.fs_id;
+
+    if to_fs_id != from_fs_id {
+        // RFC states:
+        // To.dir and from.dir must reside on the same file system and server.
+        // ...
+        // If they reside on different file systems, the error, NFS3ERR_XDEV
+        error!("Files should be in the same filesystem");
         xdr::rpc::make_success_reply(xid).serialize(output)?;
-        nfs3::nfsstat3::NFS3ERR_ROFS.serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_XDEV.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
         nfs3::wcc_data::default().serialize(output)?;
         return Ok(());
     }
 
-    let fromdirops = deserialize::<nfs3::diropargs3>(input)?;
-    let todirops = deserialize::<nfs3::diropargs3>(input)?;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&from_fs_id) else {
+        warn!("No export found for fs_id: {}", from_fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        return Ok(());
+    };
 
-    debug!("nfsproc3_rename({:?}, {:?}, {:?}) ", xid, fromdirops, todirops);
+    // if we do not have write capabilities
+    if !matches!(export.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
+        warn!("No write capabilities.");
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_ROFS.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        return Ok(());
+    }
 
     // find the from directory
-    let from_dirid = context.vfs.fh_to_id(&fromdirops.dir);
-    if let Err(stat) = from_dirid {
+    let from_dir_id = export.vfs.fh_to_id(&from_dir_ops.dir);
+    if let Err(stat) = from_dir_id {
         // directory does not exist
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
         nfs3::wcc_data::default().serialize(output)?;
         error!("Directory does not exist");
         return Ok(());
     }
 
     // find the to directory
-    let to_dirid = context.vfs.fh_to_id(&todirops.dir);
-    if let Err(stat) = to_dirid {
+    let to_dir_id = export.vfs.fh_to_id(&to_dir_ops.dir);
+    if let Err(stat) = to_dir_id {
         // directory does not exist
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
         nfs3::wcc_data::default().serialize(output)?;
         error!("Directory does not exist");
         return Ok(());
     }
 
     // found the directory, get the attributes
-    let from_dirid = from_dirid.unwrap();
-    let to_dirid = to_dirid.unwrap();
+    let from_dir_id = from_dir_id.unwrap();
+    let to_dir_id = to_dir_id.unwrap();
 
     // get the object attributes before the write
-    let pre_from_dir_attr = match context.vfs.getattr(from_dirid).await {
+    let pre_from_dir_attr = match export.vfs.getattr(from_dir_id).await {
         Ok(v) => {
             let wccattr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
             nfs3::pre_op_attr::Some(wccattr)
@@ -110,31 +138,33 @@ pub async fn nfsproc3_rename(
             xdr::rpc::make_success_reply(xid).serialize(output)?;
             stat.serialize(output)?;
             nfs3::wcc_data::default().serialize(output)?;
+            nfs3::wcc_data::default().serialize(output)?;
             return Ok(());
         }
     };
 
     // get the object attributes before the write
-    let pre_to_dir_attr = match context.vfs.getattr(to_dirid).await {
+    let pre_to_dir_attr = match export.vfs.getattr(to_dir_id).await {
         Ok(v) => {
-            let wccattr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
-            nfs3::pre_op_attr::Some(wccattr)
+            let wcc_attr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
+            nfs3::pre_op_attr::Some(wcc_attr)
         }
         Err(stat) => {
             error!("Cannot stat directory");
             xdr::rpc::make_success_reply(xid).serialize(output)?;
             stat.serialize(output)?;
+            nfs3::wcc_data::default().serialize(output)?;
             nfs3::wcc_data::default().serialize(output)?;
             return Ok(());
         }
     };
 
     // rename!
-    let res = context.vfs.rename(from_dirid, &fromdirops.name, to_dirid, &todirops.name).await;
+    let res = export.vfs.rename(from_dir_id, &from_dir_ops.name, to_dir_id, &to_dir_ops.name).await;
 
     // Re-read dir attributes for post op attr
-    let post_from_dir_attr = context.vfs.getattr(from_dirid).await.ok();
-    let post_to_dir_attr = context.vfs.getattr(to_dirid).await.ok();
+    let post_from_dir_attr = export.vfs.getattr(from_dir_id).await.ok();
+    let post_to_dir_attr = export.vfs.getattr(to_dir_id).await.ok();
     let from_wcc_res = nfs3::wcc_data { before: pre_from_dir_attr, after: post_from_dir_attr };
 
     let to_wcc_res = nfs3::wcc_data { before: pre_to_dir_attr, after: post_to_dir_attr };

--- a/src/protocol/nfs/v3/rename.rs
+++ b/src/protocol/nfs/v3/rename.rs
@@ -79,8 +79,7 @@ pub async fn nfsproc3_rename(
         return Ok(());
     }
 
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&from_fs_id) else {
+    let Some(export) = context.export_table.get(&from_fs_id) else {
         warn!("No export found for fs_id: {}", from_fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/setattr.rs
+++ b/src/protocol/nfs/v3/setattr.rs
@@ -55,8 +55,7 @@ pub async fn nfsproc3_setattr(
     debug!("nfsproc3_setattr({:?},{:?}) ", xid, args);
 
     let fs_id = args.object.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/setattr.rs
+++ b/src/protocol/nfs/v3/setattr.rs
@@ -51,28 +51,40 @@ pub async fn nfsproc3_setattr(
     output: &mut impl Write,
     context: &rpc::Context,
 ) -> io::Result<()> {
-    if !matches!(context.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
+    let args = deserialize::<nfs3::SETATTR3args>(input)?;
+    debug!("nfsproc3_setattr({:?},{:?}) ", xid, args);
+
+    let fs_id = args.object.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        return Ok(());
+    };
+
+    if !matches!(export.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
         warn!("No write capabilities.");
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_ROFS.serialize(output)?;
         nfs3::wcc_data::default().serialize(output)?;
         return Ok(());
     }
-    let args = deserialize::<nfs3::SETATTR3args>(input)?;
-    debug!("nfsproc3_setattr({:?},{:?}) ", xid, args);
 
-    let id = context.vfs.fh_to_id(&args.object);
+    let id = export.vfs.fh_to_id(&args.object);
     // fail if unable to convert file handle
     if let Err(stat) = id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
         return Ok(());
     }
     let id = id.unwrap();
 
     let ctime;
 
-    let pre_op_attr = match context.vfs.getattr(id).await {
+    let pre_op_attr = match export.vfs.getattr(id).await {
         Ok(v) => {
             let wccattr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
             ctime = v.ctime;
@@ -94,7 +106,7 @@ pub async fn nfsproc3_setattr(
         }
     }
 
-    match context.vfs.setattr(id, args.new_attribute).await {
+    match export.vfs.setattr(id, args.new_attribute).await {
         Ok(post_op_attr) => {
             debug!(" setattr success {:?} --> {:?}", xid, post_op_attr);
             let wcc_res = nfs3::wcc_data {

--- a/src/protocol/nfs/v3/setattr.rs
+++ b/src/protocol/nfs/v3/setattr.rs
@@ -86,9 +86,8 @@ pub async fn nfsproc3_setattr(
 
     let pre_op_attr = match export.vfs.getattr(id).await {
         Ok(v) => {
-            let wccattr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
             ctime = v.ctime;
-            nfs3::pre_op_attr::Some(wccattr)
+            nfs3::pre_op_attr::Some(v.into())
         }
         Err(stat) => {
             xdr::rpc::make_success_reply(xid).serialize(output)?;

--- a/src/protocol/nfs/v3/symlink.rs
+++ b/src/protocol/nfs/v3/symlink.rs
@@ -67,22 +67,31 @@ pub async fn nfsproc3_symlink(
     output: &mut impl Write,
     context: &rpc::Context,
 ) -> io::Result<()> {
+    let args = deserialize::<nfs3::dir::SYMLINK3args>(input)?;
+    debug!("nfsproc3_symlink({:?}, {:?}) ", xid, args);
+
+    let fs_id = args.dirops.dir.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        return Ok(());
+    };
+
     // if we do not have write capabilities
-    if !matches!(context.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
+    if !matches!(export.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
         warn!("No write capabilities.");
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_ROFS.serialize(output)?;
         nfs3::wcc_data::default().serialize(output)?;
         return Ok(());
     }
-    let args = deserialize::<nfs3::dir::SYMLINK3args>(input)?;
 
-    debug!("nfsproc3_symlink({:?}, {:?}) ", xid, args);
-
-    // find the directory we are supposed to create the
-    // new file in
-    let dirid = context.vfs.fh_to_id(&args.dirops.dir);
-    if let Err(stat) = dirid {
+    // find the directory we are supposed to create the new file in
+    let dir_id = export.vfs.fh_to_id(&args.dirops.dir);
+    if let Err(stat) = dir_id {
         // directory does not exist
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
@@ -91,10 +100,10 @@ pub async fn nfsproc3_symlink(
         return Ok(());
     }
     // found the directory, get the attributes
-    let dirid = dirid.unwrap();
+    let dir_id = dir_id.unwrap();
 
     // get the object attributes before the write
-    let pre_dir_attr = match context.vfs.getattr(dirid).await {
+    let pre_dir_attr = match export.vfs.getattr(dir_id).await {
         Ok(v) => {
             let wccattr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
             nfs3::pre_op_attr::Some(wccattr)
@@ -108,10 +117,10 @@ pub async fn nfsproc3_symlink(
         }
     };
 
-    let res = context
+    let res = export
         .vfs
         .symlink(
-            dirid,
+            dir_id,
             &args.dirops.name,
             &args.symlink.symlink_data,
             &args.symlink.symlink_attributes,
@@ -119,7 +128,7 @@ pub async fn nfsproc3_symlink(
         .await;
 
     // Re-read dir attributes for post op attr
-    let post_dir_attr = context.vfs.getattr(dirid).await.ok();
+    let post_dir_attr = export.vfs.getattr(dir_id).await.ok();
     let wcc_res = nfs3::wcc_data { before: pre_dir_attr, after: post_dir_attr };
 
     match res {
@@ -128,7 +137,7 @@ pub async fn nfsproc3_symlink(
             xdr::rpc::make_success_reply(xid).serialize(output)?;
             nfs3::nfsstat3::NFS3_OK.serialize(output)?;
             // serialize CREATE3resok
-            let fh = context.vfs.id_to_fh(fid);
+            let fh = export.vfs.id_to_fh(fid, fs_id);
             nfs3::post_op_fh3::Some(fh).serialize(output)?;
             nfs3::post_op_attr::Some(fattr).serialize(output)?;
             wcc_res.serialize(output)?;

--- a/src/protocol/nfs/v3/symlink.rs
+++ b/src/protocol/nfs/v3/symlink.rs
@@ -104,10 +104,7 @@ pub async fn nfsproc3_symlink(
 
     // get the object attributes before the write
     let pre_dir_attr = match export.vfs.getattr(dir_id).await {
-        Ok(v) => {
-            let wccattr = nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime };
-            nfs3::pre_op_attr::Some(wccattr)
-        }
+        Ok(v) => nfs3::pre_op_attr::Some(v.into()),
         Err(stat) => {
             error!("Cannot stat directory");
             xdr::rpc::make_success_reply(xid).serialize(output)?;

--- a/src/protocol/nfs/v3/symlink.rs
+++ b/src/protocol/nfs/v3/symlink.rs
@@ -71,8 +71,7 @@ pub async fn nfsproc3_symlink(
     debug!("nfsproc3_symlink({:?}, {:?}) ", xid, args);
 
     let fs_id = args.dirops.dir.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/nfs/v3/write.rs
+++ b/src/protocol/nfs/v3/write.rs
@@ -47,8 +47,21 @@ pub async fn nfsproc3_write(
     output: &mut impl Write,
     context: &rpc::Context,
 ) -> io::Result<()> {
+    let args = deserialize::<nfs3::file::WRITE3args>(input)?;
+    debug!("nfsproc3_write({:?},...) ", xid);
+
+    let fs_id = args.file.fs_id;
+    let guard = context.export_table.read().await;
+    let Some(export) = guard.get(&fs_id) else {
+        warn!("No export found for fs_id: {}", fs_id);
+        xdr::rpc::make_success_reply(xid).serialize(output)?;
+        nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;
+        nfs3::wcc_data::default().serialize(output)?;
+        return Ok(());
+    };
+
     // if we do not have write capabilities
-    if !matches!(context.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
+    if !matches!(export.vfs.capabilities(), vfs::Capabilities::ReadWrite) {
         warn!("No write capabilities.");
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_ROFS.serialize(output)?;
@@ -56,15 +69,13 @@ pub async fn nfsproc3_write(
         return Ok(());
     }
 
-    let args = deserialize::<nfs3::file::WRITE3args>(input)?;
-    debug!("nfsproc3_write({:?},...) ", xid);
     // sanity check the length
     if args.data.len() != args.count as usize {
         xdr::rpc::garbage_args_reply_message(xid).serialize(output)?;
         return Ok(());
     }
 
-    let id = context.vfs.fh_to_id(&args.file);
+    let id = export.vfs.fh_to_id(&args.file);
     if let Err(stat) = id {
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         stat.serialize(output)?;
@@ -74,14 +85,14 @@ pub async fn nfsproc3_write(
     let id = id.unwrap();
 
     // get the object attributes before the write
-    let pre_obj_attr = context
+    let pre_obj_attr = export
         .vfs
         .getattr(id)
         .await
         .map(|v| nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime })
         .ok();
 
-    match context.vfs.write(id, args.offset, &args.data).await {
+    match export.vfs.write(id, args.offset, &args.data).await {
         Ok(fattr) => {
             debug!("write success {:?} --> {:?}", xid, fattr);
             let res = nfs3::file::WRITE3resok {
@@ -91,7 +102,7 @@ pub async fn nfsproc3_write(
                 },
                 count: args.count,
                 committed: nfs3::file::stable_how::FILE_SYNC,
-                verf: context.vfs.server_id(),
+                verf: export.vfs.server_id(),
             };
             xdr::rpc::make_success_reply(xid).serialize(output)?;
             nfs3::nfsstat3::NFS3_OK.serialize(output)?;

--- a/src/protocol/nfs/v3/write.rs
+++ b/src/protocol/nfs/v3/write.rs
@@ -85,12 +85,7 @@ pub async fn nfsproc3_write(
     let id = id.unwrap();
 
     // get the object attributes before the write
-    let pre_obj_attr = export
-        .vfs
-        .getattr(id)
-        .await
-        .map(|v| nfs3::wcc_attr { size: v.size, mtime: v.mtime, ctime: v.ctime })
-        .ok();
+    let pre_obj_attr = export.vfs.getattr(id).await.map(nfs3::wcc_attr::from).ok();
 
     match export.vfs.write(id, args.offset, &args.data).await {
         Ok(fattr) => {

--- a/src/protocol/nfs/v3/write.rs
+++ b/src/protocol/nfs/v3/write.rs
@@ -51,8 +51,7 @@ pub async fn nfsproc3_write(
     debug!("nfsproc3_write({:?},...) ", xid);
 
     let fs_id = args.file.fs_id;
-    let guard = context.export_table.read().await;
-    let Some(export) = guard.get(&fs_id) else {
+    let Some(export) = context.export_table.get(&fs_id) else {
         warn!("No export found for fs_id: {}", fs_id);
         xdr::rpc::make_success_reply(xid).serialize(output)?;
         nfs3::nfsstat3::NFS3ERR_BADHANDLE.serialize(output)?;

--- a/src/protocol/rpc/context.rs
+++ b/src/protocol/rpc/context.rs
@@ -14,13 +14,13 @@
 //! server configuration.
 
 use std::fmt;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
-use tokio::sync::mpsc;
+use tokio::sync::RwLock;
 
 use crate::protocol::nfs::portmap::PortmapTable;
 use crate::protocol::xdr;
-use crate::vfs;
+use crate::tcp::NFSExportTable;
 
 /// Represents the execution context for RPC operations
 ///
@@ -47,16 +47,8 @@ pub struct Context {
     /// Contains user ID, group IDs, and other identity information
     pub auth: xdr::rpc::auth_unix,
 
-    /// Virtual File System implementation that handles actual file operations
-    /// Abstracts the underlying storage system for NFS operations
-    pub vfs: Arc<dyn vfs::NFSFileSystem + Send + Sync>,
-
-    /// Channel for sending mount/unmount notifications
-    /// Used to track file system mount status changes
-    pub mount_signal: Option<mpsc::Sender<bool>>,
-
-    /// Name of the exported file system available to clients
-    pub export_name: Arc<String>,
+    /// List containing all exported file systems
+    pub export_table: Arc<RwLock<NFSExportTable>>,
 
     /// Transaction state tracker for handling retransmissions
     /// Maintains idempotency by detecting duplicate RPC calls

--- a/src/protocol/rpc/context.rs
+++ b/src/protocol/rpc/context.rs
@@ -48,7 +48,7 @@ pub struct Context {
     pub auth: xdr::rpc::auth_unix,
 
     /// List containing all exported file systems
-    pub export_table: Arc<RwLock<NFSExportTable>>,
+    pub export_table: Arc<NFSExportTable>,
 
     /// Transaction state tracker for handling retransmissions
     /// Maintains idempotency by detecting duplicate RPC calls

--- a/src/protocol/rpc/wire.rs
+++ b/src/protocol/rpc/wire.rs
@@ -111,7 +111,9 @@ pub async fn handle_rpc(
                 Ok(())
             }
         },
-        portmap::PROGRAM => nfs::portmap::handle_portmap(xid, &call, input, output, &mut context).await,
+        portmap::PROGRAM => {
+            nfs::portmap::handle_portmap(xid, &call, input, output, &mut context).await
+        }
         mount::PROGRAM => nfs::mount::handle_mount(xid, call, input, output, &context).await,
         prog if prog == NFS_ACL_PROGRAM
             || prog == NFS_ID_MAP_PROGRAM

--- a/src/protocol/rpc/wire.rs
+++ b/src/protocol/rpc/wire.rs
@@ -111,7 +111,7 @@ pub async fn handle_rpc(
                 Ok(())
             }
         },
-        portmap::PROGRAM => nfs::portmap::handle_portmap(xid, &call, input, output, &mut context),
+        portmap::PROGRAM => nfs::portmap::handle_portmap(xid, &call, input, output, &mut context).await,
         mount::PROGRAM => nfs::mount::handle_mount(xid, call, input, output, &context).await,
         prog if prog == NFS_ACL_PROGRAM
             || prog == NFS_ID_MAP_PROGRAM

--- a/src/protocol/xdr/mount.rs
+++ b/src/protocol/xdr/mount.rs
@@ -12,10 +12,10 @@
 
 use std::io::{Read, Write};
 
-use crate::xdr::{DeserializeEnum, SerializeEnum};
 use num_derive::{FromPrimitive, ToPrimitive};
 
-use super::*;
+use crate::xdr::{nfs3, Deserialize, DeserializeEnum, Serialize, SerializeEnum};
+use crate::{DeserializeStruct, SerializeStruct};
 
 /// MOUNT program number for RPC
 pub const PROGRAM: u32 = 100005;
@@ -30,7 +30,7 @@ pub const MNTNAMLEN: u32 = 255;
 pub const FHSIZE3: u32 = 64;
 
 /// File handle for NFS version 3
-pub type fhandle3 = Vec<u8>;
+pub type fhandle3 = nfs3::nfs_fh3;
 /// Directory path on the server
 pub type dirpath = Vec<u8>;
 /// Name in the directory

--- a/src/protocol/xdr/nfs3/mod.rs
+++ b/src/protocol/xdr/nfs3/mod.rs
@@ -20,10 +20,9 @@ use std::io::{Read, Write};
 use filetime;
 use num_derive::{FromPrimitive, ToPrimitive};
 
+use super::{deserialize, Deserialize, Serialize};
 use crate::xdr::{DeserializeEnum, SerializeEnum};
 use crate::{DeserializeStruct, SerializeStruct};
-
-use super::{deserialize, Deserialize, Serialize};
 
 // Modules for different operation types
 pub mod dir;
@@ -219,6 +218,9 @@ pub type mode3 = u32;
 /// Used for various counting purposes in NFS operations
 pub type count3 = u32;
 
+/// Used in [nfs_fh3] to identify the file system
+pub type fs_id = u64;
+
 /// Status codes returned by NFS version 3 operations
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, FromPrimitive, ToPrimitive)]
@@ -365,11 +367,38 @@ SerializeStruct!(specdata3, specdata1, specdata2);
 #[allow(non_camel_case_types)]
 #[derive(Clone, Debug, Default)]
 pub struct nfs_fh3 {
-    /// Raw file handle data (up to `NFS3_FHSIZE` bytes)
-    pub data: Vec<u8>,
+    /// Used for stale handle detection
+    pub gen: u64,
+    /// File system identifier
+    pub fs_id: fs_id,
+    /// Unique file identifier within the file system
+    pub id: fileid3,
 }
-DeserializeStruct!(nfs_fh3, data);
-SerializeStruct!(nfs_fh3, data);
+const _: () = {
+    assert!(size_of::<nfs_fh3>() < NFS3_FHSIZE as usize);
+};
+
+// Custom (de)serializer is required because in RFC nfs_fh3 defined as variable-length opaque object,
+// and thus needs to be encoded with its length as the first 4 bytes.
+impl Deserialize for nfs_fh3 {
+    fn deserialize<R: Read>(&mut self, src: &mut R) -> std::io::Result<()> {
+        let _len = deserialize::<u32>(src)?;
+        self.gen = deserialize::<u64>(src)?;
+        self.fs_id = deserialize::<fs_id>(src)?;
+        self.id = deserialize::<fileid3>(src)?;
+        Ok(())
+    }
+}
+
+impl Serialize for nfs_fh3 {
+    fn serialize<R: Write>(&self, dest: &mut R) -> std::io::Result<()> {
+        (size_of::<Self>() as u32).serialize(dest)?;
+        self.gen.serialize(dest)?;
+        self.fs_id.serialize(dest)?;
+        self.id.serialize(dest)?;
+        Ok(())
+    }
+}
 
 /// NFS version 3 time structure
 /// Used for file timestamps (access, modify, change)

--- a/src/protocol/xdr/nfs3/mod.rs
+++ b/src/protocol/xdr/nfs3/mod.rs
@@ -382,8 +382,8 @@ const _: () = {
 // and thus needs to be encoded with its length as the first 4 bytes.
 impl Deserialize for nfs_fh3 {
     fn deserialize<R: Read>(&mut self, src: &mut R) -> std::io::Result<()> {
-        let _len = deserialize::<UsizeAsU32>(src)?;
-        if _len.0 != size_of::<nfs_fh3>() {
+        let len = deserialize::<UsizeAsU32>(src)?;
+        if len.0 != size_of::<nfs_fh3>() {
             return Err(xdr::utils::invalid_data("Invalid nfs_fh3 length"));
         }
         self.gen = deserialize::<u64>(src)?;

--- a/src/protocol/xdr/nfs3/mod.rs
+++ b/src/protocol/xdr/nfs3/mod.rs
@@ -375,7 +375,7 @@ pub struct nfs_fh3 {
     pub id: fileid3,
 }
 const _: () = {
-    assert!(size_of::<nfs_fh3>() < NFS3_FHSIZE as usize);
+    assert!(size_of::<nfs_fh3>() <= NFS3_FHSIZE as usize);
 };
 
 // Custom (de)serializer is required because in RFC nfs_fh3 defined as variable-length opaque object,

--- a/src/protocol/xdr/nfs3/mod.rs
+++ b/src/protocol/xdr/nfs3/mod.rs
@@ -22,7 +22,7 @@ use num_derive::{FromPrimitive, ToPrimitive};
 
 use super::{deserialize, Deserialize, Serialize};
 use crate::xdr::{DeserializeEnum, SerializeEnum, UsizeAsU32};
-use crate::{DeserializeStruct, SerializeStruct};
+use crate::{xdr, DeserializeStruct, SerializeStruct};
 
 // Modules for different operation types
 pub mod dir;
@@ -383,6 +383,9 @@ const _: () = {
 impl Deserialize for nfs_fh3 {
     fn deserialize<R: Read>(&mut self, src: &mut R) -> std::io::Result<()> {
         let _len = deserialize::<UsizeAsU32>(src)?;
+        if _len.0 != size_of::<nfs_fh3>() {
+            return Err(xdr::utils::invalid_data("Invalid nfs_fh3 length"));
+        }
         self.gen = deserialize::<u64>(src)?;
         self.fs_id = deserialize::<fs_id>(src)?;
         self.id = deserialize::<fileid3>(src)?;

--- a/src/protocol/xdr/nfs3/mod.rs
+++ b/src/protocol/xdr/nfs3/mod.rs
@@ -21,7 +21,7 @@ use filetime;
 use num_derive::{FromPrimitive, ToPrimitive};
 
 use super::{deserialize, Deserialize, Serialize};
-use crate::xdr::{DeserializeEnum, SerializeEnum};
+use crate::xdr::{DeserializeEnum, SerializeEnum, UsizeAsU32};
 use crate::{DeserializeStruct, SerializeStruct};
 
 // Modules for different operation types
@@ -382,7 +382,7 @@ const _: () = {
 // and thus needs to be encoded with its length as the first 4 bytes.
 impl Deserialize for nfs_fh3 {
     fn deserialize<R: Read>(&mut self, src: &mut R) -> std::io::Result<()> {
-        let _len = deserialize::<u32>(src)?;
+        let _len = deserialize::<UsizeAsU32>(src)?;
         self.gen = deserialize::<u64>(src)?;
         self.fs_id = deserialize::<fs_id>(src)?;
         self.id = deserialize::<fileid3>(src)?;
@@ -392,7 +392,7 @@ impl Deserialize for nfs_fh3 {
 
 impl Serialize for nfs_fh3 {
     fn serialize<R: Write>(&self, dest: &mut R) -> std::io::Result<()> {
-        (size_of::<Self>() as u32).serialize(dest)?;
+        UsizeAsU32(size_of::<Self>()).serialize(dest)?;
         self.gen.serialize(dest)?;
         self.fs_id.serialize(dest)?;
         self.id.serialize(dest)?;

--- a/src/protocol/xdr/nfs3/mod.rs
+++ b/src/protocol/xdr/nfs3/mod.rs
@@ -482,6 +482,12 @@ pub struct wcc_attr {
 DeserializeStruct!(wcc_attr, size, mtime, ctime);
 SerializeStruct!(wcc_attr, size, mtime, ctime);
 
+impl From<fattr3> for wcc_attr {
+    fn from(attr: fattr3) -> Self {
+        wcc_attr { size: attr.size, mtime: attr.mtime, ctime: attr.ctime }
+    }
+}
+
 /// Pre-operation attributes for weak cache consistency as defined in RFC 1813 section 2.3.8
 /// These attributes represent the file state before an operation was performed
 /// Used together with post-operation attributes to determine if file state changed

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -354,7 +354,7 @@ impl NFSTcp for NFSTcpListener {
             .write()
             .await
             .get_mut(&fs_id)
-            .ok_or_else(|| io::ErrorKind::NotFound)?
+            .ok_or(io::ErrorKind::NotFound)?
             .mount_signal = Some(signal);
         Ok(())
     }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -30,7 +30,8 @@ use crate::vfs::NFSFileSystem;
 pub struct NFSExportTableEntry {
     /// Arc reference to the NFS file system implementation
     pub vfs: Arc<dyn NFSFileSystem + Send + Sync + 'static>,
-    /// Optional channel for sending mount/unmount notifications
+    /// Channel for mount/unmount notifications
+    /// If `Some(sender)`, it will be used to notify when a client mounts (`true`) or unmounts (`false`) the file system.
     pub mount_signal: Option<mpsc::Sender<bool>>,
     /// Name of the exported file system path
     pub export_name: String,

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -8,16 +8,17 @@
 //!
 //! The implementation supports configurable export paths and notification
 //! on mount/unmount operations.
-
+use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::{Arc, RwLock};
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 use std::time::Duration;
 use std::{io, net::IpAddr};
 
 use async_trait::async_trait;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, error, info};
 
 use crate::protocol::nfs::portmap::PortmapTable;
@@ -25,19 +26,29 @@ use crate::protocol::{rpc, xdr};
 use crate::utils::error::io_other;
 use crate::vfs::NFSFileSystem;
 
+/// Entry in the NFS export table that represents a single exported file system.
+pub struct NFSExportTableEntry {
+    /// Arc reference to the NFS file system implementation
+    pub vfs: Arc<dyn NFSFileSystem + Send + Sync + 'static>,
+    /// Optional channel for sending mount/unmount notifications
+    pub mount_signal: Option<mpsc::Sender<bool>>,
+    /// Name of the exported file system path
+    pub export_name: String,
+}
+
+/// Hash map that stores all exported file systems for an NFS server.
+pub type NFSExportTable = HashMap<crate::xdr::nfs3::fs_id, NFSExportTableEntry>;
+
 /// NFS TCP Connection Handler that listens for incoming NFS client connections
 /// and processes RPC messages over TCP transport.
-pub struct NFSTcpListener<T: NFSFileSystem + Send + Sync + 'static> {
+pub struct NFSTcpListener {
+    next_id: AtomicU64,
     /// TCP Listener for accepting incoming connections
     listener: TcpListener,
     /// Port on which the server is listening
     port: u16,
-    /// Arc reference to the NFS file system implementation
-    arcfs: Arc<T>,
-    /// Optional channel for sending mount/unmount notifications
-    mount_signal: Option<mpsc::Sender<bool>>,
-    /// Name of the exported file system path
-    export_name: Arc<String>,
+    /// Table of NFS exports managed by this server
+    export_table: Arc<RwLock<NFSExportTable>>,
     /// Tracker for RPC transactions to handle retransmissions
     transaction_tracker: Arc<rpc::TransactionTracker>,
     /// Portmap table storing port-to-program mappings
@@ -151,7 +162,16 @@ pub trait NFSTcp: Send + Sync {
     /// * `signal` - MPSC sender that will receive boolean values:
     ///   * `true` when a client mounts the file system
     ///   * `false` when a client unmounts the file system
-    fn set_mount_listener(&mut self, signal: mpsc::Sender<bool>);
+    ///
+    /// # Returns
+    /// `io::Result<()>` indicating:
+    /// - `Ok(())` on successful operation
+    /// - `Err` if the export ID is not found in the export table
+    async fn set_mount_listener(
+        &mut self,
+        fs_id: xdr::nfs3::fs_id,
+        signal: mpsc::Sender<bool>,
+    ) -> io::Result<()>;
 
     /// Starts the NFS server and processes client connections
     ///
@@ -166,35 +186,33 @@ pub trait NFSTcp: Send + Sync {
     async fn handle_forever(&self) -> io::Result<()>;
 }
 
-impl<T: NFSFileSystem + Send + Sync + 'static> NFSTcpListener<T> {
+impl NFSTcpListener {
     /// Creates a new NFS TCP listener bound to the specified IP address and port
     ///
     /// # Arguments
     ///
     /// * `ipstr` - IP address and port in the format "IP:PORT" (e.g. "127.0.0.1:2049")
     ///   Special value "auto:PORT" attempts to find an available local address
-    /// * `fs` - Implementation of the [`NFSFileSystem`] trait that will handle NFS operations
     ///
     /// # Returns
     ///
     /// A Result containing either the new [`NFSTcpListener`] or an IO error
-    pub async fn bind(ipstr: &str, fs: T) -> io::Result<NFSTcpListener<T>> {
+    pub async fn bind(ipstr: &str) -> io::Result<NFSTcpListener> {
         let (ip, port) = ipstr.split_once(':').ok_or_else(|| {
             io::Error::new(io::ErrorKind::AddrNotAvailable, "IP Address must be of form ip:port")
         })?;
         let port = port.parse::<u16>().map_err(|_| {
             io::Error::new(io::ErrorKind::AddrNotAvailable, "Port not in range 0..=65535")
         })?;
-        let arcfs: Arc<T> = Arc::new(fs);
 
         if ip != "auto" {
-            return NFSTcpListener::bind_internal(ip, port, arcfs).await;
+            return NFSTcpListener::bind_internal(ip, port).await;
         }
 
         const NUM_TRIES: u16 = 32;
         for try_ip in 1..=NUM_TRIES {
             let ip = generate_host_ip(try_ip);
-            let result = NFSTcpListener::bind_internal(&ip, port, arcfs.clone()).await;
+            let result = NFSTcpListener::bind_internal(&ip, port).await;
 
             if result.is_ok() {
                 return result;
@@ -210,28 +228,43 @@ impl<T: NFSFileSystem + Send + Sync + 'static> NFSTcpListener<T> {
     ///
     /// * `ip` - IP address to bind to
     /// * `port` - Port number to bind to
-    /// * `arcfs` - Arc reference to the NFS file system implementation
-    async fn bind_internal(ip: &str, port: u16, arcfs: Arc<T>) -> io::Result<NFSTcpListener<T>> {
+    async fn bind_internal(ip: &str, port: u16) -> io::Result<NFSTcpListener> {
         let ipstr = format!("{ip}:{port}");
         let listener = TcpListener::bind(&ipstr).await?;
         info!("Listening on {:?}", &ipstr);
 
-        let port = match listener.local_addr().unwrap() {
+        let port = match listener.local_addr()? {
             SocketAddr::V4(s) => s.port(),
             SocketAddr::V6(s) => s.port(),
         };
+
         Ok(NFSTcpListener {
+            next_id: AtomicU64::new(0),
             listener,
             port,
-            arcfs,
-            mount_signal: None,
-            export_name: Arc::from("/".to_string()),
+            export_table: Arc::new(RwLock::new(HashMap::new())),
             transaction_tracker: Arc::new(rpc::TransactionTracker::new(Duration::from_secs(60))),
             portmap_table: Arc::from(RwLock::from(PortmapTable::default())),
         })
     }
 
-    /// Sets an optional NFS export name.
+    /// Registers a new NFS file system export. Export name defaults to "/".
+    ///
+    /// # Arguments
+    ///
+    /// * `fs` - Implementation of the NFSFileSystem trait that will handle NFS operations
+    ///
+    /// # Returns
+    ///
+    /// A Result containing either the generated filesystem ID or an error if registration fails
+    pub async fn register_export<T>(&mut self, fs: T) -> io::Result<xdr::nfs3::fs_id>
+    where
+        T: NFSFileSystem + Send + Sync + 'static,
+    {
+        self.register_export_with_name(fs, "").await
+    }
+
+    /// Registers a new NFS file system export with a custom export name
     ///
     /// The export name defines the path that clients will use to mount the file system.
     /// This method normalizes the provided name by adding a leading slash and removing
@@ -239,17 +272,46 @@ impl<T: NFSFileSystem + Send + Sync + 'static> NFSTcpListener<T> {
     ///
     /// # Arguments
     ///
-    /// * `export_name`: The desired export name without slashes.
-    pub fn with_export_name<S: AsRef<str>>(&mut self, export_name: S) {
-        self.export_name = Arc::new(format!(
-            "/{}",
-            export_name.as_ref().trim_end_matches('/').trim_start_matches('/')
-        ));
+    /// * `fs` - Implementation of the NFSFileSystem trait that will handle NFS operations
+    /// * `export_name` - The name/path for this export (e.g., "data" becomes "/data")
+    ///
+    /// # Returns
+    ///
+    /// A Result containing either the generated filesystem ID or an error if:
+    /// - The export name already exists
+    /// - Registration fails for another reason
+    pub async fn register_export_with_name<T, S>(
+        &mut self,
+        fs: T,
+        export_name: S,
+    ) -> io::Result<xdr::nfs3::fs_id>
+    where
+        T: NFSFileSystem + Send + Sync + 'static,
+        S: AsRef<str>,
+    {
+        let fs_id = self.next_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let export_name = format!("/{}", export_name.as_ref().trim_matches('/'));
+
+        if self.export_table.read().await.values().any(|entry| entry.export_name == export_name) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("Export with name '{export_name}' already exists"),
+            ));
+        }
+
+        debug!("Registering export with ID {fs_id} and name {export_name}");
+        self.export_table.write().await.insert(
+            fs_id,
+            NFSExportTableEntry { vfs: Arc::new(fs), export_name, mount_signal: None },
+        );
+
+        Ok(fs_id)
     }
 }
 
 #[async_trait]
-impl<T: NFSFileSystem + Send + Sync + 'static> NFSTcp for NFSTcpListener<T> {
+impl NFSTcp for NFSTcpListener {
     /// Returns the actual port number on which the server is listening
     ///
     /// This is especially useful when binding to port 0, which allows the OS
@@ -277,8 +339,23 @@ impl<T: NFSFileSystem + Send + Sync + 'static> NFSTcp for NFSTcpListener<T> {
     /// * `signal` - MPSC sender that will receive boolean values:
     ///   * `true` when a client mounts the file system
     ///   * `false` when a client unmounts the file system
-    fn set_mount_listener(&mut self, signal: mpsc::Sender<bool>) {
-        self.mount_signal = Some(signal);
+    ///
+    /// # Returns
+    /// `io::Result<()>` indicating:
+    /// - `Ok(())` on successful operation
+    /// - `Err` if the export ID is not found in the export table
+    async fn set_mount_listener(
+        &mut self,
+        fs_id: xdr::nfs3::fs_id,
+        signal: mpsc::Sender<bool>,
+    ) -> io::Result<()> {
+        self.export_table
+            .write()
+            .await
+            .get_mut(&fs_id)
+            .ok_or_else(|| io::ErrorKind::NotFound)?
+            .mount_signal = Some(signal);
+        Ok(())
     }
 
     /// Starts the NFS server and processes client connections
@@ -298,9 +375,7 @@ impl<T: NFSFileSystem + Send + Sync + 'static> NFSTcp for NFSTcpListener<T> {
                 local_port: self.port,
                 client_addr: socket.peer_addr()?.to_string(),
                 auth: xdr::rpc::auth_unix::default(),
-                vfs: self.arcfs.clone(),
-                mount_signal: self.mount_signal.clone(),
-                export_name: self.export_name.clone(),
+                export_table: self.export_table.clone(),
                 transaction_tracker: self.transaction_tracker.clone(),
                 portmap_table: self.portmap_table.clone(),
             };

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -8,7 +8,6 @@
 //!
 //! The implementation supports configurable export paths and notification
 //! on mount/unmount operations.
-use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -16,6 +15,7 @@ use std::time::Duration;
 use std::{io, net::IpAddr};
 
 use async_trait::async_trait;
+use dashmap::DashMap;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, RwLock};
@@ -41,7 +41,7 @@ pub struct NFSExportTableEntry {
 }
 
 /// Hash map that stores all exported file systems for an NFS server.
-pub type NFSExportTable = HashMap<crate::xdr::nfs3::fs_id, NFSExportTableEntry>;
+pub type NFSExportTable = DashMap<crate::xdr::nfs3::fs_id, NFSExportTableEntry>;
 
 /// NFS TCP Connection Handler that listens for incoming NFS client connections
 /// and processes RPC messages over TCP transport.
@@ -52,7 +52,7 @@ pub struct NFSTcpListener {
     /// Port on which the server is listening
     port: u16,
     /// Table of NFS exports managed by this server
-    export_table: Arc<RwLock<NFSExportTable>>,
+    export_table: Arc<NFSExportTable>,
     /// Tracker for RPC transactions to handle retransmissions
     transaction_tracker: Arc<rpc::TransactionTracker>,
     /// Portmap table storing port-to-program mappings
@@ -246,7 +246,7 @@ impl NFSTcpListener {
             next_id: AtomicU64::new(0),
             listener,
             port,
-            export_table: Arc::new(RwLock::new(HashMap::new())),
+            export_table: Arc::new(DashMap::new()),
             transaction_tracker: Arc::new(rpc::TransactionTracker::new(
                 TRANSACTION_RETENTION_PERIOD,
             )),
@@ -299,7 +299,7 @@ impl NFSTcpListener {
 
         let export_name = format!("/{}", export_name.as_ref().trim_matches('/'));
 
-        if self.export_table.read().await.values().any(|entry| entry.export_name == export_name) {
+        if self.export_table.iter().any(|entry| entry.export_name == export_name) {
             return Err(io::Error::new(
                 io::ErrorKind::AlreadyExists,
                 format!("Export with name '{export_name}' already exists"),
@@ -307,7 +307,7 @@ impl NFSTcpListener {
         }
 
         debug!("Registering export with ID {fs_id} and name {export_name}");
-        self.export_table.write().await.insert(
+        self.export_table.insert(
             fs_id,
             NFSExportTableEntry { vfs: Arc::new(fs), export_name, mount_signal: None },
         );
@@ -355,12 +355,8 @@ impl NFSTcp for NFSTcpListener {
         fs_id: xdr::nfs3::fs_id,
         signal: mpsc::Sender<bool>,
     ) -> io::Result<()> {
-        self.export_table
-            .write()
-            .await
-            .get_mut(&fs_id)
-            .ok_or(io::ErrorKind::NotFound)?
-            .mount_signal = Some(signal);
+        self.export_table.get_mut(&fs_id).ok_or(io::ErrorKind::NotFound)?.mount_signal =
+            Some(signal);
         Ok(())
     }
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -258,7 +258,7 @@ impl NFSTcpListener {
     /// # Returns
     ///
     /// A Result containing either the generated filesystem ID or an error if registration fails
-    pub async fn register_export<T>(&mut self, fs: T) -> io::Result<xdr::nfs3::fs_id>
+    pub async fn register_root_export<T>(&mut self, fs: T) -> io::Result<xdr::nfs3::fs_id>
     where
         T: NFSFileSystem + Send + Sync + 'static,
     {

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -497,15 +497,12 @@ pub trait NFSFileSystem: Sync {
     ///
     /// # Arguments
     /// * `id` - The file ID to convert
+    /// * `fs_id` - The file system's ID in the server export table
     ///
     /// # Returns
     /// * `nfs_fh3` - The opaque NFS file handle
-    fn id_to_fh(&self, id: nfs3::fileid3) -> nfs3::nfs_fh3 {
-        let gennum = self.generation();
-        let mut ret: Vec<u8> = Vec::new();
-        ret.extend_from_slice(&gennum.to_le_bytes());
-        ret.extend_from_slice(&id.to_le_bytes());
-        nfs3::nfs_fh3 { data: ret }
+    fn id_to_fh(&self, id: nfs3::fileid3, fs_id: nfs3::fs_id) -> nfs3::nfs_fh3 {
+        nfs3::nfs_fh3 { gen: self.generation(), id, fs_id }
     }
 
     /// Converts an opaque NFS file handle to a file ID
@@ -520,17 +517,11 @@ pub trait NFSFileSystem: Sync {
     /// * `Result<fileid3, nfsstat3>` - The file ID on success, or an NFS error code
     ///   Returns NFS3ERR_STALE if the file handle is from a previous server instance
     ///   Returns NFS3ERR_BADHANDLE if the file handle is malformed
-    fn fh_to_id(&self, id: &nfs3::nfs_fh3) -> Result<nfs3::fileid3, nfs3::nfsstat3> {
-        if id.data.len() != 16 {
-            return Err(nfs3::nfsstat3::NFS3ERR_BADHANDLE);
-        }
-        let gen = u64::from_le_bytes(id.data[0..8].try_into().unwrap());
-        let id = u64::from_le_bytes(id.data[8..16].try_into().unwrap());
-        let gennum = self.generation();
-        match gen.cmp(&gennum) {
+    fn fh_to_id(&self, nfs_fh: &nfs3::nfs_fh3) -> Result<nfs3::fileid3, nfs3::nfsstat3> {
+        match self.generation().cmp(&nfs_fh.gen) {
             Ordering::Less => Err(nfs3::nfsstat3::NFS3ERR_STALE),
             Ordering::Greater => Err(nfs3::nfsstat3::NFS3ERR_BADHANDLE),
-            Ordering::Equal => Ok(id),
+            Ordering::Equal => Ok(nfs_fh.id),
         }
     }
 

--- a/tests/portmap.rs
+++ b/tests/portmap.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::io;
 use std::io::Cursor;
 use std::string::ToString;
@@ -18,7 +19,7 @@ use nfs_mamont::xdr::nfs3::{
 };
 use nfs_mamont::xdr::portmap::{mapping, IPPROTO_TCP, IPPROTO_UDP};
 use nfs_mamont::xdr::rpc::call_body;
-use nfs_mamont::xdr::{nfs3, Serialize};
+use nfs_mamont::xdr::{deserialize, nfs3, Serialize};
 use nfs_mamont::{vfs, xdr};
 
 pub struct DemoFS {
@@ -305,9 +306,9 @@ async fn send_unset_port(
     )
     .await
 }
-/// Assisting macro for RPC portmap operation (`GETPORT`, `SET`, or `UNSET`) to ease operations with Cursors and asserts
+/// Assisting function for RPC portmap operation (`GETPORT`, `SET`, or `UNSET`) to ease operations with Cursors and asserts
 ///
-/// This macro:
+/// This function:
 /// 1. Resets the input/output cursor positions (to ensure clean state).
 /// 2. Executes the provided portmap operation (`function`) with the given arguments.
 /// 3. Deserializes the output buffer into type `T` (expected result type).
@@ -320,21 +321,33 @@ async fn send_unset_port(
 /// - `output`: Mutable cursor where the RPC response will be written.
 /// - `mapping`: Portmap arguments (program, port, protocol, etc.).
 /// - `expected`: The expected deserialized result (e.g., `0` for failure, port number for success).
-/// - `ty`: The type of the expected result, because compiler cannot figure it out.
 ///
 /// # Type Constraints
 /// - `T` must be deserializable (via `xdr::Deserialize`), comparable (`PartialEq`),
 ///   and have a default value (`Default`). Used for the response type.
 /// - `F`: A closure or function pointer matching one of the portmap operations.
-macro_rules! call_assert {
-    ($function:expr, $context:expr, $input:expr, $output:expr, $mapping:expr, $expected:expr, $ty:ty) => {
-        $input.set_position(0);
-        $output.set_position(0);
-        $function($context, $input, $output, $mapping).await.expect("can't proceed operation");
-        $output.set_position(RPC_MSG_SIZE);
-        let res = $crate::xdr::deserialize::<$ty>($output).expect("can't get result");
-        assert_eq!(res, $expected);
-    };
+async fn call_assert<F, T>(
+    function: F,
+    context: &mut Context,
+    input: &mut Cursor<Vec<u8>>,
+    output: &mut Cursor<Vec<u8>>,
+    mapping: mapping,
+    expected: T,
+) where
+    F: AsyncFnOnce(
+        &mut Context,
+        &mut Cursor<Vec<u8>>,
+        &mut Cursor<Vec<u8>>,
+        mapping,
+    ) -> io::Result<()>,
+    T: PartialEq + Default + xdr::Deserialize + Debug,
+{
+    input.set_position(0);
+    output.set_position(0);
+    function(context, input, output, mapping).await.expect("can't proceed operation");
+    output.set_position(RPC_MSG_SIZE);
+    let res = deserialize::<T>(output).expect("can't get result");
+    assert_eq!(res, expected);
 }
 
 #[cfg(test)]
@@ -363,7 +376,7 @@ mod tests {
             prot: IPPROTO_TCP,
             port: port as u32,
         };
-        call_assert!(send_get_port, &mut context, &mut input, &mut output, mapping_args, 0, u32);
+        call_assert(send_get_port, &mut context, &mut input, &mut output, mapping_args, 0).await;
     }
 
     ///simple test to assure, that after SET_PORT operation for program without
@@ -385,16 +398,8 @@ mod tests {
             prot: IPPROTO_TCP,
             port: port as u32,
         };
-        call_assert!(send_get_port, &mut context, &mut input, &mut output, mapping_args, 0, u32);
-        call_assert!(
-            send_set_port,
-            &mut context,
-            &mut input,
-            &mut output,
-            mapping_args,
-            true,
-            bool
-        );
+        call_assert(send_get_port, &mut context, &mut input, &mut output, mapping_args, 0).await;
+        call_assert(send_set_port, &mut context, &mut input, &mut output, mapping_args, true).await;
     }
 
     ///simple test of GET_PORT after SET_PORT
@@ -415,24 +420,16 @@ mod tests {
         };
         let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
         let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
-        call_assert!(
-            send_set_port,
-            &mut context,
-            &mut input,
-            &mut output,
-            mapping_args,
-            true,
-            bool
-        );
-        call_assert!(
+        call_assert(send_set_port, &mut context, &mut input, &mut output, mapping_args, true).await;
+        call_assert(
             send_get_port,
             &mut context,
             &mut input,
             &mut output,
             mapping_args,
             port as u32,
-            u32
-        );
+        )
+        .await;
     }
 
     ///test of multiple GET_PORT after SET_PORT
@@ -450,27 +447,20 @@ mod tests {
         let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
 
         for mapping_arg in maps.clone() {
-            call_assert!(
-                send_set_port,
-                &mut context,
-                &mut input,
-                &mut output,
-                mapping_arg,
-                true,
-                bool
-            );
+            call_assert(send_set_port, &mut context, &mut input, &mut output, mapping_arg, true)
+                .await;
         }
 
         for mapping_arg in maps {
-            call_assert!(
+            call_assert(
                 send_get_port,
                 &mut context,
                 &mut input,
                 &mut output,
                 mapping_arg,
                 mapping_arg.prog + mapping_arg.vers * 1000,
-                u32
-            );
+            )
+            .await;
         }
     }
 
@@ -490,51 +480,51 @@ mod tests {
                     block_on(async move {
                         let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
                         let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
-                        call_assert!(
+                        call_assert(
                             send_get_port,
                             &mut context,
                             &mut input,
                             &mut output,
                             mappings_1,
                             0,
-                            u32
-                        );
-                        call_assert!(
+                        )
+                        .await;
+                        call_assert(
                             send_set_port,
                             &mut context,
                             &mut input,
                             &mut output,
                             mappings_1,
                             true,
-                            bool
-                        );
-                        call_assert!(
+                        )
+                        .await;
+                        call_assert(
                             send_set_port,
                             &mut context,
                             &mut input,
                             &mut output,
                             mappings_2,
                             true,
-                            bool
-                        );
-                        call_assert!(
+                        )
+                        .await;
+                        call_assert(
                             send_get_port,
                             &mut context,
                             &mut input,
                             &mut output,
                             mappings_1,
                             mappings_1.prog + mappings_1.vers * 1000,
-                            u32
-                        );
-                        call_assert!(
+                        )
+                        .await;
+                        call_assert(
                             send_get_port,
                             &mut context,
                             &mut input,
                             &mut output,
                             mappings_2,
                             mappings_2.prog + mappings_2.vers * 1000,
-                            u32
-                        );
+                        )
+                        .await;
                     })
                 });
             }
@@ -544,15 +534,15 @@ mod tests {
         let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
 
         for mapping_arg in mappings {
-            call_assert!(
+            call_assert(
                 send_get_port,
                 &mut contexts[0],
                 &mut input,
                 &mut output,
                 mapping_arg,
                 mapping_arg.prog + mapping_arg.vers * 1000,
-                u32
-            );
+            )
+            .await;
         }
     }
     ///test of UNSET when programs that haven't been mapped to port
@@ -571,7 +561,7 @@ mod tests {
         let args_tcp = multiple_mappings(amount, IPPROTO_TCP);
 
         for arg in args_tcp {
-            call_assert!(send_unset_port, &mut context, &mut input, &mut output, arg, false, bool);
+            call_assert(send_unset_port, &mut context, &mut input, &mut output, arg, false).await;
         }
     }
 
@@ -591,11 +581,11 @@ mod tests {
         let args = multiple_mappings(amount, IPPROTO_UDP);
 
         for arg in &args {
-            call_assert!(send_set_port, &mut context, &mut input, &mut output, *arg, true, bool);
+            call_assert(send_set_port, &mut context, &mut input, &mut output, *arg, true).await;
         }
 
         for arg in args {
-            call_assert!(send_unset_port, &mut context, &mut input, &mut output, arg, true, bool);
+            call_assert(send_unset_port, &mut context, &mut input, &mut output, arg, true).await;
         }
     }
 
@@ -616,34 +606,20 @@ mod tests {
         let args_tcp = multiple_mappings(amount, IPPROTO_TCP);
 
         for arg in &args_udp {
-            call_assert!(send_set_port, &mut context, &mut input, &mut output, *arg, true, bool);
+            call_assert(send_set_port, &mut context, &mut input, &mut output, *arg, true).await;
         }
 
         for arg in &args_tcp {
-            call_assert!(send_set_port, &mut context, &mut input, &mut output, *arg, true, bool);
+            call_assert(send_set_port, &mut context, &mut input, &mut output, *arg, true).await;
         }
 
         for mapping in args_tcp {
-            call_assert!(
-                send_unset_port,
-                &mut context,
-                &mut input,
-                &mut output,
-                mapping,
-                true,
-                bool
-            );
+            call_assert(send_unset_port, &mut context, &mut input, &mut output, mapping, true)
+                .await;
         }
         for mapping in args_udp {
-            call_assert!(
-                send_unset_port,
-                &mut context,
-                &mut input,
-                &mut output,
-                mapping,
-                false,
-                bool
-            );
+            call_assert(send_unset_port, &mut context, &mut input, &mut output, mapping, false)
+                .await;
         }
     }
 
@@ -664,66 +640,66 @@ mod tests {
                 scope.spawn(async move || {
                     let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
                     let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
-                    call_assert!(
+                    call_assert(
                         send_unset_port,
                         &mut context,
                         &mut input,
                         &mut output,
                         mappings_2,
                         false,
-                        bool
-                    );
-                    call_assert!(
+                    )
+                    .await;
+                    call_assert(
                         send_set_port,
                         &mut context,
                         &mut input,
                         &mut output,
                         mappings_2,
                         true,
-                        bool
-                    );
-                    call_assert!(
+                    )
+                    .await;
+                    call_assert(
                         send_set_port,
                         &mut context,
                         &mut input,
                         &mut output,
                         mappings_1,
                         true,
-                        bool
-                    );
-                    call_assert!(
+                    )
+                    .await;
+                    call_assert(
                         send_unset_port,
                         &mut context,
                         &mut input,
                         &mut output,
                         mappings_1,
                         true,
-                        bool
-                    );
-                    call_assert!(
+                    )
+                    .await;
+                    call_assert(
                         send_unset_port,
                         &mut context,
                         &mut input,
                         &mut output,
                         mappings_2,
                         false,
-                        bool
-                    );
+                    )
+                    .await;
                 });
             }
         });
         let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
         let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
         for mapping in mapping_udp {
-            call_assert!(
+            call_assert(
                 send_get_port,
                 &mut context[0].clone(),
                 &mut input,
                 &mut output,
                 mapping,
                 0,
-                u32
-            );
+            )
+            .await;
         }
     }
 
@@ -741,15 +717,7 @@ mod tests {
         let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
         let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
         for mapping in &mappings {
-            call_assert!(
-                send_set_port,
-                &mut context,
-                &mut input,
-                &mut output,
-                *mapping,
-                true,
-                bool
-            );
+            call_assert(send_set_port, &mut context, &mut input, &mut output, *mapping, true).await;
         }
         output.set_position(0);
         send_dump(&mut context, &mut input, &mut output).await.unwrap();
@@ -782,15 +750,8 @@ mod tests {
         let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
         let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
         for mapping in mappings {
-            call_assert!(
-                send_set_port,
-                &mut contexts[0],
-                &mut input,
-                &mut output,
-                *mapping,
-                true,
-                bool
-            );
+            call_assert(send_set_port, &mut contexts[0], &mut input, &mut output, *mapping, true)
+                .await;
         }
         std::thread::scope(|scope| {
             for context in &mut contexts {

--- a/tests/portmap.rs
+++ b/tests/portmap.rs
@@ -175,8 +175,8 @@ fn multiple_mappings(amount: u32, prot: u32) -> Vec<mapping> {
     result
 }
 
-fn create_export_table() -> Arc<RwLock<nfs_mamont::tcp::NFSExportTable>> {
-    let mut export_table = nfs_mamont::tcp::NFSExportTable::default();
+fn create_export_table() -> Arc<nfs_mamont::tcp::NFSExportTable> {
+    let export_table = nfs_mamont::tcp::NFSExportTable::default();
     export_table.insert(
         0,
         NFSExportTableEntry {
@@ -185,7 +185,7 @@ fn create_export_table() -> Arc<RwLock<nfs_mamont::tcp::NFSExportTable>> {
             export_name: DEFAULT_EXPORT_NAME.to_string(),
         },
     );
-    Arc::new(RwLock::new(export_table))
+    Arc::new(export_table)
 }
 
 fn multiple_contexts(amount: u32) -> Vec<Context> {

--- a/tests/portmap.rs
+++ b/tests/portmap.rs
@@ -307,7 +307,7 @@ async fn send_unset_port(
 }
 /// Assisting macro for RPC portmap operation (`GETPORT`, `SET`, or `UNSET`) to ease operations with Cursors and asserts
 ///
-/// This macro::
+/// This macro:
 /// 1. Resets the input/output cursor positions (to ensure clean state).
 /// 2. Executes the provided portmap operation (`function`) with the given arguments.
 /// 3. Deserializes the output buffer into type `T` (expected result type).

--- a/tests/portmap.rs
+++ b/tests/portmap.rs
@@ -332,7 +332,7 @@ macro_rules! call_assert {
         $output.set_position(0);
         $function($context, $input, $output, $mapping).await.expect("can't proceed operation");
         $output.set_position(RPC_MSG_SIZE);
-        let res = crate::xdr::deserialize::<$ty>($output).expect("can't get result");
+        let res = $crate::xdr::deserialize::<$ty>($output).expect("can't get result");
         assert_eq!(res, $expected);
     };
 }

--- a/tests/portmap.rs
+++ b/tests/portmap.rs
@@ -1,22 +1,24 @@
 use std::io;
 use std::io::Cursor;
 use std::string::ToString;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use num_traits::ToPrimitive;
+use tokio::sync::RwLock;
 
 use nfs_mamont::protocol::nfs::portmap::PortmapTable;
 use nfs_mamont::protocol::rpc;
 use nfs_mamont::protocol::rpc::Context;
+use nfs_mamont::tcp::NFSExportTableEntry;
 use nfs_mamont::vfs::{Capabilities, ReadDirResult};
 use nfs_mamont::xdr::nfs3::{
     fattr3, fileid3, filename3, ftype3, nfspath3, nfsstat3, sattr3, specdata3,
 };
 use nfs_mamont::xdr::portmap::{mapping, IPPROTO_TCP, IPPROTO_UDP};
 use nfs_mamont::xdr::rpc::call_body;
-use nfs_mamont::xdr::{deserialize, nfs3, Serialize};
+use nfs_mamont::xdr::{nfs3, Serialize};
 use nfs_mamont::{vfs, xdr};
 
 pub struct DemoFS {
@@ -171,6 +173,20 @@ fn multiple_mappings(amount: u32, prot: u32) -> Vec<mapping> {
     }
     result
 }
+
+fn create_export_table() -> Arc<RwLock<nfs_mamont::tcp::NFSExportTable>> {
+    let mut export_table = nfs_mamont::tcp::NFSExportTable::default();
+    export_table.insert(
+        0,
+        NFSExportTableEntry {
+            vfs: Arc::new(DemoFS { _root: String::default() }),
+            mount_signal: None,
+            export_name: DEFAULT_EXPORT_NAME.to_string(),
+        },
+    );
+    Arc::new(RwLock::new(export_table))
+}
+
 fn multiple_contexts(amount: u32) -> Vec<Context> {
     let mut result = Vec::<Context>::with_capacity(amount as usize);
     let table = Arc::from(RwLock::from(PortmapTable::default()));
@@ -179,9 +195,7 @@ fn multiple_contexts(amount: u32) -> Vec<Context> {
             local_port: DEFAULT_PROG,
             client_addr: format!("0.0.0.0:{}", i),
             auth: xdr::rpc::auth_unix::default(),
-            vfs: Arc::new(DemoFS { _root: String::default() }),
-            mount_signal: None,
-            export_name: Arc::from(DEFAULT_EXPORT_NAME.to_string()),
+            export_table: create_export_table(),
             transaction_tracker: Arc::new(rpc::TransactionTracker::new(Duration::from_secs(60))),
             portmap_table: table.clone(),
         });
@@ -189,7 +203,7 @@ fn multiple_contexts(amount: u32) -> Vec<Context> {
     result
 }
 
-fn send_get_port(
+async fn send_get_port(
     context: &mut Context,
     input: &mut Cursor<Vec<u8>>,
     output: &mut Cursor<Vec<u8>>,
@@ -213,9 +227,10 @@ fn send_get_port(
         output,
         context,
     )
+    .await
 }
 
-fn send_set_port(
+async fn send_set_port(
     context: &mut Context,
     input: &mut Cursor<Vec<u8>>,
     output: &mut Cursor<Vec<u8>>,
@@ -239,9 +254,10 @@ fn send_set_port(
         output,
         context,
     )
+    .await
 }
 
-fn send_dump(
+async fn send_dump(
     context: &mut Context,
     input: &mut Cursor<Vec<u8>>,
     output: &mut Cursor<Vec<u8>>,
@@ -261,8 +277,9 @@ fn send_dump(
         output,
         context,
     )
+    .await
 }
-fn send_unset_port(
+async fn send_unset_port(
     context: &mut Context,
     input: &mut Cursor<Vec<u8>>,
     output: &mut Cursor<Vec<u8>>,
@@ -286,10 +303,11 @@ fn send_unset_port(
         output,
         context,
     )
+    .await
 }
-/// Assisting function for RPC portmap operation (`GETPORT`, `SET`, or `UNSET`) to ease operations with Cursors and asserts
+/// Assisting macro for RPC portmap operation (`GETPORT`, `SET`, or `UNSET`) to ease operations with Cursors and asserts
 ///
-/// This function:
+/// This macro::
 /// 1. Resets the input/output cursor positions (to ensure clean state).
 /// 2. Executes the provided portmap operation (`function`) with the given arguments.
 /// 3. Deserializes the output buffer into type `T` (expected result type).
@@ -302,45 +320,38 @@ fn send_unset_port(
 /// - `output`: Mutable cursor where the RPC response will be written.
 /// - `mapping`: Portmap arguments (program, port, protocol, etc.).
 /// - `expected`: The expected deserialized result (e.g., `0` for failure, port number for success).
+/// - `ty`: The type of the expected result, because compiler cannot figure it out.
 ///
 /// # Type Constraints
 /// - `T` must be deserializable (via `xdr::Deserialize`), comparable (`PartialEq`),
 ///   and have a default value (`Default`). Used for the response type.
 /// - `F`: A closure or function pointer matching one of the portmap operations.
-fn call_assert<F, T>(
-    function: F,
-    context: &mut Context,
-    input: &mut Cursor<Vec<u8>>,
-    output: &mut Cursor<Vec<u8>>,
-    mapping: mapping,
-    expected: T,
-) where
-    F: FnOnce(&mut Context, &mut Cursor<Vec<u8>>, &mut Cursor<Vec<u8>>, mapping) -> io::Result<()>,
-    T: PartialEq + Default + xdr::Deserialize + std::fmt::Debug,
-{
-    input.set_position(0);
-    output.set_position(0);
-    function(context, input, output, mapping).expect("can't proceed operation");
-    output.set_position(RPC_MSG_SIZE);
-    let res = deserialize::<T>(output).expect("can't get result");
-    assert_eq!(res, expected);
+macro_rules! call_assert {
+    ($function:expr, $context:expr, $input:expr, $output:expr, $mapping:expr, $expected:expr, $ty:ty) => {
+        $input.set_position(0);
+        $output.set_position(0);
+        $function($context, $input, $output, $mapping).await.expect("can't proceed operation");
+        $output.set_position(RPC_MSG_SIZE);
+        let res = crate::xdr::deserialize::<$ty>($output).expect("can't get result");
+        assert_eq!(res, $expected);
+    };
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use nfs_mamont::xdr::deserialize;
     use nfs_mamont::xdr::portmap::pmaplist;
 
-    use super::*;
     /// simple test to assure, that result of GET_PORT operation is zero,
     /// when there is no attached port to corresponding program
-    fn get_port_zero_reply(port: u16) {
+    async fn get_port_zero_reply(port: u16) {
         let mut context = Context {
             local_port: DEFAULT_PORT,
             client_addr: DEFAULT_ADDRESS.to_string(),
             auth: xdr::rpc::auth_unix::default(),
-            vfs: Arc::new(DemoFS { _root: String::default() }),
-            mount_signal: None,
-            export_name: Arc::from(DEFAULT_EXPORT_NAME.to_string()),
+            export_table: create_export_table(),
             transaction_tracker: Arc::new(rpc::TransactionTracker::new(Duration::from_secs(60))),
             portmap_table: Arc::from(RwLock::from(PortmapTable::default())),
         };
@@ -352,19 +363,17 @@ mod tests {
             prot: IPPROTO_TCP,
             port: port as u32,
         };
-        call_assert(send_get_port, &mut context, &mut input, &mut output, mapping_args, 0);
+        call_assert!(send_get_port, &mut context, &mut input, &mut output, mapping_args, 0, u32);
     }
 
     ///simple test to assure, that after SET_PORT operation for program without
     /// associated port, entry creates and result of operation is TRUE
-    fn set_port_ok_reply(port: u16) {
+    async fn set_port_ok_reply(port: u16) {
         let mut context = Context {
             local_port: DEFAULT_PORT,
             client_addr: DEFAULT_ADDRESS.to_string(),
             auth: xdr::rpc::auth_unix::default(),
-            vfs: Arc::new(DemoFS { _root: String::default() }),
-            mount_signal: None,
-            export_name: Arc::from(DEFAULT_EXPORT_NAME.to_string()),
+            export_table: create_export_table(),
             transaction_tracker: Arc::new(rpc::TransactionTracker::new(Duration::from_secs(60))),
             portmap_table: Arc::from(RwLock::from(PortmapTable::default())),
         };
@@ -376,12 +385,20 @@ mod tests {
             prot: IPPROTO_TCP,
             port: port as u32,
         };
-        call_assert(send_get_port, &mut context, &mut input, &mut output, mapping_args, 0);
-        call_assert(send_set_port, &mut context, &mut input, &mut output, mapping_args, true);
+        call_assert!(send_get_port, &mut context, &mut input, &mut output, mapping_args, 0, u32);
+        call_assert!(
+            send_set_port,
+            &mut context,
+            &mut input,
+            &mut output,
+            mapping_args,
+            true,
+            bool
+        );
     }
 
     ///simple test of GET_PORT after SET_PORT
-    fn get_port_ok_reply(port: u16) {
+    async fn get_port_ok_reply(port: u16) {
         let mapping_args = mapping {
             prog: nfs3::PROGRAM,
             vers: DEFAULT_VERSION,
@@ -392,35 +409,40 @@ mod tests {
             local_port: DEFAULT_PORT,
             client_addr: DEFAULT_ADDRESS.to_string(),
             auth: xdr::rpc::auth_unix::default(),
-            vfs: Arc::new(DemoFS { _root: String::default() }),
-            mount_signal: None,
-            export_name: Arc::from(DEFAULT_EXPORT_NAME.to_string()),
+            export_table: create_export_table(),
             transaction_tracker: Arc::new(rpc::TransactionTracker::new(Duration::from_secs(60))),
             portmap_table: Arc::from(RwLock::from(PortmapTable::default())),
         };
         let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
         let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
-        call_assert(send_set_port, &mut context, &mut input, &mut output, mapping_args, true);
-        call_assert(
+        call_assert!(
+            send_set_port,
+            &mut context,
+            &mut input,
+            &mut output,
+            mapping_args,
+            true,
+            bool
+        );
+        call_assert!(
             send_get_port,
             &mut context,
             &mut input,
             &mut output,
             mapping_args,
             port as u32,
+            u32
         );
     }
 
     ///test of multiple GET_PORT after SET_PORT
-    fn set_and_get_multiple(amount: u32) {
+    async fn set_and_get_multiple(amount: u32) {
         let maps = multiple_mappings(amount, IPPROTO_TCP);
         let mut context = Context {
             local_port: DEFAULT_PORT,
             client_addr: DEFAULT_ADDRESS.to_string(),
             auth: xdr::rpc::auth_unix::default(),
-            vfs: Arc::new(DemoFS { _root: String::default() }),
-            mount_signal: None,
-            export_name: Arc::from(DEFAULT_EXPORT_NAME.to_string()),
+            export_table: create_export_table(),
             transaction_tracker: Arc::new(rpc::TransactionTracker::new(Duration::from_secs(60))),
             portmap_table: Arc::from(RwLock::from(PortmapTable::default())),
         };
@@ -428,23 +450,32 @@ mod tests {
         let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
 
         for mapping_arg in maps.clone() {
-            call_assert(send_set_port, &mut context, &mut input, &mut output, mapping_arg, true);
+            call_assert!(
+                send_set_port,
+                &mut context,
+                &mut input,
+                &mut output,
+                mapping_arg,
+                true,
+                bool
+            );
         }
 
         for mapping_arg in maps {
-            call_assert(
+            call_assert!(
                 send_get_port,
                 &mut context,
                 &mut input,
                 &mut output,
                 mapping_arg,
                 mapping_arg.prog + mapping_arg.vers * 1000,
+                u32
             );
         }
     }
 
     ///test of multiple operations asynchronously
-    fn multi_thread_get_set(amount: usize) {
+    async fn multi_thread_get_set(amount: usize) {
         let mut contexts = multiple_contexts((amount / 2) as u32);
         let mappings = multiple_mappings(amount as u32, IPPROTO_TCP);
 
@@ -456,48 +487,55 @@ mod tests {
         std::thread::scope(|scope| {
             for (mut context, (mappings_1, mappings_2)) in set_for_thread {
                 scope.spawn(move || {
-                    let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
-                    let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
-                    call_assert(
-                        send_get_port,
-                        &mut context,
-                        &mut input,
-                        &mut output,
-                        mappings_1,
-                        0,
-                    );
-                    call_assert(
-                        send_set_port,
-                        &mut context,
-                        &mut input,
-                        &mut output,
-                        mappings_1,
-                        true,
-                    );
-                    call_assert(
-                        send_set_port,
-                        &mut context,
-                        &mut input,
-                        &mut output,
-                        mappings_2,
-                        true,
-                    );
-                    call_assert(
-                        send_get_port,
-                        &mut context,
-                        &mut input,
-                        &mut output,
-                        mappings_1,
-                        mappings_1.prog + mappings_1.vers * 1000,
-                    );
-                    call_assert(
-                        send_get_port,
-                        &mut context,
-                        &mut input,
-                        &mut output,
-                        mappings_2,
-                        mappings_2.prog + mappings_2.vers * 1000,
-                    );
+                    block_on(async move {
+                        let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
+                        let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
+                        call_assert!(
+                            send_get_port,
+                            &mut context,
+                            &mut input,
+                            &mut output,
+                            mappings_1,
+                            0,
+                            u32
+                        );
+                        call_assert!(
+                            send_set_port,
+                            &mut context,
+                            &mut input,
+                            &mut output,
+                            mappings_1,
+                            true,
+                            bool
+                        );
+                        call_assert!(
+                            send_set_port,
+                            &mut context,
+                            &mut input,
+                            &mut output,
+                            mappings_2,
+                            true,
+                            bool
+                        );
+                        call_assert!(
+                            send_get_port,
+                            &mut context,
+                            &mut input,
+                            &mut output,
+                            mappings_1,
+                            mappings_1.prog + mappings_1.vers * 1000,
+                            u32
+                        );
+                        call_assert!(
+                            send_get_port,
+                            &mut context,
+                            &mut input,
+                            &mut output,
+                            mappings_2,
+                            mappings_2.prog + mappings_2.vers * 1000,
+                            u32
+                        );
+                    })
                 });
             }
         });
@@ -506,25 +544,24 @@ mod tests {
         let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
 
         for mapping_arg in mappings {
-            call_assert(
+            call_assert!(
                 send_get_port,
                 &mut contexts[0],
                 &mut input,
                 &mut output,
                 mapping_arg,
                 mapping_arg.prog + mapping_arg.vers * 1000,
+                u32
             );
         }
     }
     ///test of UNSET when programs that haven't been mapped to port
-    fn unset_empty_table(amount: u32) {
+    async fn unset_empty_table(amount: u32) {
         let mut context = Context {
             local_port: DEFAULT_PORT,
             client_addr: DEFAULT_ADDRESS.to_string(),
             auth: xdr::rpc::auth_unix::default(),
-            vfs: Arc::new(DemoFS { _root: String::default() }),
-            mount_signal: None,
-            export_name: Arc::from(DEFAULT_EXPORT_NAME.to_string()),
+            export_table: create_export_table(),
             transaction_tracker: Arc::new(rpc::TransactionTracker::new(Duration::from_secs(60))),
             portmap_table: Arc::from(RwLock::from(PortmapTable::default())),
         };
@@ -534,19 +571,17 @@ mod tests {
         let args_tcp = multiple_mappings(amount, IPPROTO_TCP);
 
         for arg in args_tcp {
-            call_assert(send_unset_port, &mut context, &mut input, &mut output, arg, false);
+            call_assert!(send_unset_port, &mut context, &mut input, &mut output, arg, false, bool);
         }
     }
 
     ///test of UNSET, when only one of two (TCP or UDP) protocols are mapped
-    fn unset_single_protocol(amount: u32) {
+    async fn unset_single_protocol(amount: u32) {
         let mut context = Context {
             local_port: DEFAULT_PORT,
             client_addr: DEFAULT_ADDRESS.to_string(),
             auth: xdr::rpc::auth_unix::default(),
-            vfs: Arc::new(DemoFS { _root: String::default() }),
-            mount_signal: None,
-            export_name: Arc::from(DEFAULT_EXPORT_NAME.to_string()),
+            export_table: create_export_table(),
             transaction_tracker: Arc::new(rpc::TransactionTracker::new(Duration::from_secs(60))),
             portmap_table: Arc::from(RwLock::from(PortmapTable::default())),
         };
@@ -556,23 +591,21 @@ mod tests {
         let args = multiple_mappings(amount, IPPROTO_UDP);
 
         for arg in &args {
-            call_assert(send_set_port, &mut context, &mut input, &mut output, *arg, true);
+            call_assert!(send_set_port, &mut context, &mut input, &mut output, *arg, true, bool);
         }
 
         for arg in args {
-            call_assert(send_unset_port, &mut context, &mut input, &mut output, arg, true);
+            call_assert!(send_unset_port, &mut context, &mut input, &mut output, arg, true, bool);
         }
     }
 
     ///test of UNSET, when both protocols (TCP or UDP) are mapped
-    fn unset_both_protocols(amount: u32) {
+    async fn unset_both_protocols(amount: u32) {
         let mut context = Context {
             local_port: DEFAULT_PORT,
             client_addr: DEFAULT_ADDRESS.to_string(),
             auth: xdr::rpc::auth_unix::default(),
-            vfs: Arc::new(DemoFS { _root: String::default() }),
-            mount_signal: None,
-            export_name: Arc::from(DEFAULT_EXPORT_NAME.to_string()),
+            export_table: create_export_table(),
             transaction_tracker: Arc::new(rpc::TransactionTracker::new(Duration::from_secs(60))),
             portmap_table: Arc::from(RwLock::from(PortmapTable::default())),
         };
@@ -583,23 +616,39 @@ mod tests {
         let args_tcp = multiple_mappings(amount, IPPROTO_TCP);
 
         for arg in &args_udp {
-            call_assert(send_set_port, &mut context, &mut input, &mut output, *arg, true);
+            call_assert!(send_set_port, &mut context, &mut input, &mut output, *arg, true, bool);
         }
 
         for arg in &args_tcp {
-            call_assert(send_set_port, &mut context, &mut input, &mut output, *arg, true);
+            call_assert!(send_set_port, &mut context, &mut input, &mut output, *arg, true, bool);
         }
 
         for mapping in args_tcp {
-            call_assert(send_unset_port, &mut context, &mut input, &mut output, mapping, true);
+            call_assert!(
+                send_unset_port,
+                &mut context,
+                &mut input,
+                &mut output,
+                mapping,
+                true,
+                bool
+            );
         }
         for mapping in args_udp {
-            call_assert(send_unset_port, &mut context, &mut input, &mut output, mapping, false);
+            call_assert!(
+                send_unset_port,
+                &mut context,
+                &mut input,
+                &mut output,
+                mapping,
+                false,
+                bool
+            );
         }
     }
 
     ///test of UNSET, where requests are sent from different threads
-    fn unset_several_threads(amount_threads: usize) {
+    async fn unset_several_threads(amount_threads: usize) {
         let context = multiple_contexts(amount_threads as u32);
         let mapping_tcp = multiple_mappings(amount_threads as u32, IPPROTO_TCP);
         let mapping_udp = multiple_mappings(amount_threads as u32, IPPROTO_UDP);
@@ -612,48 +661,53 @@ mod tests {
 
         std::thread::scope(|scope| {
             for (mut context, mappings_1, mappings_2) in set_for_thread {
-                scope.spawn(move || {
+                scope.spawn(async move || {
                     let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
                     let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
-                    call_assert(
+                    call_assert!(
                         send_unset_port,
                         &mut context,
                         &mut input,
                         &mut output,
                         mappings_2,
                         false,
+                        bool
                     );
-                    call_assert(
+                    call_assert!(
                         send_set_port,
                         &mut context,
                         &mut input,
                         &mut output,
                         mappings_2,
                         true,
+                        bool
                     );
-                    call_assert(
+                    call_assert!(
                         send_set_port,
                         &mut context,
                         &mut input,
                         &mut output,
                         mappings_1,
                         true,
+                        bool
                     );
-                    call_assert(
+                    call_assert!(
                         send_unset_port,
                         &mut context,
                         &mut input,
                         &mut output,
                         mappings_1,
                         true,
+                        bool
                     );
-                    call_assert(
+                    call_assert!(
                         send_unset_port,
                         &mut context,
                         &mut input,
                         &mut output,
                         mappings_2,
                         false,
+                        bool
                     );
                 });
             }
@@ -661,37 +715,44 @@ mod tests {
         let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
         let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
         for mapping in mapping_udp {
-            call_assert(
+            call_assert!(
                 send_get_port,
                 &mut context[0].clone(),
                 &mut input,
                 &mut output,
                 mapping,
                 0,
+                u32
             );
         }
     }
 
     ///test of simple dump in single thread
-    fn dump_one_thread(entries_amount: u32) {
+    async fn dump_one_thread(entries_amount: u32) {
         let mappings = multiple_mappings(entries_amount, IPPROTO_TCP);
         let mut context = Context {
             local_port: DEFAULT_PORT,
             client_addr: DEFAULT_ADDRESS.to_string(),
             auth: xdr::rpc::auth_unix::default(),
-            vfs: Arc::new(DemoFS { _root: String::default() }),
-            mount_signal: None,
-            export_name: Arc::from(DEFAULT_EXPORT_NAME.to_string()),
+            export_table: create_export_table(),
             transaction_tracker: Arc::new(rpc::TransactionTracker::new(Duration::from_secs(60))),
             portmap_table: Arc::from(RwLock::from(PortmapTable::default())),
         };
         let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
         let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
         for mapping in &mappings {
-            call_assert(send_set_port, &mut context, &mut input, &mut output, *mapping, true);
+            call_assert!(
+                send_set_port,
+                &mut context,
+                &mut input,
+                &mut output,
+                *mapping,
+                true,
+                bool
+            );
         }
         output.set_position(0);
-        send_dump(&mut context, &mut input, &mut output).unwrap();
+        send_dump(&mut context, &mut input, &mut output).await.unwrap();
 
         output.set_position(RPC_MSG_SIZE);
         let mut result = &deserialize::<Option<pmaplist>>(&mut output).unwrap();
@@ -715,20 +776,28 @@ mod tests {
     }
 
     ///test of dump from several threads
-    fn dump_multi_thread(amount_threads: usize) {
+    async fn dump_multi_thread(amount_threads: usize) {
         let mut contexts = multiple_contexts(amount_threads as u32);
         let mappings = &multiple_mappings(amount_threads as u32, IPPROTO_TCP);
         let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
         let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
         for mapping in mappings {
-            call_assert(send_set_port, &mut contexts[0], &mut input, &mut output, *mapping, true);
+            call_assert!(
+                send_set_port,
+                &mut contexts[0],
+                &mut input,
+                &mut output,
+                *mapping,
+                true,
+                bool
+            );
         }
         std::thread::scope(|scope| {
             for context in &mut contexts {
-                scope.spawn(|| {
+                scope.spawn(async || {
                     let mut input = Cursor::new(Vec::with_capacity(INPUT_SIZE));
                     let mut output = Cursor::new(Vec::with_capacity(OUTPUT_SIZE));
-                    send_dump(context, &mut input, &mut output).unwrap();
+                    send_dump(context, &mut input, &mut output).await.unwrap();
                     output.set_position(RPC_MSG_SIZE);
                     let mut result = &deserialize::<Option<pmaplist>>(&mut output).unwrap();
                     let mut amount = 0;
@@ -752,67 +821,68 @@ mod tests {
         })
     }
 
-    #[test]
-    fn get_port_zero_reply_multiple() {
-        get_port_zero_reply(0);
-        get_port_zero_reply(u16::MAX);
+    #[tokio::test]
+    async fn get_port_zero_reply_multiple() {
+        get_port_zero_reply(0).await;
+        get_port_zero_reply(u16::MAX).await;
     }
 
-    #[test]
-    fn set_port_ok_reply_multiple() {
-        set_port_ok_reply(0);
-        set_port_ok_reply(u16::MAX);
+    #[tokio::test]
+    async fn set_port_ok_reply_multiple() {
+        set_port_ok_reply(0).await;
+        set_port_ok_reply(u16::MAX).await;
     }
-    #[test]
+    #[tokio::test]
 
-    fn get_port_ok_reply_multiple() {
-        get_port_ok_reply(0);
-        get_port_ok_reply(u16::MAX);
+    async fn get_port_ok_reply_multiple() {
+        get_port_ok_reply(0).await;
+        get_port_ok_reply(u16::MAX).await;
     }
-    #[test]
-    fn multiple_gets_after_sets() {
-        set_and_get_multiple(0);
-        set_and_get_multiple(789);
+    #[tokio::test]
+    async fn multiple_gets_after_sets() {
+        set_and_get_multiple(0).await;
+        set_and_get_multiple(789).await;
     }
-    #[test]
-    fn multi_threads_gets_sets() {
-        multi_thread_get_set(0);
-        multi_thread_get_set(100);
-    }
-
-    #[test]
-    fn dump_single_thread() {
-        dump_one_thread(0);
-        dump_one_thread(200);
+    #[tokio::test]
+    async fn multi_threads_gets_sets() {
+        multi_thread_get_set(0).await;
+        multi_thread_get_set(100).await;
     }
 
-    #[test]
-    fn multi_thread_dump() {
-        dump_multi_thread(0);
-        dump_multi_thread(1);
-        dump_multi_thread(100);
-    }
-    #[test]
-    fn empty_unsets() {
-        unset_empty_table(0);
-        unset_empty_table(200);
+    #[tokio::test]
+    async fn empty_unsets() {
+        unset_empty_table(0).await;
+        unset_empty_table(200).await;
     }
 
-    #[test]
-    fn unset_one_protocol_entry() {
-        unset_single_protocol(0);
-        unset_single_protocol(200);
+    #[tokio::test]
+    async fn dump_single_thread() {
+        dump_one_thread(0).await;
+        dump_one_thread(200).await;
     }
 
-    #[test]
-    fn unset_two_protocol_entry() {
-        unset_both_protocols(0);
-        unset_both_protocols(200);
+    #[tokio::test]
+    async fn multi_thread_dump() {
+        dump_multi_thread(0).await;
+        dump_multi_thread(1).await;
+        dump_multi_thread(100).await;
     }
 
-    #[test]
-    fn multi_thread_unset() {
-        unset_several_threads(0);
-        unset_several_threads(100);
+    #[tokio::test]
+    async fn unset_one_protocol_entry() {
+        unset_single_protocol(0).await;
+        unset_single_protocol(200).await;
+    }
+
+    #[tokio::test]
+    async fn unset_two_protocol_entry() {
+        unset_both_protocols(0).await;
+        unset_both_protocols(200).await;
+    }
+
+    #[tokio::test]
+    async fn multi_thread_unset() {
+        unset_several_threads(0).await;
+        unset_several_threads(100).await;
     }
 }


### PR DESCRIPTION
- Add exprort table to the NFSTcpListner
- Update Mount and NFSv3 protocols implementation accordingly
- Add example with multiple FSs

Resolves: https://github.com/RMamonts/nfs-mamont/issues/27

Old PR: https://github.com/RMamonts/nfs-mamont/pull/29

Known problems:

- Copy-paste and possible simplification of code - would be done right after this PR because it requires abstracting out reply construction which in turn requires adding missing reply types