### PR TITLE
Setup error propagation 

### DIFF
--- a/src/protocol/nfs/mount/mod.rs
+++ b/src/protocol/nfs/mount/mod.rs
@@ -1,13 +1,15 @@
 //! `MOUNT` protocol implementation for NFS version 3 as specified in RFC 1813 section 5.0.
 //! <https://datatracker.ietf.org/doc/html/rfc1813#section-5.0>.
 
-use std::io;
 use std::io::{Read, Write};
 
-use crate::protocol::rpc;
-use crate::protocol::xdr::{self, mount, Serialize};
 use num_traits::cast::FromPrimitive;
-use tracing::warn;
+use tracing::{error, warn};
+
+use crate::protocol::rpc;
+use crate::protocol::xdr::{self, mount};
+use crate::xdr::rpc::accept_body;
+use crate::xdr::ProtocolErrors;
 
 mod dump;
 mod export;
@@ -87,21 +89,27 @@ pub async fn handle_mount(
     input: &mut impl Read,
     output: &mut impl Write,
     context: &rpc::Context,
-) -> io::Result<()> {
-    let prog = mount::MountProgram::from_u32(call.proc).unwrap_or(mount::MountProgram::INVALID);
+) -> Result<(), ProtocolErrors> {
+    if let Some(prog) = mount::MountProgram::from_u32(call.proc) {
+        Ok(match prog {
+            mount::MountProgram::MOUNTPROC3_NULL => mountproc3_null(xid, output),
+            mount::MountProgram::MOUNTPROC3_MNT => {
+                mountproc3_mnt(xid, input, output, context).await
+            }
+            mount::MountProgram::MOUNTPROC3_DUMP => mountproc3_dump(xid, output, context).await,
+            mount::MountProgram::MOUNTPROC3_UMNT => {
+                mountproc3_umnt(xid, input, output, context).await
+            }
 
-    match prog {
-        mount::MountProgram::MOUNTPROC3_NULL => mountproc3_null(xid, output)?,
-        mount::MountProgram::MOUNTPROC3_MNT => mountproc3_mnt(xid, input, output, context).await?,
-        mount::MountProgram::MOUNTPROC3_DUMP => mountproc3_dump(xid, output, context).await?,
-        mount::MountProgram::MOUNTPROC3_UMNT => {
-            mountproc3_umnt(xid, input, output, context).await?;
+            mount::MountProgram::MOUNTPROC3_UMNTALL => {
+                mountproc3_umnt_all(xid, output, context).await
+            }
+
+            mount::MountProgram::MOUNTPROC3_EXPORT => mountproc3_export(xid, output, context).await,
         }
-        mount::MountProgram::MOUNTPROC3_UMNTALL => {
-            mountproc3_umnt_all(xid, output, context).await?;
-        }
-        mount::MountProgram::MOUNTPROC3_EXPORT => mountproc3_export(xid, output, context).await?,
-        _ => xdr::rpc::proc_unavail_reply_message(xid).serialize(output)?,
+        .map_err(|_| ProtocolErrors::RpcAccepted(accept_body::GARBAGE_ARGS))?)
+    } else {
+        error!("Invalid procedure number for Mount");
+        Err(ProtocolErrors::RpcAccepted(accept_body::PROC_UNAVAIL))
     }
-    Ok(())
 }

--- a/src/protocol/nfs/v3/mod.rs
+++ b/src/protocol/nfs/v3/mod.rs
@@ -37,14 +37,13 @@
 //! - Better attribute caching with the `ACCESS` procedure
 //! - Enhanced directory reading with `READDIRPLUS`
 
-use std::io;
 use std::io::{Read, Write};
 
 use num_traits::cast::FromPrimitive;
-use tracing::warn;
+use tracing::error;
 
 use crate::protocol::rpc;
-use crate::protocol::xdr::{self, nfs3, Serialize};
+use crate::protocol::xdr::{self, nfs3};
 
 mod access;
 mod commit;
@@ -67,6 +66,9 @@ mod rename;
 mod setattr;
 mod symlink;
 mod write;
+
+use crate::xdr::rpc::accept_body;
+use crate::xdr::ProtocolErrors;
 
 use access::nfsproc3_access;
 use commit::nfsproc3_commit;
@@ -113,49 +115,49 @@ pub async fn handle_nfs(
     input: &mut impl Read,
     output: &mut impl Write,
     context: &rpc::Context,
-) -> io::Result<()> {
-    if call.vers != nfs3::VERSION {
-        warn!("Invalid NFS Version number {} != {}", call.vers, nfs3::VERSION);
-        // TODO: Use prog_version_range_mismatch_reply_message with proper version range
-        // Currently this only reports NFS v3 support, but server actually supports v3-v4
-        xdr::rpc::prog_mismatch_reply_message(xid, nfs3::VERSION).serialize(output)?;
-        return Ok(());
+) -> Result<(), ProtocolErrors> {
+    if let Some(prog) = nfs3::NFSProgram::from_u32(call.proc) {
+        Ok(match prog {
+            nfs3::NFSProgram::NFSPROC3_NULL => nfsproc3_null(xid, output),
+            nfs3::NFSProgram::NFSPROC3_GETATTR => {
+                nfsproc3_getattr(xid, input, output, context).await
+            }
+            nfs3::NFSProgram::NFSPROC3_LOOKUP => nfsproc3_lookup(xid, input, output, context).await,
+            nfs3::NFSProgram::NFSPROC3_READ => nfsproc3_read(xid, input, output, context).await,
+            nfs3::NFSProgram::NFSPROC3_FSINFO => nfsproc3_fsinfo(xid, input, output, context).await,
+            nfs3::NFSProgram::NFSPROC3_ACCESS => nfsproc3_access(xid, input, output, context).await,
+            nfs3::NFSProgram::NFSPROC3_PATHCONF => {
+                nfsproc3_pathconf(xid, input, output, context).await
+            }
+            nfs3::NFSProgram::NFSPROC3_FSSTAT => nfsproc3_fsstat(xid, input, output, context).await,
+            nfs3::NFSProgram::NFSPROC3_READDIR => {
+                nfsproc3_readdir(xid, input, output, context).await
+            }
+            nfs3::NFSProgram::NFSPROC3_READDIRPLUS => {
+                nfsproc3_readdirplus(xid, input, output, context).await
+            }
+            nfs3::NFSProgram::NFSPROC3_WRITE => nfsproc3_write(xid, input, output, context).await,
+            nfs3::NFSProgram::NFSPROC3_CREATE => nfsproc3_create(xid, input, output, context).await,
+            nfs3::NFSProgram::NFSPROC3_SETATTR => {
+                nfsproc3_setattr(xid, input, output, context).await
+            }
+            nfs3::NFSProgram::NFSPROC3_REMOVE => nfsproc3_remove(xid, input, output, context).await,
+            nfs3::NFSProgram::NFSPROC3_RMDIR => nfsproc3_remove(xid, input, output, context).await,
+            nfs3::NFSProgram::NFSPROC3_RENAME => nfsproc3_rename(xid, input, output, context).await,
+            nfs3::NFSProgram::NFSPROC3_MKDIR => nfsproc3_mkdir(xid, input, output, context).await,
+            nfs3::NFSProgram::NFSPROC3_SYMLINK => {
+                nfsproc3_symlink(xid, input, output, context).await
+            }
+            nfs3::NFSProgram::NFSPROC3_READLINK => {
+                nfsproc3_readlink(xid, input, output, context).await
+            }
+            nfs3::NFSProgram::NFSPROC3_MKNOD => nfsproc3_mknod(xid, input, output, context).await,
+            nfs3::NFSProgram::NFSPROC3_LINK => nfsproc3_link(xid, input, output, context).await,
+            nfs3::NFSProgram::NFSPROC3_COMMIT => nfsproc3_commit(xid, input, output, context).await,
+        }
+        .map_err(|_| ProtocolErrors::RpcAccepted(accept_body::GARBAGE_ARGS))?)
+    } else {
+        error!("Invalid procedure number for NFS version 3");
+        Err(ProtocolErrors::RpcAccepted(accept_body::PROC_UNAVAIL))
     }
-    let prog = nfs3::NFSProgram::from_u32(call.proc).unwrap_or(nfs3::NFSProgram::INVALID);
-
-    match prog {
-        nfs3::NFSProgram::NFSPROC3_NULL => nfsproc3_null(xid, output)?,
-        nfs3::NFSProgram::NFSPROC3_GETATTR => nfsproc3_getattr(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_LOOKUP => nfsproc3_lookup(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_READ => nfsproc3_read(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_FSINFO => nfsproc3_fsinfo(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_ACCESS => nfsproc3_access(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_PATHCONF => {
-            nfsproc3_pathconf(xid, input, output, context).await?;
-        }
-        nfs3::NFSProgram::NFSPROC3_FSSTAT => nfsproc3_fsstat(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_READDIR => nfsproc3_readdir(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_READDIRPLUS => {
-            nfsproc3_readdirplus(xid, input, output, context).await?;
-        }
-        nfs3::NFSProgram::NFSPROC3_WRITE => nfsproc3_write(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_CREATE => nfsproc3_create(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_SETATTR => nfsproc3_setattr(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_REMOVE => nfsproc3_remove(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_RMDIR => nfsproc3_remove(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_RENAME => nfsproc3_rename(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_MKDIR => nfsproc3_mkdir(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_SYMLINK => nfsproc3_symlink(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_READLINK => {
-            nfsproc3_readlink(xid, input, output, context).await?;
-        }
-        nfs3::NFSProgram::NFSPROC3_MKNOD => nfsproc3_mknod(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_LINK => nfsproc3_link(xid, input, output, context).await?,
-        nfs3::NFSProgram::NFSPROC3_COMMIT => nfsproc3_commit(xid, input, output, context).await?,
-        _ => {
-            warn!("Unimplemented message {:?}", prog);
-            xdr::rpc::proc_unavail_reply_message(xid).serialize(output)?;
-        }
-    }
-    Ok(())
 }

--- a/src/protocol/nfs/v3/mod.rs
+++ b/src/protocol/nfs/v3/mod.rs
@@ -44,6 +44,8 @@ use tracing::error;
 
 use crate::protocol::rpc;
 use crate::protocol::xdr::{self, nfs3};
+use crate::xdr::rpc::accept_body;
+use crate::xdr::ProtocolErrors;
 
 mod access;
 mod commit;
@@ -66,9 +68,6 @@ mod rename;
 mod setattr;
 mod symlink;
 mod write;
-
-use crate::xdr::rpc::accept_body;
-use crate::xdr::ProtocolErrors;
 
 use access::nfsproc3_access;
 use commit::nfsproc3_commit;

--- a/src/protocol/nfs/v4/mod.rs
+++ b/src/protocol/nfs/v4/mod.rs
@@ -25,20 +25,21 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 use std::collections::HashMap;
-use std::io;
 use std::io::{Read, Write};
 use std::sync::Arc;
 
 use num_traits::cast::FromPrimitive;
 use tokio::sync::RwLock;
-use tracing::warn;
+use tracing::{error, warn};
 
 use crate::protocol::rpc;
-use crate::protocol::xdr::{self, nfs4, Serialize};
+use crate::protocol::xdr::{self, nfs4};
 use crate::vfs::NFSv4FileSystem;
 use crate::xdr::nfs4::{
     clientid4, filehandle, nfs_client_id, nfs_fh4, state_owner_type, state_type, stateid4,
 };
+use crate::xdr::rpc::accept_body;
+use crate::xdr::ProtocolErrors;
 
 mod compound;
 mod null;
@@ -69,27 +70,25 @@ pub async fn handle_nfs(
     input: &mut impl Read,
     output: &mut impl Write,
     context: &rpc::Context,
-) -> io::Result<()> {
-    if call.vers != VERSION {
-        warn!("Invalid NFS Version number {} != {}", call.vers, VERSION);
-        xdr::rpc::prog_mismatch_reply_message(xid, VERSION).serialize(output)?;
-        return Ok(());
-    }
-
-    let prog = nfs4::nfs_opnum4::from_u32(call.proc).unwrap_or(nfs4::nfs_opnum4::OP_ILLEGAL);
-
-    match prog {
-        nfs4::nfs_opnum4::OP_NULL => null::nfsproc4_null(xid, output)?,
-        nfs4::nfs_opnum4::OP_COMPOUND => {
-            compound::nfsproc4_compound(xid, input, output, context).await?
+) -> Result<(), ProtocolErrors> {
+    if let Some(prog) = nfs4::nfs_opnum4::from_u32(call.proc) {
+        match prog {
+            nfs4::nfs_opnum4::OP_NULL => null::nfsproc4_null(xid, output)
+                .map_err(|_| ProtocolErrors::RpcAccepted(accept_body::GARBAGE_ARGS)),
+            nfs4::nfs_opnum4::OP_COMPOUND => {
+                compound::nfsproc4_compound(xid, input, output, context)
+                    .await
+                    .map_err(|_| ProtocolErrors::RpcAccepted(accept_body::GARBAGE_ARGS))
+            }
+            _ => {
+                warn!("Unimplemented NFS v4 operation: {:?}", prog);
+                Err(ProtocolErrors::RpcAccepted(accept_body::PROC_UNAVAIL))
+            }
         }
-        _ => {
-            warn!("Unimplemented NFS v4 operation: {:?}", prog);
-            xdr::rpc::proc_unavail_reply_message(xid).serialize(output)?;
-        }
+    } else {
+        error!("Invalid procedure number for NFS version 4");
+        Err(ProtocolErrors::RpcAccepted(accept_body::PROC_UNAVAIL))
     }
-
-    Ok(())
 }
 
 /// Represents the execution context for a single NFSv4.0 compound operation.

--- a/src/protocol/xdr/mod.rs
+++ b/src/protocol/xdr/mod.rs
@@ -444,9 +444,9 @@ impl<T: Deserialize> Deserialize for Option<T> {
 pub use crate::DeserializeStruct;
 pub use crate::SerializeStruct;
 
-enum ProtocolErrors {
+pub enum ProtocolErrors {
     RpcRejected(rejected_reply),
     RpcAccepted(accept_body),
     NFSv3(nfsstat3),
-    Mount(mountstat3)
+    Mount(mountstat3),
 }

--- a/src/protocol/xdr/mod.rs
+++ b/src/protocol/xdr/mod.rs
@@ -444,6 +444,7 @@ impl<T: Deserialize> Deserialize for Option<T> {
 pub use crate::DeserializeStruct;
 pub use crate::SerializeStruct;
 
+/// Type for error propagation
 #[derive(Debug)]
 pub enum ProtocolErrors {
     RpcRejected(rejected_reply),

--- a/src/protocol/xdr/mod.rs
+++ b/src/protocol/xdr/mod.rs
@@ -444,6 +444,7 @@ impl<T: Deserialize> Deserialize for Option<T> {
 pub use crate::DeserializeStruct;
 pub use crate::SerializeStruct;
 
+#[derive(Debug)]
 pub enum ProtocolErrors {
     RpcRejected(rejected_reply),
     RpcAccepted(accept_body),

--- a/src/protocol/xdr/mod.rs
+++ b/src/protocol/xdr/mod.rs
@@ -22,6 +22,10 @@ use byteorder::BigEndian;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use num_traits::{FromPrimitive, ToPrimitive};
 
+use crate::xdr::mount::mountstat3;
+use crate::xdr::nfs3::nfsstat3;
+use crate::xdr::rpc::{accept_body, rejected_reply};
+
 pub mod mount;
 pub mod nfs3;
 pub mod nfs4;
@@ -439,3 +443,10 @@ impl<T: Deserialize> Deserialize for Option<T> {
 // Re-export public types for use in other modules
 pub use crate::DeserializeStruct;
 pub use crate::SerializeStruct;
+
+enum ProtocolErrors {
+    RpcRejected(rejected_reply),
+    RpcAccepted(accept_body),
+    NFSv3(nfsstat3),
+    Mount(mountstat3)
+}

--- a/src/protocol/xdr/mount.rs
+++ b/src/protocol/xdr/mount.rs
@@ -94,8 +94,6 @@ pub enum MountProgram {
     MOUNTPROC3_UMNTALL = 4,
     /// Get list of exported file systems
     MOUNTPROC3_EXPORT = 5,
-    /// Invalid procedure number
-    INVALID,
 }
 impl SerializeEnum for MountProgram {}
 impl DeserializeEnum for MountProgram {}

--- a/src/protocol/xdr/nfs3/mod.rs
+++ b/src/protocol/xdr/nfs3/mod.rs
@@ -172,8 +172,6 @@ pub enum NFSProgram {
     NFSPROC3_PATHCONF = 20,
     /// Commit cached data
     NFSPROC3_COMMIT = 21,
-    /// Invalid procedure
-    INVALID = 22,
 }
 
 /// Opaque byte type as defined in RFC 1813 section 2.5

--- a/src/protocol/xdr/rpc.rs
+++ b/src/protocol/xdr/rpc.rs
@@ -423,65 +423,12 @@ impl Deserialize for rejected_reply {
     }
 }
 
-/// Creates a reply message indicating that the requested procedure is not available
-pub fn proc_unavail_reply_message(xid: u32) -> rpc_msg {
-    let reply = reply_body::MSG_ACCEPTED(accepted_reply {
-        verf: opaque_auth::default(),
-        reply_data: accept_body::PROC_UNAVAIL,
-    });
-    rpc_msg { xid, body: rpc_body::REPLY(reply) }
-}
-
-/// Creates a reply message indicating that the requested program is not available
-pub fn prog_unavail_reply_message(xid: u32) -> rpc_msg {
-    let reply = reply_body::MSG_ACCEPTED(accepted_reply {
-        verf: opaque_auth::default(),
-        reply_data: accept_body::PROG_UNAVAIL,
-    });
-    rpc_msg { xid, body: rpc_body::REPLY(reply) }
-}
-
-/// Creates a reply message indicating a program version mismatch
-pub fn prog_mismatch_reply_message(xid: u32, accepted_ver: u32) -> rpc_msg {
-    let reply = reply_body::MSG_ACCEPTED(accepted_reply {
-        verf: opaque_auth::default(),
-        reply_data: accept_body::PROG_MISMATCH(mismatch_info {
-            low: accepted_ver,
-            high: accepted_ver,
-        }),
-    });
-    rpc_msg { xid, body: rpc_body::REPLY(reply) }
-}
-
-/// Creates a reply message indicating a program version mismatch with supported version range
-pub fn prog_version_range_mismatch_reply_message(
-    xid: u32,
-    low_version: u32,
-    high_version: u32,
-) -> rpc_msg {
-    let reply = reply_body::MSG_ACCEPTED(accepted_reply {
-        verf: opaque_auth::default(),
-        reply_data: accept_body::PROG_MISMATCH(mismatch_info {
-            low: low_version,
-            high: high_version,
-        }),
-    });
-    rpc_msg { xid, body: rpc_body::REPLY(reply) }
-}
-
 /// Creates a reply message indicating that the arguments could not be decoded
 pub fn garbage_args_reply_message(xid: u32) -> rpc_msg {
     let reply = reply_body::MSG_ACCEPTED(accepted_reply {
         verf: opaque_auth::default(),
         reply_data: accept_body::GARBAGE_ARGS,
     });
-    rpc_msg { xid, body: rpc_body::REPLY(reply) }
-}
-
-/// Creates a reply message indicating an RPC version mismatch
-pub fn rpc_vers_mismatch(xid: u32) -> rpc_msg {
-    let mismatch_info = mismatch_info { low: PROTOCOL_VERSION, high: PROTOCOL_VERSION };
-    let reply = reply_body::MSG_DENIED(rejected_reply::RPC_MISMATCH(mismatch_info));
     rpc_msg { xid, body: rpc_body::REPLY(reply) }
 }
 

--- a/src/response_buffer.rs
+++ b/src/response_buffer.rs
@@ -10,6 +10,7 @@ const LAST_FG_MASK: u32 = 1 << 31;
 const MAX_RM_FRAGMENT_SIZE: usize = (1 << 31) - 1;
 
 /// Represents a response buffer that minimizes data copying
+#[derive(Debug)]
 pub struct ResponseBuffer {
     /// Internal buffer for writing data
     buffer: Vec<u8>,
@@ -48,38 +49,38 @@ impl ResponseBuffer {
         self.buffer.clear();
         self.has_content = false;
     }
+}
 
-    /// Writes a complete RPC result from a TCP socket using a Record Marking Protocol.
-    ///
-    /// This method implements a Record Marking Standard by splitting result in
-    /// fragments and inserting header (size of fragment with flag, whether current fragment
-    /// is the last) before it.
-    pub async fn write_fragment(&mut self, write_half: &mut OwnedWriteHalf) -> io::Result<()> {
-        // Maximum fragment size is 2^31 - 1 bytes
+/// Writes a complete RPC result from a TCP socket using a Record Marking Protocol.
+///
+/// This method implements a Record Marking Standard by splitting result in
+/// fragments and inserting header (size of fragment with flag, whether current fragment
+/// is the last) before it.
+pub async fn write_fragment(buffer: &mut [u8], write_half: &mut OwnedWriteHalf) -> io::Result<()> {
+    // Maximum fragment size is 2^31 - 1 bytes
 
-        let mut offset = 0;
-        while offset < self.buffer.len() {
-            // Calculate the size of this fragment
-            let remaining = self.buffer.len() - offset;
-            let fragment_size = std::cmp::min(remaining, MAX_RM_FRAGMENT_SIZE);
+    let mut offset = 0;
+    while offset < buffer.len() {
+        // Calculate the size of this fragment
+        let remaining = buffer.len() - offset;
+        let fragment_size = std::cmp::min(remaining, MAX_RM_FRAGMENT_SIZE);
 
-            // Determine if this is the last fragment
-            let is_last = offset + fragment_size >= self.buffer.len();
+        // Determine if this is the last fragment
+        let is_last = offset + fragment_size >= buffer.len();
 
-            // Create the fragment header
-            // The highest bit indicates if this is the last fragment
-            let fragment_header =
-                if is_last { fragment_size as u32 + LAST_FG_MASK } else { fragment_size as u32 };
+        // Create the fragment header
+        // The highest bit indicates if this is the last fragment
+        let fragment_header =
+            if is_last { fragment_size as u32 + LAST_FG_MASK } else { fragment_size as u32 };
 
-            let header_buf = u32::to_be_bytes(fragment_header);
-            write_half.write_all(&header_buf).await?;
+        let header_buf = u32::to_be_bytes(fragment_header);
+        write_half.write_all(&header_buf).await?;
 
-            trace!("Writing fragment length:{}, last:{}", fragment_size, is_last);
-            write_half.write_all(&self.buffer[offset..offset + fragment_size]).await?;
+        trace!("Writing fragment length:{}, last:{}", fragment_size, is_last);
+        write_half.write_all(&buffer[offset..offset + fragment_size]).await?;
 
-            offset += fragment_size;
-        }
-
-        Ok(())
+        offset += fragment_size;
     }
+
+    Ok(())
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -65,7 +65,7 @@ pub fn generate_host_ip(hostnum: u16) -> String {
 }
 
 /// Command processing result
-pub type CommandResult = Result<ResponseBuffer, ProtocolErrors>;
+pub type CommandResult = (u32, Result<ResponseBuffer, ProtocolErrors>);
 
 /// Processes an established TCP socket connection from an NFS client
 ///

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -28,7 +28,7 @@ use crate::rpc_command::RpcCommand;
 use crate::vfs::NFSFileSystem;
 use crate::vfs_task::VfsTask;
 use crate::write_task::WriteTask;
-use crate::xdr::nfs3;
+use crate::xdr::{nfs3, ProtocolErrors};
 
 /// Entry in the NFS export table that represents a single exported file system.
 pub struct NFSExportTableEntry {
@@ -65,7 +65,7 @@ pub fn generate_host_ip(hostnum: u16) -> String {
 }
 
 /// Command processing result
-pub type CommandResult = Result<Option<ResponseBuffer>, io::Error>;
+pub type CommandResult = Result<ResponseBuffer, ProtocolErrors>;
 
 /// Processes an established TCP socket connection from an NFS client
 ///

--- a/src/vfs_task.rs
+++ b/src/vfs_task.rs
@@ -9,7 +9,7 @@ use crate::response_buffer::ResponseBuffer;
 use crate::rpc_command::RpcCommand;
 use crate::tcp::CommandResult;
 use crate::xdr;
-use crate::xdr::rpc::{accept_body, mismatch_info, rejected_reply, PROTOCOL_VERSION};
+use crate::xdr::rpc::{accept_body, mismatch_info, rejected_reply, rpc_msg, PROTOCOL_VERSION};
 use crate::xdr::{deserialize, mount, nfs3, ProtocolErrors};
 
 /// RPC program number for NFS Access Control Lists
@@ -65,23 +65,29 @@ impl VfsTask {
             let mut input_cursor = Cursor::new(command.data);
             let mut output_cursor = Cursor::new(output_buffer.get_mut_buffer());
 
-            // Call async processor
-            let result = match self.handle_rpc(&mut input_cursor, &mut output_cursor).await {
-                Ok(_) => {
-                    // Processor indicated response needs to be sent
-                    output_buffer.mark_has_content();
-                    let buffer_to_send = std::mem::replace(
-                        &mut output_buffer,
-                        ResponseBuffer::with_capacity(DEFAULT_RESPONSE_BUFFER_CAPACITY),
-                    );
-                    Ok(buffer_to_send)
+            if let Ok(recv) = deserialize::<xdr::rpc::rpc_msg>(&mut input_cursor) {
+                let xid = recv.xid;
+                // Call async processor
+                let result =
+                    match self.handle_rpc(xid, recv, &mut input_cursor, &mut output_cursor).await {
+                        Ok(_) => {
+                            // Processor indicated response needs to be sent
+                            output_buffer.mark_has_content();
+                            let buffer_to_send = std::mem::replace(
+                                &mut output_buffer,
+                                ResponseBuffer::with_capacity(DEFAULT_RESPONSE_BUFFER_CAPACITY),
+                            );
+                            Ok(buffer_to_send)
+                        }
+                        Err(e) => Err(e),
+                    };
+                // Send result
+                if let Err(e) = self.result_sender.send(CommandResult::from((xid, result))) {
+                    error!("Failed to send command processing result: {:?}", e);
+                    break;
                 }
-                Err(e) => Err(e),
-            };
-
-            // Send result
-            if let Err(e) = self.result_sender.send(result) {
-                error!("Failed to send command processing result: {:?}", e);
+            } else {
+                error!("Cannot process REPLY");
                 break;
             }
         }
@@ -104,12 +110,11 @@ impl VfsTask {
     /// Returns true if a response was sent, false otherwise (for retransmissions).
     pub async fn handle_rpc(
         &mut self,
+        xid: u32,
+        recv: rpc_msg,
         input: &mut impl Read,
         output: &mut impl Write,
     ) -> Result<(), ProtocolErrors> {
-        let recv = deserialize::<xdr::rpc::rpc_msg>(input)
-            .map_err(|_| ProtocolErrors::RpcAccepted(accept_body::GARBAGE_ARGS))?;
-        let xid = recv.xid;
         if let xdr::rpc::rpc_body::CALL(call) = recv.body {
             if let xdr::rpc::auth_flavor::AUTH_SYS = call.cred.flavor {
                 let auth = deserialize(&mut Cursor::new(&call.cred.body))

--- a/src/vfs_task.rs
+++ b/src/vfs_task.rs
@@ -140,9 +140,18 @@ impl VfsTask {
                         )))
                     }
                 },
-                mount::PROGRAM => {
-                    Ok(nfs::mount::handle_mount(xid, call, input, output, &self.context).await?)
-                }
+                mount::PROGRAM => match call.vers {
+                    mount::VERSION => {
+                        Ok(nfs::mount::handle_mount(xid, call, input, output, &self.context)
+                            .await?)
+                    }
+                    v => {
+                        warn!("Unsupported Mount version: {}", v);
+                        Err(ProtocolErrors::RpcAccepted(accept_body::PROG_MISMATCH(
+                            mismatch_info { low: mount::VERSION, high: mount::VERSION },
+                        )))
+                    }
+                },
                 prog if prog == NFS_ACL_PROGRAM
                     || prog == NFS_ID_MAP_PROGRAM
                     || prog == NFS_METADATA_PROGRAM =>

--- a/src/vfs_task.rs
+++ b/src/vfs_task.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::io::{Cursor, Read, Write};
 
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -9,9 +8,9 @@ use crate::protocol::rpc::Context;
 use crate::response_buffer::ResponseBuffer;
 use crate::rpc_command::RpcCommand;
 use crate::tcp::CommandResult;
-use crate::utils::error::io_other;
 use crate::xdr;
-use crate::xdr::{deserialize, mount, nfs3, Serialize};
+use crate::xdr::rpc::{accept_body, mismatch_info, rejected_reply, PROTOCOL_VERSION};
+use crate::xdr::{deserialize, mount, nfs3, ProtocolErrors};
 
 /// RPC program number for NFS Access Control Lists
 const NFS_ACL_PROGRAM: u32 = 100227;
@@ -68,18 +67,14 @@ impl VfsTask {
 
             // Call async processor
             let result = match self.handle_rpc(&mut input_cursor, &mut output_cursor).await {
-                Ok(true) => {
+                Ok(_) => {
                     // Processor indicated response needs to be sent
                     output_buffer.mark_has_content();
                     let buffer_to_send = std::mem::replace(
                         &mut output_buffer,
                         ResponseBuffer::with_capacity(DEFAULT_RESPONSE_BUFFER_CAPACITY),
                     );
-                    Ok(Some(buffer_to_send))
-                }
-                Ok(false) => {
-                    // No response needed (e.g. retransmission)
-                    Ok(None)
+                    Ok(buffer_to_send)
                 }
                 Err(e) => Err(e),
             };
@@ -111,67 +106,60 @@ impl VfsTask {
         &mut self,
         input: &mut impl Read,
         output: &mut impl Write,
-    ) -> io::Result<bool> {
-        let recv = deserialize::<xdr::rpc::rpc_msg>(input)?;
+    ) -> Result<(), ProtocolErrors> {
+        let recv = deserialize::<xdr::rpc::rpc_msg>(input)
+            .map_err(|_| ProtocolErrors::RpcAccepted(accept_body::GARBAGE_ARGS))?;
         let xid = recv.xid;
         if let xdr::rpc::rpc_body::CALL(call) = recv.body {
             if let xdr::rpc::auth_flavor::AUTH_SYS = call.cred.flavor {
-                let auth = deserialize(&mut Cursor::new(&call.cred.body))?;
+                let auth = deserialize(&mut Cursor::new(&call.cred.body))
+                    .map_err(|_| ProtocolErrors::RpcAccepted(accept_body::GARBAGE_ARGS))?;
                 self.context.auth = Some(auth);
             }
-            if call.rpcvers != xdr::rpc::PROTOCOL_VERSION {
+            if call.rpcvers != PROTOCOL_VERSION {
                 warn!("Invalid RPC version {} != 2", call.rpcvers);
-                xdr::rpc::rpc_vers_mismatch(xid).serialize(output)?;
-                return Ok(true);
+                return Err(ProtocolErrors::RpcRejected(rejected_reply::RPC_MISMATCH(
+                    mismatch_info { low: PROTOCOL_VERSION, high: PROTOCOL_VERSION },
+                )));
             }
 
-            let result = match call.prog {
+            match call.prog {
                 nfs3::PROGRAM => match call.vers {
                     nfs3::VERSION => {
-                        nfs::v3::handle_nfs(xid, call, input, output, &self.context).await
+                        Ok(nfs::v3::handle_nfs(xid, call, input, output, &self.context).await?)
                     }
                     nfs::v4::VERSION => {
-                        nfs::v4::handle_nfs(xid, call, input, output, &self.context).await
+                        Ok(nfs::v4::handle_nfs(xid, call, input, output, &self.context).await?)
                     }
                     v => {
                         warn!("Unsupported NFS version: {}", v);
-                        xdr::rpc::prog_version_range_mismatch_reply_message(
-                            xid,
-                            nfs3::VERSION,
-                            nfs::v4::VERSION,
-                        )
-                        .serialize(output)?;
-                        Ok(())
+                        Err(ProtocolErrors::RpcAccepted(accept_body::PROG_MISMATCH(
+                            mismatch_info { low: nfs3::VERSION, high: nfs::v4::VERSION },
+                        )))
                     }
                 },
                 mount::PROGRAM => {
-                    nfs::mount::handle_mount(xid, call, input, output, &self.context).await
+                    Ok(nfs::mount::handle_mount(xid, call, input, output, &self.context).await?)
                 }
                 prog if prog == NFS_ACL_PROGRAM
                     || prog == NFS_ID_MAP_PROGRAM
                     || prog == NFS_METADATA_PROGRAM =>
                 {
                     trace!("ignoring NFS_ACL/ID_MAP/METADATA packet");
-                    xdr::rpc::prog_unavail_reply_message(xid).serialize(output)?;
-                    Ok(())
+                    Err(ProtocolErrors::RpcAccepted(accept_body::PROG_UNAVAIL))
                 }
                 NFS_LOCALIO_PROGRAM => {
                     trace!("Ignoring NFS_LOCALIO packet");
-                    xdr::rpc::prog_unavail_reply_message(xid).serialize(output)?;
-                    Ok(())
+                    Err(ProtocolErrors::RpcAccepted(accept_body::PROG_UNAVAIL))
                 }
                 _ => {
                     warn!("Unknown RPC Program number {} != {}", call.prog, nfs3::PROGRAM);
-                    xdr::rpc::prog_unavail_reply_message(xid).serialize(output)?;
-                    Ok(())
+                    Err(ProtocolErrors::RpcAccepted(accept_body::PROG_UNAVAIL))
                 }
             }
-            .map(|_| true);
-
-            result
         } else {
             error!("Unexpectedly received a Reply instead of a Call");
-            io_other("Bad RPC Call format")
+            Err(ProtocolErrors::RpcAccepted(accept_body::GARBAGE_ARGS))
         }
     }
 }

--- a/src/vfs_task.rs
+++ b/src/vfs_task.rs
@@ -100,14 +100,11 @@ impl VfsTask {
     /// 1. Deserializes the incoming RPC message using XDR format
     /// 2. Validates the RPC version number (must be version 2)
     /// 3. Extracts authentication information if provided
-    /// 4. Checks for retransmissions to ensure idempotent operation
-    /// 5. Routes the call to the appropriate protocol handler (NFS, MOUNT, PORTMAP)
-    /// 6. Tracks transaction completion state
+    /// 4. Routes the call to the appropriate protocol handler (NFS, MOUNT, PORTMAP)
+    /// 5. Tracks transaction completion state
     ///
     /// This implementation follows RFC 5531 (previously RFC 1057) section on Authentication and
     /// Record Marking Standard for proper RPC message handling.
-    ///
-    /// Returns true if a response was sent, false otherwise (for retransmissions).
     pub async fn handle_rpc(
         &mut self,
         xid: u32,

--- a/src/write_task.rs
+++ b/src/write_task.rs
@@ -1,11 +1,13 @@
-use std::io::Error;
-
+use std::io;
+use std::io::{Cursor, Error};
+use tokio::io::AsyncWriteExt;
 use tokio::net::tcp::OwnedWriteHalf;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{debug, error};
 
 use crate::tcp::CommandResult;
-use crate::xdr::ProtocolErrors;
+use crate::xdr::rpc::{accepted_reply, opaque_auth, reply_body, rpc_body, rpc_msg};
+use crate::xdr::{ProtocolErrors, Serialize};
 
 /// An asynchronous task responsible for writing [`VfsTask`] responses to a network connection.
 pub struct WriteTask {
@@ -32,7 +34,7 @@ impl WriteTask {
     }
 
     async fn run(mut self) -> Result<(), Error> {
-        while let Some(result) = self.result_receiver.recv().await {
+        while let Some((xid, result)) = self.result_receiver.recv().await {
             match result {
                 Ok(mut response_buffer) => {
                     if let Err(e) = response_buffer.write_fragment(&mut self.writehalf).await {
@@ -41,12 +43,43 @@ impl WriteTask {
                     }
                 }
                 Err(e) => {
-                    debug!("Message handling closed : {:?}", e);
-                    return Err(e);
+                    return match self.error_replying(xid, e).await {
+                        Ok(_) => {
+                            debug!("Replying successfully to client with error");
+                            Ok(())
+                        }
+                        Err(e) => {
+                            error!("Failed to send error reply to client: {:?}", e);
+                            Err(e)
+                        }
+                    }
                 }
             }
         }
         debug!("Command result handler finished");
         Ok(())
+    }
+
+    async fn error_replying(&mut self, xid: u32, error: ProtocolErrors) -> io::Result<()> {
+        debug!("Replying with protocol error : {:?}", error);
+        let mut buf = Cursor::new(vec![0_u8; 450]);
+        match error {
+            ProtocolErrors::RpcRejected(e) => {
+                rpc_msg { xid, body: rpc_body::REPLY(reply_body::MSG_DENIED(e)) }
+                    .serialize(&mut buf)?;
+                self.writehalf.write_all(&buf.into_inner()).await
+            }
+            ProtocolErrors::RpcAccepted(e) => {
+                reply_body::MSG_ACCEPTED(accepted_reply {
+                    verf: opaque_auth::default(),
+                    reply_data: e,
+                })
+                .serialize(&mut buf)?;
+                self.writehalf.write_all(&buf.into_inner()).await
+            }
+            _ => {
+                todo!()
+            }
+        }
     }
 }

--- a/src/write_task.rs
+++ b/src/write_task.rs
@@ -1,13 +1,15 @@
 use std::io;
 use std::io::{Cursor, Error};
-use tokio::io::AsyncWriteExt;
 use tokio::net::tcp::OwnedWriteHalf;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{debug, error};
 
+use crate::response_buffer::write_fragment;
 use crate::tcp::CommandResult;
 use crate::xdr::rpc::{accepted_reply, opaque_auth, reply_body, rpc_body, rpc_msg};
 use crate::xdr::{ProtocolErrors, Serialize};
+
+const ERROR_BUFFER_SIZE: usize = 50;
 
 /// An asynchronous task responsible for writing [`VfsTask`] responses to a network connection.
 pub struct WriteTask {
@@ -36,13 +38,16 @@ impl WriteTask {
     async fn run(mut self) -> Result<(), Error> {
         while let Some((xid, result)) = self.result_receiver.recv().await {
             match result {
-                Ok(mut response_buffer) => {
-                    if let Err(e) = response_buffer.write_fragment(&mut self.writehalf).await {
+                Ok(response_buffer) => {
+                    if let Err(e) =
+                        write_fragment(&mut response_buffer.into_inner(), &mut self.writehalf).await
+                    {
                         error!("Write error {:?}", e);
                         return Err(e);
                     }
                 }
                 Err(e) => {
+                    debug!("Error to send: {:?}", e);
                     return match self.error_replying(xid, e).await {
                         Ok(_) => {
                             debug!("Replying successfully to client with error");
@@ -52,7 +57,7 @@ impl WriteTask {
                             error!("Failed to send error reply to client: {:?}", e);
                             Err(e)
                         }
-                    }
+                    };
                 }
             }
         }
@@ -62,22 +67,26 @@ impl WriteTask {
 
     async fn error_replying(&mut self, xid: u32, error: ProtocolErrors) -> io::Result<()> {
         debug!("Replying with protocol error : {:?}", error);
-        let mut buf = Cursor::new(vec![0_u8; 450]);
+        let mut buf = Cursor::new(Vec::with_capacity(ERROR_BUFFER_SIZE));
         match error {
             ProtocolErrors::RpcRejected(e) => {
                 rpc_msg { xid, body: rpc_body::REPLY(reply_body::MSG_DENIED(e)) }
                     .serialize(&mut buf)?;
-                self.writehalf.write_all(&buf.into_inner()).await
+                write_fragment(&mut buf.into_inner(), &mut self.writehalf).await
             }
             ProtocolErrors::RpcAccepted(e) => {
-                reply_body::MSG_ACCEPTED(accepted_reply {
-                    verf: opaque_auth::default(),
-                    reply_data: e,
-                })
+                rpc_msg {
+                    xid,
+                    body: rpc_body::REPLY(reply_body::MSG_ACCEPTED(accepted_reply {
+                        verf: opaque_auth::default(),
+                        reply_data: e,
+                    })),
+                }
                 .serialize(&mut buf)?;
-                self.writehalf.write_all(&buf.into_inner()).await
+                write_fragment(&mut buf.into_inner(), &mut self.writehalf).await
             }
             _ => {
+                // Setup for errors of Mount and Nfs
                 todo!()
             }
         }

--- a/src/write_task.rs
+++ b/src/write_task.rs
@@ -5,6 +5,7 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{debug, error};
 
 use crate::tcp::CommandResult;
+use crate::xdr::ProtocolErrors;
 
 /// An asynchronous task responsible for writing [`VfsTask`] responses to a network connection.
 pub struct WriteTask {
@@ -33,17 +34,11 @@ impl WriteTask {
     async fn run(mut self) -> Result<(), Error> {
         while let Some(result) = self.result_receiver.recv().await {
             match result {
-                Ok(Some(mut response_buffer)) if response_buffer.has_content() => {
+                Ok(mut response_buffer) => {
                     if let Err(e) = response_buffer.write_fragment(&mut self.writehalf).await {
                         error!("Write error {:?}", e);
                         return Err(e);
                     }
-                }
-                Ok(None) => {
-                    // No response needed, so nothing to send
-                }
-                Ok(Some(_)) => {
-                    // Buffer exists but contains no data to send
                 }
                 Err(e) => {
                     debug!("Message handling closed : {:?}", e);


### PR DESCRIPTION
- create enum for all errors defined in rfc
- change type `CommandResult` to send error codes directly to WriteTask
- change `io::Result<()>` to `Result<(), ProtocolErrors>` as return values

This changes would allow us to propagate errors directly to WriteTask.

Resolves #163 