### PR TITLE
RPC: improve transaction tracker performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +201,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "intaglio"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +294,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "byteorder",
+ "dashmap",
  "filetime",
  "futures",
  "intaglio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 [dependencies]
 async-trait = "0.1.9"
 byteorder = "1.5"
+dashmap = "6.1.0"
 filetime = "0.2"
 futures = "0.3.31"
 num-derive = "0.4"

--- a/src/protocol/rpc/transaction_tracker.rs
+++ b/src/protocol/rpc/transaction_tracker.rs
@@ -13,9 +13,11 @@
 //! semantics required by NFS and other RPC-based protocols, where duplicate
 //! operations (like file writes) could cause data corruption.
 
-use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::atomic::AtomicU64;
 use std::time::{Duration, SystemTime};
+
+use dashmap::DashMap;
+use tracing::info;
 
 /// Tracks RPC transactions to detect and handle retransmissions
 ///
@@ -25,7 +27,11 @@ use std::time::{Duration, SystemTime};
 /// and maintains transaction state for a configurable retention period.
 pub struct TransactionTracker {
     retention_period: Duration,
-    transactions: Mutex<HashMap<(u32, String), TransactionState>>,
+    transactions: DashMap<(u32, String), TransactionState>,
+    /// Counter to track operations for periodic cleanup
+    operation_count: AtomicU64,
+    /// How often to run cleanup (every N operations)
+    cleanup_threshold: u64,
 }
 
 impl TransactionTracker {
@@ -35,7 +41,12 @@ impl TransactionTracker {
     /// for the given duration. This helps balance memory usage with the ability
     /// to detect retransmissions over time.
     pub fn new(retention_period: Duration) -> Self {
-        Self { retention_period, transactions: Mutex::new(HashMap::new()) }
+        Self {
+            retention_period,
+            transactions: DashMap::new(),
+            operation_count: AtomicU64::new(0),
+            cleanup_threshold: 10_000, // Run cleanup every 1000 operations
+        }
     }
 
     /// Checks if a transaction is a retransmission
@@ -43,17 +54,32 @@ impl TransactionTracker {
     /// Identifies whether the transaction with given XID and client address
     /// has been seen before. If it's a new transaction, marks it as in-progress.
     /// Returns true for retransmissions, false for new transactions.
+    ///
+    /// Optimized to minimize locking and reduce overhead on the hot path.
     pub fn is_retransmission(&self, xid: u32, client_addr: &str) -> bool {
-        let key = (xid, client_addr.to_string());
-        let mut transactions =
-            self.transactions.lock().expect("unable to unlock transactions mutex");
-        housekeeping(&mut transactions, self.retention_period);
-        if let std::collections::hash_map::Entry::Vacant(e) = transactions.entry(key) {
-            e.insert(TransactionState::InProgress);
-            false
-        } else {
-            true
+        // Fast path: check if transaction already exists without acquiring lock
+        if self.transactions.contains_key(&(xid, client_addr.to_string())) {
+            return true;
         }
+
+        // Increment operation count and check if cleanup is needed
+        let should_cleanup = {
+            let count = self.operation_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            info!("should_cleanup: count {}", count);
+            count % self.cleanup_threshold == 0
+        };
+
+        // Perform cleanup periodically to avoid accumulation
+        if should_cleanup {
+            housekeeping(&self.transactions, self.retention_period);
+
+            // TODO: reset self.operation_count
+        }
+
+        // Insert new transaction
+        self.transactions.insert((xid, client_addr.to_string()), TransactionState::InProgress);
+
+        false
     }
 
     /// Marks a transaction as successfully processed
@@ -64,9 +90,7 @@ impl TransactionTracker {
     pub fn mark_processed(&self, xid: u32, client_addr: &str) {
         let key = (xid, client_addr.to_string());
         let completion_time = SystemTime::now();
-        let mut transactions =
-            self.transactions.lock().expect("unable to unlock transactions mutex");
-        if let Some(tx) = transactions.get_mut(&key) {
+        if let Some(mut tx) = self.transactions.get_mut(&key) {
             *tx = TransactionState::Completed(completion_time);
         }
     }
@@ -77,7 +101,7 @@ impl TransactionTracker {
 /// Cleans up completed transactions that have exceeded the maximum retention age.
 /// Keeps in-progress transactions regardless of age to prevent processing duplicates.
 /// Called during transaction checks to maintain memory efficiency.
-fn housekeeping(transactions: &mut HashMap<(u32, String), TransactionState>, max_age: Duration) {
+fn housekeeping(transactions: &DashMap<(u32, String), TransactionState>, max_age: Duration) {
     let mut cutoff = SystemTime::now() - max_age;
     transactions.retain(|_, v| match v {
         TransactionState::InProgress => true,


### PR DESCRIPTION
Improved transaction tracker performance. It is not best solution, so PR for time will be draft

About speed(on my laptop):
- was ~10 MB/S
- now with log level `INFO` ~150 MB/S

Resolves #97