### PR TITLE
Reduce number of tokio task to process socket 

### DIFF
--- a/src/protocol/rpc/command_queue.rs
+++ b/src/protocol/rpc/command_queue.rs
@@ -12,51 +12,9 @@ use tracing::{debug, error, trace};
 
 use crate::protocol::rpc;
 use crate::protocol::rpc::Context;
-use crate::tcp::RpcCommand;
+use crate::tcp::{CommandResult, ResponseBuffer, RpcCommand};
 
-/// Represents a response buffer that minimizes data copying
-pub struct ResponseBuffer {
-    /// Internal buffer for writing data
-    buffer: Vec<u8>,
-    /// Indicates that the buffer contains data to send
-    has_content: bool,
-}
 
-impl ResponseBuffer {
-    /// Creates a new response buffer with pre-allocated capacity
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self { buffer: Vec::with_capacity(capacity), has_content: false }
-    }
-
-    /// Gets the internal buffer for writing
-    pub fn get_mut_buffer(&mut self) -> &mut Vec<u8> {
-        &mut self.buffer
-    }
-
-    /// Marks the buffer as containing data to send
-    pub fn mark_has_content(&mut self) {
-        self.has_content = true;
-    }
-
-    /// Checks if the buffer contains data to send
-    pub fn has_content(&self) -> bool {
-        self.has_content
-    }
-
-    /// Takes the internal buffer, consuming the structure
-    pub fn into_inner(self) -> Vec<u8> {
-        self.buffer
-    }
-
-    /// Clears the buffer for reuse
-    pub fn clear(&mut self) {
-        self.buffer.clear();
-        self.has_content = false;
-    }
-}
-
-/// Command processing result
-pub type CommandResult = Result<Option<ResponseBuffer>, io::Error>;
 
 /// Type for asynchronous RPC command processor
 pub type AsyncCommandProcessor = for<'a> fn(

--- a/src/protocol/rpc/command_queue.rs
+++ b/src/protocol/rpc/command_queue.rs
@@ -5,16 +5,11 @@
 //! necessary for proper NFS protocol operation.
 
 use std::io;
-use tokio::io::{AsyncReadExt, ReadHalf};
-use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tracing::{debug, error, trace};
 
 use crate::protocol::rpc;
-use crate::protocol::rpc::Context;
 use crate::tcp::{CommandResult, ResponseBuffer, RpcCommand};
-
-
 
 /// Type for asynchronous RPC command processor
 pub type AsyncCommandProcessor = for<'a> fn(

--- a/src/protocol/rpc/command_queue.rs
+++ b/src/protocol/rpc/command_queue.rs
@@ -5,11 +5,14 @@
 //! necessary for proper NFS protocol operation.
 
 use std::io;
-
+use tokio::io::{AsyncReadExt, ReadHalf};
+use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tracing::{debug, error, trace};
 
 use crate::protocol::rpc;
+use crate::protocol::rpc::Context;
+use crate::tcp::RpcCommand;
 
 /// Represents a response buffer that minimizes data copying
 pub struct ResponseBuffer {
@@ -50,15 +53,6 @@ impl ResponseBuffer {
         self.buffer.clear();
         self.has_content = false;
     }
-}
-
-/// RPC command type with context
-#[derive(Debug)]
-pub struct RpcCommand {
-    /// RPC message data
-    pub data: Vec<u8>,
-    /// Context associated with this command
-    pub context: rpc::Context,
 }
 
 /// Command processing result

