### PR TITLE
feat: file handle const size

### DIFF
--- a/src/mount.rs
+++ b/src/mount.rs
@@ -11,7 +11,7 @@ const MNTNAMLEN: u32 = 255;
 #[allow(dead_code)]
 const FHSIZE3: u32 = 64;
 
-type fhandle3 = Vec<u8>;
+type fhandle3 = [u8; 8];
 type dirpath = Vec<u8>;
 type name = Vec<u8>;
 

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -9,9 +9,9 @@ const MNTPATHLEN: u32 = 1024;
 #[allow(dead_code)]
 const MNTNAMLEN: u32 = 255;
 #[allow(dead_code)]
-const FHSIZE3: u32 = 64;
+const FHSIZE3: u32 = 8;
 
-type fhandle3 = [u8; 8];
+type fhandle3 = [u8; FHSIZE3 as usize];
 type dirpath = Vec<u8>;
 type name = Vec<u8>;
 

--- a/src/nfsv3.rs
+++ b/src/nfsv3.rs
@@ -170,7 +170,7 @@ struct specdata3 {
 
 #[allow(dead_code)]
 struct nfs_fh3 {
-    data: Vec<u8>,
+    data: [u8; 8],
 }
 
 #[allow(dead_code)]

--- a/src/nfsv3.rs
+++ b/src/nfsv3.rs
@@ -170,7 +170,7 @@ struct specdata3 {
 
 #[allow(dead_code)]
 struct nfs_fh3 {
-    data: [u8; 8],
+    data: [u8; NFS3_FHSIZE as usize],
 }
 
 #[allow(dead_code)]

--- a/src/nfsv3.rs
+++ b/src/nfsv3.rs
@@ -5,7 +5,7 @@ const NFS_PROGRAM: u32 = 100003;
 #[allow(dead_code)]
 const NFS_VERSION: u32 = 3;
 #[allow(dead_code)]
-const NFS3_FHSIZE: u32 = 64;
+const NFS3_FHSIZE: u32 = 8;
 #[allow(dead_code)]
 const NFS3_COOKIEVERFSIZE: u32 = 8;
 #[allow(dead_code)]

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 pub type VfsResult<T> = Result<T, NfsError>;
 
 /// Maximum number of bytes allowed in a file handle (per RFC 1813 2.4).
-pub const MAX_FILE_HANDLE_LEN: usize = 64;
+pub const MAX_FILE_HANDLE_LEN: usize = 8;
 
 /// Maximum number of bytes allowed in a file name (per RFC 1813 2.4).
 pub const MAX_NAME_LEN: usize = 255;


### PR DESCRIPTION
Accroding to RFC 1813 fhandle size is variable and cannot be more than 64 bytes. But in practice, it is not possible to overflow 8 bytes, and it is easier to work with contant size. So we decided to set it to 8 bytes.