### PR TITLE
MIRROR_FS: change listener binding address from localhost to 0.0.0.0

### DIFF
--- a/examples/mirror_fs/main.rs
+++ b/examples/mirror_fs/main.rs
@@ -26,7 +26,7 @@ async fn main() {
     let path = PathBuf::from(path);
 
     let fs = fs::MirrorFS::new(path);
-    let mut listener = NFSTcpListener::bind(&format!("127.0.0.1:{HOSTPORT}")).await.unwrap();
+    let mut listener = NFSTcpListener::bind(&format!("0.0.0.0:{HOSTPORT}")).await.unwrap();
     listener.register_root_export(fs).await.unwrap();
     listener.handle_forever().await.unwrap();
 }


### PR DESCRIPTION
Binding the NFS server to 0.0.0.0 instead of 127.0.0.1 is necessary to allow remote clients to connect