--- a/src/protocol/rpc/command_queue.rs
+++ b/src/protocol/rpc/command_queue.rs
@@ -155,7 +155,7 @@ impl CommandQueue {
     ///
     /// `true` if command was successfully submitted,
     /// `false` if submission failed (e.g. if queue was closed)
-    pub fn submit_command(&self, data: Vec<u8>, context: rpc::Context) -> bool {
-        self.command_sender.send(RpcCommand { data, context }).is_ok()
+    pub fn submit_command(&self, command: RpcCommand) -> bool {
+        self.command_sender.send(command).is_ok()
     }
 }

--- a/src/protocol/rpc/mod.rs
+++ b/src/protocol/rpc/mod.rs
@@ -31,4 +31,4 @@ mod wire;
 
 pub use context::Context;
 pub use transaction_tracker::TransactionTracker;
-pub use wire::{write_fragment, SocketMessageHandler};
+pub use wire::SocketMessageHandler;

--- a/src/protocol/rpc/wire.rs
+++ b/src/protocol/rpc/wire.rs
@@ -21,17 +21,13 @@ use std::io;
 use std::io::Cursor;
 use std::io::{Read, Write};
 
-use tokio::io::AsyncReadExt;
-use tokio::io::AsyncWriteExt;
-use tokio::io::{ReadHalf, SimplexStream, WriteHalf};
-use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tracing::{debug, error, trace, warn};
 
-use crate::protocol::rpc::command_queue::{CommandQueue};
+use crate::protocol::rpc::command_queue::CommandQueue;
 use crate::protocol::xdr::{self, deserialize, mount, nfs3, portmap, Serialize};
 use crate::protocol::{nfs, rpc};
-use crate::tcp::{CommandResult, ResponseBuffer, RpcCommand};
+use crate::tcp::{CommandResult, ResponseBuffer};
 use crate::utils::error::io_other;
 
 // Information from RFC 5531 (ONC RPC v2)
@@ -139,7 +135,6 @@ pub async fn handle_rpc(
     }
 }
 
-
 /// Handles RPC message processing over a TCP connection
 ///
 /// Receives record-marked RPC messages from a TCP stream, processes
@@ -162,20 +157,14 @@ impl SocketMessageHandler {
     /// This setup enables asynchronous processing of RPC messages while maintaining
     /// order of operations.
     pub fn new() -> (Self, mpsc::UnboundedReceiver<CommandResult>) {
-
         // Create separate channel for command results
-        let (result_sender, mut result_receiver) = mpsc::unbounded_channel::<CommandResult>();
+        let (result_sender, result_receiver) = mpsc::unbounded_channel::<CommandResult>();
 
         // Create command queue with our RPC processing function
         let command_queue =
             CommandQueue::new(process_rpc_command, result_sender, DEFAULT_RESPONSE_BUFFER_CAPACITY);
 
-        (
-            Self {
-                command_queue,
-            },
-            result_receiver,
-        )
+        (Self { command_queue }, result_receiver)
     }
 }
 

--- a/src/protocol/rpc/wire.rs
+++ b/src/protocol/rpc/wire.rs
@@ -194,12 +194,6 @@ pub type SocketMessageType = io::Result<Vec<u8>>;
 /// for reliable message delimitation over TCP.
 #[derive(Debug)]
 pub struct SocketMessageHandler {
-    /// Buffer for current fragment
-    cur_fragment: Vec<u8>,
-    /// Channel for receiving data from socket
-    socket_receive_channel: ReadHalf<SimplexStream>,
-    /// RPC context for request processing
-    context: rpc::Context,
     /// Command queue for ordered processing
     pub command_queue: CommandQueue,
 }
