### PR TITLE
refactor(VFS): Refactor NFSv3 argument structures to use DirOpArgs for operations

### DIFF
--- a/src/parser/nfsv3/create.rs
+++ b/src/parser/nfsv3/create.rs
@@ -50,8 +50,10 @@ pub fn how(src: &mut impl Read) -> Result<create::How> {
 /// Parses the arguments for an NFSv3 `CREATE` operation from the provided `Read` source.
 pub fn args(src: &mut impl Read) -> Result<create::Args> {
     Ok(create::Args {
-        dir: file::handle(src)?,
-        name: string_max_size(src, MAX_FILENAME)?,
+        object: crate::vfs::DirOpArgs {
+            dir: file::handle(src)?,
+            name: string_max_size(src, MAX_FILENAME)?,
+        },
         how: how(src)?,
     })
 }
@@ -79,8 +81,8 @@ mod tests {
 
         let result = super::args(&mut Cursor::new(DATA)).unwrap();
 
-        assert_eq!(result.dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-        assert_eq!(result.name, "file");
+        assert_eq!(result.object.dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+        assert_eq!(result.object.name, "file");
         assert!(matches!(
             result.how,
             create::How::Unchecked(set_attr::NewAttr {

--- a/src/parser/nfsv3/link.rs
+++ b/src/parser/nfsv3/link.rs
@@ -11,8 +11,10 @@ use crate::vfs::link;
 pub fn args(src: &mut impl Read) -> Result<link::Args> {
     Ok(link::Args {
         file: file::handle(src)?,
-        dir: file::handle(src)?,
-        name: string_max_size(src, MAX_FILENAME)?,
+        link: crate::vfs::DirOpArgs {
+            dir: file::handle(src)?,
+            name: string_max_size(src, MAX_FILENAME)?,
+        },
     })
 }
 
@@ -33,7 +35,7 @@ mod tests {
         let result = super::args(&mut Cursor::new(DATA)).unwrap();
 
         assert_eq!(result.file.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-        assert_eq!(result.dir.0, [0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10]);
-        assert_eq!(result.name, "link");
+        assert_eq!(result.link.dir.0, [0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10]);
+        assert_eq!(result.link.name, "link");
     }
 }

--- a/src/parser/nfsv3/mk_dir.rs
+++ b/src/parser/nfsv3/mk_dir.rs
@@ -11,8 +11,10 @@ use crate::vfs::mk_dir;
 /// Parses the arguments for an NFSv3 `MKDIR` operation from the provided `Read` source.
 pub fn args(src: &mut impl Read) -> Result<mk_dir::Args> {
     Ok(mk_dir::Args {
-        dir: file::handle(src)?,
-        name: string_max_size(src, MAX_FILENAME)?,
+        object: crate::vfs::DirOpArgs {
+            dir: file::handle(src)?,
+            name: string_max_size(src, MAX_FILENAME)?,
+        },
         attr: new_attr(src)?,
     })
 }
@@ -37,8 +39,8 @@ mod tests {
 
         let result = super::args(&mut Cursor::new(DATA)).unwrap();
 
-        assert_eq!(result.dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-        assert_eq!(result.name, "dir1");
+        assert_eq!(result.object.dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+        assert_eq!(result.object.name, "dir1");
         assert!(matches!(
             result.attr,
             set_attr::NewAttr {

--- a/src/parser/nfsv3/mk_node.rs
+++ b/src/parser/nfsv3/mk_node.rs
@@ -25,8 +25,10 @@ fn what(src: &mut impl Read) -> Result<mk_node::What> {
 /// Parses the arguments for an NFSv3 `MKNOD` operation from the provided `Read` source.
 pub fn args(src: &mut impl Read) -> Result<mk_node::Args> {
     Ok(mk_node::Args {
-        dir: file::handle(src)?,
-        name: string_max_size(src, MAX_FILENAME)?,
+        object: crate::vfs::DirOpArgs {
+            dir: file::handle(src)?,
+            name: string_max_size(src, MAX_FILENAME)?,
+        },
         what: what(src)?,
     })
 }
@@ -46,8 +48,8 @@ mod tests {
 
         let result = super::args(&mut Cursor::new(DATA)).unwrap();
 
-        assert_eq!(result.dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-        assert_eq!(result.name, "node");
+        assert_eq!(result.object.dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+        assert_eq!(result.object.name, "node");
 
         // TODO()
         // assert!(matches!(result.what, mk_node::What::Block(todo!(), todo!())));

--- a/src/parser/nfsv3/remove.rs
+++ b/src/parser/nfsv3/remove.rs
@@ -9,7 +9,12 @@ use crate::vfs::remove;
 
 /// Parses the arguments for an NFSv3 `REMOVE` operation from the provided `Read` source.
 pub fn args(src: &mut impl Read) -> Result<remove::Args> {
-    Ok(remove::Args { dir: file::handle(src)?, name: string_max_size(src, MAX_FILENAME)? })
+    Ok(remove::Args {
+        object: crate::vfs::DirOpArgs {
+            dir: file::handle(src)?,
+            name: string_max_size(src, MAX_FILENAME)?,
+        },
+    })
 }
 
 #[cfg(test)]
@@ -27,7 +32,7 @@ mod tests {
 
         let result = super::args(&mut Cursor::new(DATA)).unwrap();
 
-        assert_eq!(result.dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-        assert_eq!(result.name, "file");
+        assert_eq!(result.object.dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+        assert_eq!(result.object.name, "file");
     }
 }

--- a/src/parser/nfsv3/rename.rs
+++ b/src/parser/nfsv3/rename.rs
@@ -10,10 +10,14 @@ use crate::vfs::rename;
 /// Parses the arguments for an NFSv3 `RENAME` operation from the provided `Read` source.
 pub fn args(src: &mut impl Read) -> Result<rename::Args> {
     Ok(rename::Args {
-        from_dir: file::handle(src)?,
-        from_name: string_max_size(src, MAX_FILENAME)?,
-        to_dir: file::handle(src)?,
-        to_name: string_max_size(src, MAX_FILENAME)?,
+        from: crate::vfs::DirOpArgs {
+            dir: file::handle(src)?,
+            name: string_max_size(src, MAX_FILENAME)?,
+        },
+        to: crate::vfs::DirOpArgs {
+            dir: file::handle(src)?,
+            name: string_max_size(src, MAX_FILENAME)?,
+        },
     })
 }
 
@@ -34,9 +38,9 @@ mod tests {
 
         let result = super::args(&mut Cursor::new(DATA)).unwrap();
 
-        assert_eq!(result.from_dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-        assert_eq!(result.from_name, "oldn");
-        assert_eq!(result.to_dir.0, [0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10]);
-        assert_eq!(result.to_name, "newn");
+        assert_eq!(result.from.dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+        assert_eq!(result.from.name, "oldn");
+        assert_eq!(result.to.dir.0, [0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10]);
+        assert_eq!(result.to.name, "newn");
     }
 }

--- a/src/parser/nfsv3/rm_dir.rs
+++ b/src/parser/nfsv3/rm_dir.rs
@@ -9,7 +9,12 @@ use crate::vfs::rm_dir;
 
 /// Parses the arguments for an NFSv3 `RMDIR` operation from the provided `Read` source.
 pub fn args(src: &mut impl Read) -> Result<rm_dir::Args> {
-    Ok(rm_dir::Args { dir: file::handle(src)?, name: string_max_size(src, MAX_FILENAME)? })
+    Ok(rm_dir::Args {
+        object: crate::vfs::DirOpArgs {
+            dir: file::handle(src)?,
+            name: string_max_size(src, MAX_FILENAME)?,
+        },
+    })
 }
 
 #[cfg(test)]
@@ -27,7 +32,7 @@ mod tests {
 
         let result = super::args(&mut Cursor::new(DATA)).unwrap();
 
-        assert_eq!(result.dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-        assert_eq!(result.name, "dir1");
+        assert_eq!(result.object.dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+        assert_eq!(result.object.name, "dir1");
     }
 }

--- a/src/parser/nfsv3/symlink.rs
+++ b/src/parser/nfsv3/symlink.rs
@@ -11,8 +11,10 @@ use crate::vfs::symlink;
 /// Parses the arguments for an NFSv3 `SYMLINK` operation from the provided `Read` source.
 pub fn args(src: &mut impl Read) -> Result<symlink::Args> {
     Ok(symlink::Args {
-        dir: file::handle(src)?,
-        name: string_max_size(src, MAX_FILENAME)?,
+        object: crate::vfs::DirOpArgs {
+            dir: file::handle(src)?,
+            name: string_max_size(src, MAX_FILENAME)?,
+        },
         attr: new_attr(src)?,
         path: path(src)?,
     })
@@ -40,8 +42,8 @@ mod tests {
 
         let result = super::args(&mut Cursor::new(DATA)).unwrap();
 
-        assert_eq!(result.dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-        assert_eq!(result.name, "link");
+        assert_eq!(result.object.dir.0, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+        assert_eq!(result.object.name, "link");
         assert!(matches!(
             result.attr,
             set_attr::NewAttr {

--- a/src/vfs/create.rs
+++ b/src/vfs/create.rs
@@ -60,10 +60,8 @@ pub trait Promise {
 
 /// [`Create::create`] arguments.
 pub struct Args {
-    /// The file handle for the directory in which the file is to be created.
-    pub dir: file::Handle,
-    /// The name that is to be associated with the created file.
-    pub name: String,
+    /// The location of the file to be created.
+    pub object: vfs::DirOpArgs,
     /// The file creation mode. See [`How`] documentation.
     pub how: How,
 }

--- a/src/vfs/link.rs
+++ b/src/vfs/link.rs
@@ -36,19 +36,17 @@ pub trait Promise {
 pub struct Args {
     /// The file handle for the existing file system object.
     pub file: file::Handle,
-    /// The file handle for the directory in which the link is to be created.
-    pub dir: file::Handle,
-    /// The name that is to be associated with the created link.
-    pub name: String,
+    /// The location of the link to be created
+    pub link: vfs::DirOpArgs,
 }
 
 #[async_trait]
 pub trait Link {
-    /// Creates a hard link from [`Args::file`] to [`Args::name`], in the directory, [`Args::dir`].
+    /// Creates a hard link from [`Args::file`] to [`Args::link`], in the directory.
     ///
     /// Changes to any property of the hard-linked files are reflected in all of the linked files.
     ///
-    /// [`Args::file`] and [`Args::dir`] must reside on the same file system and server, means
+    /// [`Args::file`] and [`Args::link`] must reside on the same file system and server, means
     /// that the fsid fields in the attributes for the directories are the same. If they reside on different file systems,
     /// the error, [`vfs::Error::XDev`], is returned.
     ///

--- a/src/vfs/mk_dir.rs
+++ b/src/vfs/mk_dir.rs
@@ -12,7 +12,7 @@ pub struct Success {
     pub file: Option<file::Handle>,
     /// The attributes for the newly created subdirectory.
     pub attr: Option<file::Attr>,
-    /// Weak cache consistency data for the [`Args::dir`].
+    /// Weak cache consistency data for the [`Args::object`] dir.
     pub wcc_data: vfs::WccData,
 }
 
@@ -20,7 +20,7 @@ pub struct Success {
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,
-    /// Weak cache consistency data for the directory, [`Args::dir`].
+    /// Weak cache consistency data for the directory, [`Args::object`] dir.
     pub dir_wcc: vfs::WccData,
 }
 
@@ -34,10 +34,8 @@ pub trait Promise {
 
 /// [`MkDir::mk_dir`] arguments.
 pub struct Args {
-    /// The file handle for the directory in which the subdirectory is to be created.
-    pub dir: file::Handle,
-    /// The name that is to be associated with the created subdirectory.
-    pub name: String,
+    /// The location of the subdirectory to be created.
+    pub object: vfs::DirOpArgs,
     /// The initial attributes for the subdirectory.
     pub attr: super::set_attr::NewAttr,
 }

--- a/src/vfs/mk_node.rs
+++ b/src/vfs/mk_node.rs
@@ -54,10 +54,8 @@ pub trait Promise {
 
 /// [`MkNode::mk_node`] arguments.
 pub struct Args {
-    /// The file handle for the directory in which the special file is to be created.
-    pub dir: file::Handle,
-    /// The name that is to be associated with the created special file.
-    pub name: String,
+    /// The location of the special file to be created
+    pub object: vfs::DirOpArgs,
     /// The type of the special file to be created. See [`What`].
     pub what: What,
 }

--- a/src/vfs/mod.rs
+++ b/src/vfs/mod.rs
@@ -137,13 +137,15 @@ pub struct WccData {
     pub after: Option<file::Attr>,
 }
 
-/// This struct represents diropargs3 from NFS3
+/// This struct represents the generic `diropargs3` structure from NFSv3.
 ///
-/// Can be foud in NFS3 RFC 1813, <https://datatracker.ietf.org/doc/html/rfc1813#autoid-15>
+/// It is used by several directory operations (for example, create, mkdir, rmdir,
+/// remove, symlink, mknod, link, and rename). See NFSv3 RFC 1813:
+/// <https://datatracker.ietf.org/doc/html/rfc1813#autoid-15>
 pub struct DirOpArgs {
-    /// The file handle for the directory from which the subdirectory is to be removed.
+    /// The file handle for the directory.
     pub dir: file::Handle,
-    /// The name of the subdirectory to be removed.
+    /// The name of the entry within the directory.
     pub name: String,
 }
 

--- a/src/vfs/mod.rs
+++ b/src/vfs/mod.rs
@@ -137,4 +137,14 @@ pub struct WccData {
     pub after: Option<file::Attr>,
 }
 
+/// This struct represents diropargs3 from NFS3
+///
+/// Can be foud in NFS3 RFC 1813, <https://datatracker.ietf.org/doc/html/rfc1813#autoid-15>
+pub struct DirOpArgs {
+    /// The file handle for the directory from which the subdirectory is to be removed.
+    pub dir: file::Handle,
+    /// The name of the subdirectory to be removed.
+    pub name: String,
+}
+
 pub trait Vfs {}

--- a/src/vfs/remove.rs
+++ b/src/vfs/remove.rs
@@ -4,8 +4,6 @@ use async_trait::async_trait;
 
 use crate::vfs::{self};
 
-use super::file;
-
 /// Success result.
 pub struct Success {
     /// Weak cache consistency data for the directory.
@@ -16,7 +14,7 @@ pub struct Success {
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,
-    /// Weak cache consistency data for the directory, where.dir.
+    /// Weak cache consistency data for the directory, [`Args::object`] dir.
     /// TODO(use Args structure).
     pub dir_wcc: vfs::WccData,
 }
@@ -31,10 +29,8 @@ pub trait Promise {
 
 /// [`Remove::remove`] arguments.
 pub struct Args {
-    /// The file handle for the directory from which the entry is to be removed.
-    pub dir: file::Handle,
-    /// The name of the entry to be removed.
-    pub name: String,
+    /// A [`vfs::DirOpArgs`] structure identifying the entry to be removed.
+    pub object: vfs::DirOpArgs,
 }
 
 #[async_trait]

--- a/src/vfs/rename.rs
+++ b/src/vfs/rename.rs
@@ -4,8 +4,6 @@ use async_trait::async_trait;
 
 use crate::vfs::{self};
 
-use super::file;
-
 /// Success result.
 pub struct Success {
     /// Weak cache consistency data for the directory, `from_dir`.
@@ -34,14 +32,12 @@ pub trait Promise {
 
 /// [`Rename::rename`] arguments.
 pub struct Args {
-    /// The file handle for the directory from which the entry is to be renamed.
-    pub from_dir: file::Handle,
-    /// The name of the entry that identifies the object to be renamed.
-    pub from_name: String,
-    /// The file handle for the directory to which the object is to be renamed.
-    pub to_dir: file::Handle,
-    /// The new name for the object.
-    pub to_name: String,
+    /// A [`vfs::DirOpArgs`] structure identifying the source (the file
+    /// system object to be re-named)
+    pub from: vfs::DirOpArgs,
+    /// A [`vfs::DirOpArgs`] structure identifying the target (the new
+    /// name of the object):
+    pub to: vfs::DirOpArgs,
 }
 
 #[async_trait]
@@ -50,7 +46,7 @@ pub trait Rename {
     ///
     /// The operation is required to be atomic to the client.
     ///
-    /// [`Args::to_dir`] and [`Args::from_dir`] must reside on the same file system and server,
+    /// [`Args::to`] and [`Args::from`] must reside on the same file system and server,
     /// means that the fsid fields in the attributes for the directories are the same. If they
     /// reside on different file systems, the error, [`vfs::Error::XDev`], is returned.
     ///
@@ -61,12 +57,12 @@ pub trait Rename {
     /// strongly encouraged to attempt to keep file handles from becoming stale in this fashion.
     ///
     /// On some servers, the filenames, "." and "..", are illegal as either from.name or to.name.
-    /// In addition, neither [`Args::from_name`] nor [`Args::to_name`] can be an alias for
-    /// [`Args::from_dir`]. These servers will return the error, [`vfs::Error::InvalidArgument`],
+    /// In addition, neither [`Args::from`] nor [`Args::to`]  names can be an alias for
+    /// [`Args::from`] dir. These servers will return the error, [`vfs::Error::InvalidArgument`],
     /// in these cases.
     ///
-    /// If the directory, [`Args::to_dir`], already contains an entry with the name,
-    /// [`Args::to_name`], the source object must be compatible with the target: either both are
+    /// If the directory, [`Args::to`] dir, already contains an entry with the name,
+    /// [`Args::to`] name, the source object must be compatible with the target: either both are
     /// non-directories or both are directories and the target must be empty. If compatible, the
     /// existing target is removed before the rename occurs. If they are not compatible or if the
     /// target is a directory but not empty, the server should return the error,

--- a/src/vfs/rm_dir.rs
+++ b/src/vfs/rm_dir.rs
@@ -4,8 +4,6 @@ use async_trait::async_trait;
 
 use crate::vfs;
 
-use super::file;
-
 /// Success result.
 pub struct Success {
     /// Weak cache consistency data for the directory.
@@ -31,10 +29,9 @@ pub trait Promise {
 
 /// [`RmDir::rm_dir`] arguments.
 pub struct Args {
-    /// The file handle for the directory from which the subdirectory is to be removed.
-    pub dir: file::Handle,
-    /// The name of the subdirectory to be removed.
-    pub name: String,
+    /// A [`vfs::DirOpArgs`] structure identifying the directory entry
+    /// to be removed.
+    pub object: vfs::DirOpArgs,
 }
 
 #[async_trait]

--- a/src/vfs/symlink.rs
+++ b/src/vfs/symlink.rs
@@ -37,10 +37,8 @@ pub trait Promise {
 
 /// [`Symlink::symlink`] arguments.
 pub struct Args {
-    /// The file handle for the directory in which the symbolic link to be created.
-    pub dir: file::Handle,
-    /// The name that is to be associated with the created symbolic link.
-    pub name: String,
+    /// The location of the symbolic link to be created.
+    pub object: vfs::DirOpArgs,
     /// The initial attributes for the symbolic link.
     pub attr: super::set_attr::NewAttr,
     /// The symbolic link data.


### PR DESCRIPTION
No functional changes, just move `name` and `dir` from `Args`  to its type `diropargs3` that provides control types from one place

And fix tests to pass, just refactor types