### PR TITLE
fix: Change count3 type from u64 to u32

### DIFF
--- a/src/vfs/read.rs
+++ b/src/vfs/read.rs
@@ -11,7 +11,7 @@ pub struct Success {
     /// The attributes of the file on completion of the read.
     pub file_attr: Option<file::Attr>,
     /// The number of bytes of data returned by the read.
-    pub count: u64,
+    pub count: u32,
     /// If the read ended at the end-of-file.
     pub eof: bool,
     /// The counted data read from the file.

--- a/src/vfs/write.rs
+++ b/src/vfs/write.rs
@@ -27,7 +27,7 @@ pub struct Success {
     /// Weak cache consistency data for the file.
     pub file_wcc: vfs::WccData,
     /// The number of bytes of data written to the file.
-    pub count: u64,
+    pub count: u32,
     /// The indication of the level of commitment of the data and metadata.
     pub commited: StableHow,
     /// TODO(what is it?)


### PR DESCRIPTION
according to rfc
```
 count3
         typedef uint32 count3;
```