@@ -213,10 +207,7 @@ impl SocketMessageHandler {
     ///
     /// This setup enables asynchronous processing of RPC messages while maintaining
     /// order of operations.
-    pub fn new(
-        context: &rpc::Context,
-    ) -> (Self, WriteHalf<SimplexStream>, mpsc::UnboundedReceiver<SocketMessageType>) {
-        let (sockrecv, socksend) = tokio::io::simplex(256_000);
+    pub fn new() -> (Self, mpsc::UnboundedReceiver<SocketMessageType>) {
         let (msgsend, msgrecv) = mpsc::unbounded_channel();
 
         // Create separate channel for command results
@@ -250,12 +241,8 @@ impl SocketMessageHandler {
 
         (
             Self {
-                cur_fragment: Vec::new(),
-                socket_receive_channel: sockrecv,
-                context: context.clone(),
                 command_queue,
             },
-            socksend,
             msgrecv,
         )
     }

--- a/src/protocol/rpc/wire.rs
+++ b/src/protocol/rpc/wire.rs
@@ -201,7 +201,7 @@ pub struct SocketMessageHandler {
     /// RPC context for request processing
     context: rpc::Context,
     /// Command queue for ordered processing
-    command_queue: CommandQueue,
+    pub command_queue: CommandQueue,
 }
 
 impl SocketMessageHandler {

--- a/src/protocol/rpc/wire.rs
+++ b/src/protocol/rpc/wire.rs
@@ -31,6 +31,7 @@ use tracing::{debug, error, trace, warn};
 use crate::protocol::rpc::command_queue::{CommandQueue, CommandResult, ResponseBuffer};
 use crate::protocol::xdr::{self, deserialize, mount, nfs3, portmap, Serialize};
 use crate::protocol::{nfs, rpc};
+use crate::tcp::RpcCommand;
 use crate::utils::error::io_other;
 
 // Information from RFC 5531 (ONC RPC v2)
@@ -136,37 +137,6 @@ pub async fn handle_rpc(
         error!("Unexpectedly received a Reply instead of a Call");
         io_other("Bad RPC Call format")
     }
-}
-
-/// Reads a single record-marked fragment from a stream
-///
-/// Implements the RFC 5531 (previously RFC 1057 section 10) Record Marking Standard for TCP transport.
-/// The record marking standard addresses the problem of delimiting records in a
-/// stream protocol like TCP by prefixing each record with a 4-byte header.
-///
-/// This function:
-/// 1. Reads the 4-byte header from the socket
-/// 2. Extracts the fragment length (lower 31 bits) and last-fragment flag (highest bit)
-/// 3. Reads exactly that many bytes from the socket
-/// 4. Appends the read data to the provided buffer
-///
-/// Returns true if this was the last fragment in the RPC record, false otherwise.
-/// This allows for reassembly of multi-fragment RPC messages.
-async fn read_fragment(
-    socket: &mut ReadHalf<SimplexStream>,
-    append_to: &mut Vec<u8>,
-) -> io::Result<bool> {
-    let mut header_buf = [0_u8; 4];
-    socket.read_exact(&mut header_buf).await?;
-    let fragment_header = u32::from_be_bytes(header_buf);
-    let is_last = (fragment_header & (1 << 31)) > 0;
-    let length = (fragment_header & ((1 << 31) - 1)) as usize;
-    trace!("Reading fragment length:{}, last:{}", length, is_last);
-    let start_offset = append_to.len();
-    append_to.resize(append_to.len() + length, 0);
-    socket.read_exact(&mut append_to[start_offset..]).await?;
-    trace!("Finishing Reading fragment length:{}, last:{}", length, is_last);
-    Ok(is_last)
 }
 
 /// Writes data as record-marked fragments to a TCP stream
@@ -288,29 +258,6 @@ impl SocketMessageHandler {
             socksend,
             msgrecv,
         )
-    }
-
-    /// Reads and processes a fragment from the socket
-    ///
-    /// Reads a single record-marked fragment from the socket and appends it to
-    /// the current message buffer. If the fragment is the last one in the record,
-    /// submits a command to the queue for processing in order.
-    /// Should be called in a loop to continuously process incoming messages.
-    pub async fn read(&mut self) -> io::Result<()> {
-        let is_last =
-            read_fragment(&mut self.socket_receive_channel, &mut self.cur_fragment).await?;
-        if is_last {
-            // Take buffer and create new one for next fragment
-            let fragment_data = std::mem::take(&mut self.cur_fragment);
-            let context = self.context.clone();
-
-            // Submit command to queue for ordered processing
-            if !self.command_queue.submit_command(fragment_data, context) {
-                error!("Failed to submit command to queue");
-                return io_other("Command queue error");
-            }
-        }
-        Ok(())
     }
 }
 

--- a/src/protocol/rpc/wire.rs
+++ b/src/protocol/rpc/wire.rs
@@ -28,10 +28,10 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tracing::{debug, error, trace, warn};
 
-use crate::protocol::rpc::command_queue::{CommandQueue, CommandResult, ResponseBuffer};
+use crate::protocol::rpc::command_queue::{CommandQueue};
 use crate::protocol::xdr::{self, deserialize, mount, nfs3, portmap, Serialize};
 use crate::protocol::{nfs, rpc};
-use crate::tcp::RpcCommand;
+use crate::tcp::{CommandResult, ResponseBuffer, RpcCommand};
 use crate::utils::error::io_other;
 
 // Information from RFC 5531 (ONC RPC v2)
@@ -139,52 +139,6 @@ pub async fn handle_rpc(
     }
 }
 
-/// Writes data as record-marked fragments to a TCP stream
-///
-/// Implements the RFC 5531 (previously RFC 1057 section 10) Record Marking Standard for TCP transport.
-/// This standard enables RPC to utilize TCP as a transport while maintaining proper
-/// message boundaries essential for RPC semantics.
-///
-/// The function:
-/// 1. Divides large buffers into manageable fragments (maximum 2GB each)
-/// 2. Prefixes each fragment with a 4-byte header
-///    - The lower 31 bits contain the fragment length
-///    - The highest bit indicates if this is the last fragment (1=last, 0=more)
-/// 3. Writes both header and data to the socket
-///
-/// This ensures reliable transmission of RPC messages over TCP with proper
-/// message framing and enables receivers to allocate appropriate buffer space.
-pub async fn write_fragment(write_half: &mut WriteHalf<TcpStream>, buf: &[u8]) -> io::Result<()> {
-    // Maximum fragment size is 2^31 - 1 bytes
-    const MAX_FRAGMENT_SIZE: usize = (1 << 31) - 1;
-
-    let mut offset = 0;
-    while offset < buf.len() {
-        // Calculate the size of this fragment
-        let remaining = buf.len() - offset;
-        let fragment_size = std::cmp::min(remaining, MAX_FRAGMENT_SIZE);
-
-        // Determine if this is the last fragment
-        let is_last = offset + fragment_size >= buf.len();
-
-        // Create the fragment header
-        // The highest bit indicates if this is the last fragment
-        let fragment_header =
-            if is_last { fragment_size as u32 + (1 << 31) } else { fragment_size as u32 };
-
-        let header_buf = u32::to_be_bytes(fragment_header);
-        write_half.write_all(&header_buf).await?;
-
-        trace!("Writing fragment length:{}, last:{}", fragment_size, is_last);
-        write_half.write_all(&buf[offset..offset + fragment_size]).await?;
-
-        offset += fragment_size;
-    }
-
-    Ok(())
-}
-
-pub type SocketMessageType = io::Result<Vec<u8>>;
 
 /// Handles RPC message processing over a TCP connection
 ///
@@ -207,8 +161,7 @@ impl SocketMessageHandler {
     ///
     /// This setup enables asynchronous processing of RPC messages while maintaining
     /// order of operations.
-    pub fn new() -> (Self, mpsc::UnboundedReceiver<SocketMessageType>) {
-        let (msgsend, msgrecv) = mpsc::unbounded_channel();
+    pub fn new() -> (Self, mpsc::UnboundedReceiver<CommandResult>) {
 
         // Create separate channel for command results
         let (result_sender, mut result_receiver) = mpsc::unbounded_channel::<CommandResult>();
@@ -217,33 +170,11 @@ impl SocketMessageHandler {
         let command_queue =
             CommandQueue::new(process_rpc_command, result_sender, DEFAULT_RESPONSE_BUFFER_CAPACITY);
 
-        // Process results from command queue and send them to socket
-        tokio::spawn(async move {
-            while let Some(result) = result_receiver.recv().await {
-                match result {
-                    Ok(Some(response_buffer)) if response_buffer.has_content() => {
-                        let _ = msgsend.send(Ok(response_buffer.into_inner()));
-                    }
-                    Ok(None) => {
-                        // No response needed, so nothing to send
-                    }
-                    Ok(Some(_)) => {
-                        // Buffer exists but contains no data to send
-                    }
-                    Err(e) => {
-                        error!("RPC error: {:?}", e);
-                        let _ = msgsend.send(Err(e));
-                    }
-                }
-            }
-            debug!("Command result handler finished");
-        });
-
         (
             Self {
                 command_queue,
             },
-            msgrecv,
+            result_receiver,
         )
     }
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -25,6 +25,7 @@ use tracing::{debug, error, info, trace};
 use crate::protocol::nfs::portmap::PortmapTable;
 use crate::protocol::rpc::Context;
 use crate::protocol::{rpc, xdr};
+use crate::utils::error::io_other;
 use crate::vfs::NFSFileSystem;
 
 /// Default transaction retention period
@@ -116,32 +117,27 @@ async fn process_socket(socket: TcpStream, context: Context) {
     let (mut message_handler, mut socksend, mut msgrecvchan) =
         rpc::SocketMessageHandler::new(&context);
 
-    tokio::spawn(async move {
-        loop {
-            if let Err(e) = message_handler.read().await {
-                debug!("Message loop broken due to {:?}", e);
-                break;
-            }
-        }
-    });
-
     let (mut readhalf, mut writehalf) = tokio::io::split(socket);
 
     tokio::spawn(async move {
-        let mut buf = [0; 128000];
-        loop {
-            match readhalf.read(&mut buf).await {
-                Ok(0) => return Ok(()),
-                Ok(n) => {
-                    let _ = socksend.write_all(&buf[..n]).await;
-                }
-                Err(e) => {
-                    debug!("Message handling closed : {:?}", e);
-                    return Err(e);
+            loop {
+                let mut command = RpcCommand { data: Vec::new(), context: context.clone() };
+                match command.read_command_from_socket(&mut readhalf).await {
+                    Ok(()) => {
+                        //here some processing - actually sending to processing rpc task
+                        if !message_handler.command_queue.submit_command(command) {
+                            error!("Failed to submit command to queue");
+                            return io_other("Command queue error");
+                        }
+                    },
+                    Err(e) => {
+                        error!("Message loop broken due to {:?}", e);
+                        return io_other("Socket reading error");
+                    }
                 }
             }
-        }
     });
+
 
     tokio::spawn(async move {
         while let Some(reply) = msgrecvchan.recv().await {

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -11,7 +11,6 @@
 use async_trait::async_trait;
 use dashmap::DashMap;
 use std::collections::HashSet;
-use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -140,7 +139,10 @@ impl ResponseBuffer {
         self.buffer.clear();
         self.has_content = false;
     }
-    pub async fn write_fragment(&mut self, write_half: &mut WriteHalf<TcpStream>) -> io::Result<()> {
+    pub async fn write_fragment(
+        &mut self,
+        write_half: &mut WriteHalf<TcpStream>,
+    ) -> io::Result<()> {
         // Maximum fragment size is 2^31 - 1 bytes
         const MAX_FRAGMENT_SIZE: usize = (1 << 31) - 1;
 
@@ -169,8 +171,6 @@ impl ResponseBuffer {
 
         Ok(())
     }
-
-
 }
 
 /// Command processing result
@@ -189,30 +189,28 @@ pub type CommandResult = Result<Option<ResponseBuffer>, io::Error>;
 /// * `socket` - The established TCP connection to the client
 /// * `context` - RPC context containing server state and client information
 async fn process_socket(socket: TcpStream, context: Context) {
-    let (mut message_handler, mut msgrecvchan) =
-        rpc::SocketMessageHandler::new();
+    let (message_handler, mut msgrecvchan) = rpc::SocketMessageHandler::new();
 
     let (mut readhalf, mut writehalf) = tokio::io::split(socket);
 
     tokio::spawn(async move {
-            loop {
-                let mut command = RpcCommand { data: Vec::new(), context: context.clone() };
-                match command.read_command_from_socket(&mut readhalf).await {
-                    Ok(()) => {
-                        //here some processing - actually sending to processing rpc task
-                        if !message_handler.command_queue.submit_command(command) {
-                            error!("Failed to submit command to queue");
-                            return io_other("Command queue error");
-                        }
-                    },
-                    Err(e) => {
-                        error!("Message loop broken due to {:?}", e);
-                        return io_other("Socket reading error");
+        loop {
+            let mut command = RpcCommand { data: Vec::new(), context: context.clone() };
+            match command.read_command_from_socket(&mut readhalf).await {
+                Ok(()) => {
+                    //here some processing - actually sending to processing rpc task
+                    if !message_handler.command_queue.submit_command(command) {
+                        error!("Failed to submit command to queue");
+                        return io_other::<(), &str>("Command queue error");
                     }
                 }
+                Err(e) => {
+                    error!("Message loop broken due to {:?}", e);
+                    return Err(e);
+                }
             }
+        }
     });
-
 
     tokio::spawn(async move {
         while let Some(result) = msgrecvchan.recv().await {

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -114,8 +114,8 @@ impl RpcCommand {
 /// * `socket` - The established TCP connection to the client
 /// * `context` - RPC context containing server state and client information
 async fn process_socket(socket: TcpStream, context: Context) {
-    let (mut message_handler, mut socksend, mut msgrecvchan) =
-        rpc::SocketMessageHandler::new(&context);
+    let (mut message_handler, mut msgrecvchan) =
+        rpc::SocketMessageHandler::new();
 
     let (mut readhalf, mut writehalf) = tokio::io::split(socket);
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -11,17 +11,19 @@
 use async_trait::async_trait;
 use dashmap::DashMap;
 use std::collections::HashSet;
+use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{io, net::IpAddr};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf};
+use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, RwLock};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 use crate::protocol::nfs::portmap::PortmapTable;
+use crate::protocol::rpc::Context;
 use crate::protocol::{rpc, xdr};
 use crate::vfs::NFSFileSystem;
 
@@ -67,6 +69,37 @@ pub fn generate_host_ip(hostnum: u16) -> String {
     format!("127.88.{}.{}", ((hostnum >> 8) & 0xFF) as u8, (hostnum & 0xFF) as u8)
 }
 
+/// RPC command type with context
+#[derive(Debug)]
+pub struct RpcCommand {
+    /// RPC message data
+    pub data: Vec<u8>,
+    /// Context associated with this command
+    pub context: Context,
+}
+
+impl RpcCommand {
+    pub async fn read_command_from_socket(
+        &mut self,
+        socket: &mut ReadHalf<TcpStream>,
+    ) -> io::Result<()> {
+        let mut is_last = true;
+        let mut header_buf = [0_u8; 4];
+        while !is_last {
+            socket.read_exact(&mut header_buf).await?;
+            let fragment_header = u32::from_be_bytes(header_buf);
+            is_last = (fragment_header & (1 << 31)) > 0;
+            let length = (fragment_header & ((1 << 31) - 1)) as usize;
+            trace!("Reading fragment length:{}, last:{}", length, is_last);
+            let start_offset = self.data.len();
+            self.data.resize(self.data.len() + length, 0);
+            socket.read_exact(&mut self.data[start_offset..]).await?;
+            trace!("Finishing Reading fragment length:{}, last:{}", length, is_last);
+        }
+        Ok(())
+    }
+}
+
 /// Processes an established TCP socket connection from an NFS client
 ///
 /// This function:
@@ -79,7 +112,7 @@ pub fn generate_host_ip(hostnum: u16) -> String {
 ///
 /// * `socket` - The established TCP connection to the client
 /// * `context` - RPC context containing server state and client information
-async fn process_socket(socket: tokio::net::TcpStream, context: rpc::Context) {
+async fn process_socket(socket: TcpStream, context: Context) {
     let (mut message_handler, mut socksend, mut msgrecvchan) =
         rpc::SocketMessageHandler::new(&context);
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{io, net::IpAddr};
-use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf, WriteHalf};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, error, info, trace};
@@ -101,6 +101,81 @@ impl RpcCommand {
     }
 }
 
+/// Represents a response buffer that minimizes data copying
+pub struct ResponseBuffer {
+    /// Internal buffer for writing data
+    buffer: Vec<u8>,
+    /// Indicates that the buffer contains data to send
+    has_content: bool,
+}
+
+impl ResponseBuffer {
+    /// Creates a new response buffer with pre-allocated capacity
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self { buffer: Vec::with_capacity(capacity), has_content: false }
+    }
+
+    /// Gets the internal buffer for writing
+    pub fn get_mut_buffer(&mut self) -> &mut Vec<u8> {
+        &mut self.buffer
+    }
+
+    /// Marks the buffer as containing data to send
+    pub fn mark_has_content(&mut self) {
+        self.has_content = true;
+    }
+
+    /// Checks if the buffer contains data to send
+    pub fn has_content(&self) -> bool {
+        self.has_content
+    }
+
+    /// Takes the internal buffer, consuming the structure
+    pub fn into_inner(self) -> Vec<u8> {
+        self.buffer
+    }
+
+    /// Clears the buffer for reuse
+    pub fn clear(&mut self) {
+        self.buffer.clear();
+        self.has_content = false;
+    }
+    pub async fn write_fragment(&mut self, write_half: &mut WriteHalf<TcpStream>) -> io::Result<()> {
+        // Maximum fragment size is 2^31 - 1 bytes
+        const MAX_FRAGMENT_SIZE: usize = (1 << 31) - 1;
+
+        let mut offset = 0;
+        while offset < self.buffer.len() {
+            // Calculate the size of this fragment
+            let remaining = self.buffer.len() - offset;
+            let fragment_size = std::cmp::min(remaining, MAX_FRAGMENT_SIZE);
+
+            // Determine if this is the last fragment
+            let is_last = offset + fragment_size >= self.buffer.len();
+
+            // Create the fragment header
+            // The highest bit indicates if this is the last fragment
+            let fragment_header =
+                if is_last { fragment_size as u32 + (1 << 31) } else { fragment_size as u32 };
+
+            let header_buf = u32::to_be_bytes(fragment_header);
+            write_half.write_all(&header_buf).await?;
+
+            trace!("Writing fragment length:{}, last:{}", fragment_size, is_last);
+            write_half.write_all(&self.buffer[offset..offset + fragment_size]).await?;
+
+            offset += fragment_size;
+        }
+
+        Ok(())
+    }
+
+
+}
+
+/// Command processing result
+pub type CommandResult = Result<Option<ResponseBuffer>, io::Error>;
+
 /// Processes an established TCP socket connection from an NFS client
 ///
 /// This function:
@@ -140,20 +215,26 @@ async fn process_socket(socket: TcpStream, context: Context) {
 
 
     tokio::spawn(async move {
-        while let Some(reply) = msgrecvchan.recv().await {
-            match reply {
+        while let Some(result) = msgrecvchan.recv().await {
+            match result {
+                Ok(Some(mut response_buffer)) if response_buffer.has_content() => {
+                    if let Err(e) = response_buffer.write_fragment(&mut writehalf).await {
+                        error!("Write error {:?}", e);
+                    }
+                }
+                Ok(None) => {
+                    // No response needed, so nothing to send
+                }
+                Ok(Some(_)) => {
+                    // Buffer exists but contains no data to send
+                }
                 Err(e) => {
                     debug!("Message handling closed : {:?}", e);
                     return Err(e);
                 }
-                Ok(msg) => {
-                    if let Err(e) = rpc::write_fragment(&mut writehalf, &msg).await {
-                        error!("Write error {:?}", e);
-                    }
-                }
             }
         }
-        debug!("Channel closed, sending results to socket terminated");
+        debug!("Command result handler finished");
         Ok(())
     });
 }


### PR DESCRIPTION
Current version has spawns a total amount of 5 tasks per single tcp connection, when only one is actually processing PRC-request. So, writing from socket and reading to one take two tasks each: first one to fetch some data from socket (or send to socket) and one to find boundaries of request (by record marking standard). So, it might be a good idea to unite each pair into one, because it would lead to less data transfers between tasks, which cause multiple temporary buffers allocations, and also because it would simplify structure of code. 
So, with this changes there would be totally 3 tasks per connection: one for reading and creating RpcCommand, ready to be processed,  one for processing (and packing result in ResponseBuffer) and one to send it to socket. Also these would require only two pairs of mpsc channels instead of four.
Second pull request resolving #117
