### PR TITLE
Splitting RPC errors from 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,3 @@
 *secrets*.csv
 .env.local
 .env.production
-
-/fuzz

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 *secrets*.csv
 .env.local
 .env.production
+
+/fuzz

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10,10 +10,7 @@ mod rpc;
 #[cfg(test)]
 mod tests;
 
-use std::future::Future;
-
 use crate::parser::mount::{MountArgs, UnmountArgs};
-use crate::rpc::Error;
 use crate::vfs::{
     access, commit, create, fs_info, fs_stat, get_attr, link, lookup, mk_dir, mk_node, path_conf,
     read, read_dir, read_dir_plus, read_link, remove, rename, rm_dir, set_attr, symlink, write,
@@ -22,14 +19,15 @@ use crate::vfs::{
 /// Result of parsing operations with errors type [`Error`].
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Helper function to process nested errors.
-/// Function takes `future` to call. If result is `OK`, discards it, and returns `error`.
-/// If `future` returns error - returns new one, rather than `error`
-pub async fn proc_nested_errors<T>(error: Error, future: impl Future<Output = Result<T>>) -> Error {
-    match future.await {
-        Ok(_) => error,
-        Err(err) => err,
-    }
+#[derive(PartialEq, Debug)]
+pub enum Error {
+    UnexpectedEof,
+    ConnectionClosed,
+    IncorrectData,
+    InvalidState,
+    TooMany,
+    OutOfMemory,
+    Other,
 }
 
 /// Enumerates the different types of arguments that can be parsed.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -19,14 +19,22 @@ use crate::vfs::{
 /// Result of parsing operations with errors type [`Error`].
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Errors that can occur during parsing.
 #[derive(PartialEq, Debug)]
 pub enum Error {
+    /// An error returned when an operation could not be completed because an “end of file” was reached prematurely.
     UnexpectedEof,
+    /// Underlying socket was closed by remote source
     ConnectionClosed,
+    /// Incorrect value, though correctly parsed
     IncorrectData,
+    /// Side effect error occur during parsing
     InvalidState,
+    /// Size of underlying type with dynamic size (like vector or array) is too big
     TooMany,
+    /// An operation could not be completed, because it failed to allocate enough memory.
     OutOfMemory,
+    /// Other error
     Other,
 }
 

--- a/src/parser/nfsv3/create.rs
+++ b/src/parser/nfsv3/create.rs
@@ -29,7 +29,7 @@ pub fn set_time(src: &mut impl Read) -> Result<SetTime> {
         0 => Ok(SetTime::DontChange),
         1 => Ok(SetTime::ToServer),
         2 => Ok(SetTime::ToClient(nfs_time(src)?)),
-        _ => Err(Error::EnumDiscMismatch),
+        _ => Err(Error::IncorrectData),
     }
 }
 
@@ -44,7 +44,7 @@ pub fn how(src: &mut impl Read) -> Result<create::How> {
         0 => Ok(create::How::Unchecked(new_attr(src)?)),
         1 => Ok(create::How::Guarded(new_attr(src)?)),
         2 => Ok(create::How::Exclusive(Verifier(array::<{ VERIFY_LEN }>(src)?))),
-        _ => Err(Error::EnumDiscMismatch),
+        _ => Err(Error::IncorrectData),
     }
 }
 
@@ -139,6 +139,6 @@ mod tests {
     fn test_how_failure() {
         const DATA: &[u8] = &[0x00, 0x00, 0x00, 0x03];
 
-        assert!(matches!(super::how(&mut Cursor::new(DATA)), Err(Error::EnumDiscMismatch)));
+        assert!(matches!(super::how(&mut Cursor::new(DATA)), Err(Error::IncorrectData)));
     }
 }

--- a/src/parser/nfsv3/mk_node.rs
+++ b/src/parser/nfsv3/mk_node.rs
@@ -19,7 +19,7 @@ fn what(src: &mut impl Read) -> Result<mk_node::What> {
         5 => Ok(What::SymbolicLink),
         6 => Ok(What::Socket(new_attr(src)?)),
         7 => Ok(What::Fifo(new_attr(src)?)),
-        _ => Err(Error::EnumDiscMismatch),
+        _ => Err(Error::IncorrectData),
     }
 }
 

--- a/src/parser/nfsv3/read.rs
+++ b/src/parser/nfsv3/read.rs
@@ -43,6 +43,6 @@ mod tests {
         ];
 
         let result = super::args(&mut Cursor::new(DATA));
-        assert!(matches!(result, Err(Error::IO(_))));
+        assert!(matches!(result, Err(Error::UnexpectedEof)));
     }
 }

--- a/src/parser/nfsv3/set_attr.rs
+++ b/src/parser/nfsv3/set_attr.rs
@@ -73,7 +73,7 @@ mod tests {
         ];
 
         let result = super::args(&mut Cursor::new(DATA));
-        assert!(matches!(result, Err(Error::IO(_))));
+        assert!(matches!(result, Err(Error::UnexpectedEof)));
     }
 
     #[test]
@@ -109,7 +109,7 @@ mod tests {
     fn test_set_time_failure() {
         const DATA: &[u8] = &[0x00, 0x00, 0x00, 0x03];
 
-        assert!(matches!(set_time(&mut Cursor::new(DATA)), Err(Error::EnumDiscMismatch)));
+        assert!(matches!(set_time(&mut Cursor::new(DATA)), Err(Error::IncorrectData)));
     }
 
     #[test]

--- a/src/parser/parser_struct.rs
+++ b/src/parser/parser_struct.rs
@@ -13,7 +13,7 @@
 //! supporting retry logic for parsing operations that may need additional data.
 
 use std::cmp::min;
-use std::io::{self, ErrorKind};
+use std::future::Future;
 use std::num::NonZeroUsize;
 
 use tokio::io::AsyncRead;
@@ -29,9 +29,9 @@ use crate::parser::nfsv3::{
 use crate::parser::primitive::{u32, u32_as_usize, ALIGNMENT};
 use crate::parser::read_buffer::CountBuffer;
 use crate::parser::rpc::{auth, RpcMessage};
-use crate::parser::{proc_nested_errors, Arguments, Error, Result};
-use crate::rpc::{AuthFlavor, AuthStat, RpcBody, VersionMismatch, RPC_VERSION};
-use crate::vfs;
+use crate::parser::Arguments;
+use crate::rpc::{AuthFlavor, AuthStat, Error, Result, RpcBody, VersionMismatch, RPC_VERSION};
+use crate::{parser, vfs};
 
 const RMS_HEADER_SIZE: usize = size_of::<u32>();
 
@@ -39,6 +39,19 @@ const RMS_HEADER_SIZE: usize = size_of::<u32>();
 /// with NFSv3 or Mount protocol arguments, except for NFSv3 `WRITE` procedure -
 /// this size is enough to hold only arguments without opaque data ([`Slice`] in [`vfs::write::Args`])
 const DEFAULT_SIZE: usize = 2500;
+
+/// Helper function to process nested errors.
+/// Function takes `future` to call. If result is `OK`, discards it, and returns `error`.
+/// If `future` returns error - returns new one, rather than `error`
+pub async fn proc_nested_errors<T>(
+    error: Error,
+    future: impl Future<Output = Result<T>>,
+) -> crate::rpc::Error {
+    match future.await {
+        Ok(_) => error,
+        Err(err) => err,
+    }
+}
 
 /// Parser for RPC messages over async streams.
 ///
@@ -133,25 +146,16 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
         self.last = header & 0x8000_0000 != 0;
         self.current_frame_size = (header & 0x7FFF_FFFF) as usize;
 
-        if self.current_frame_size < std::mem::size_of::<u32>() {
-            return Err(Error::IO(io::Error::new(
-                ErrorKind::InvalidData,
-                "Frame size must include XID",
-            )));
+        if self.current_frame_size < size_of::<u32>() {
+            return Err(Error::IncorrectMessage);
         }
         if self.current_frame_size > DEFAULT_SIZE {
-            return Err(Error::IO(io::Error::new(
-                ErrorKind::InvalidData,
-                "Frame exceeds maximum supported length",
-            )));
+            return Err(Error::IncorrectMessage);
         }
 
         // this is temporal check, apparently this will go to separate object Validator
         if !self.last {
-            return Err(Error::IO(io::Error::new(
-                ErrorKind::Unsupported,
-                "Fragmented messages not supported",
-            )));
+            return Err(Error::IncorrectMessage);
         }
         let _xid = self.buffer.parse_with_retry(u32).await?;
         Ok(())
@@ -346,17 +350,13 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
         // CountBuffer keep count of bytes, read from it,
         // but first u32 of message - header that shouldn't be counted
         // https://datatracker.ietf.org/doc/html/rfc5531#section-11
-        let bytes_consumed = self.buffer.total_bytes().checked_sub(RMS_HEADER_SIZE).ok_or(
-            Error::IO(io::Error::new(
-                ErrorKind::InvalidData,
-                "Consumed bytes are less than RMS header size",
-            )),
-        )?;
+        let bytes_consumed = self
+            .buffer
+            .total_bytes()
+            .checked_sub(RMS_HEADER_SIZE)
+            .ok_or(Error::IncorrectMessage)?;
         if bytes_consumed != self.current_frame_size {
-            return Err(Error::IO(io::Error::new(
-                ErrorKind::InvalidData,
-                "Unparsed data remaining in frame",
-            )));
+            return Err(Error::IncorrectMessage);
         }
 
         self.buffer.clean();
@@ -408,11 +408,8 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
         // https://datatracker.ietf.org/doc/html/rfc5531#section-11
         let remaining = (self.current_frame_size + RMS_HEADER_SIZE)
             .checked_sub(self.buffer.total_bytes())
-            .ok_or(Error::IO(io::Error::new(
-                ErrorKind::InvalidData,
-                "Consumed more bytes than RMS header suggests",
-            )))?;
-        self.buffer.discard_bytes(remaining).await.map_err(Error::IO)?;
+            .ok_or(Error::IncorrectMessage)?;
+        self.buffer.discard_bytes(remaining).await.map_err(Error::ServerFailure)?;
         self.finalize_parsing()?;
         Ok(())
     }
@@ -448,9 +445,10 @@ async fn adapter_for_write<S: AsyncRead + Unpin>(
 
     // Attempt allocation with the given size, or fallback to NonZeroUsize::MIN.
     let non_zero_size = NonZeroUsize::new(size).unwrap_or(NonZeroUsize::MIN);
-    let mut slice = alloc.allocate(non_zero_size).await.ok_or_else(|| {
-        Error::IO(io::Error::new(ErrorKind::OutOfMemory, "cannot allocate memory"))
-    })?;
+    let mut slice = alloc
+        .allocate(non_zero_size)
+        .await
+        .ok_or(Error::ServerFailure(parser::Error::OutOfMemory))?;
 
     // Calculate necessary padding to maintain ALIGNMENT
     let padding = (ALIGNMENT - (size % ALIGNMENT)) % ALIGNMENT;
@@ -462,7 +460,7 @@ async fn adapter_for_write<S: AsyncRead + Unpin>(
     }
 
     // Discard any trailing padding bytes after the data.
-    buffer.discard_bytes(padding).await.map_err(Error::IO)?;
+    buffer.discard_bytes(padding).await.map_err(Error::ServerFailure)?;
     Ok(vfs::write::Args {
         file: part_arg.file,
         offset: part_arg.offset,
@@ -501,16 +499,14 @@ pub async fn read_in_slice_async<S: AsyncRead + Unpin>(
     for buf in slice.iter_mut() {
         let in_cur = min(left_skip, buf.len());
         if left_skip > 0 && in_cur == buf.len() {
-            left_skip = left_skip
-                .checked_sub(in_cur)
-                .ok_or(Error::IO(io::Error::new(ErrorKind::InvalidInput, "invalid buffer size")))?;
+            left_skip = left_skip.checked_sub(in_cur).ok_or(Error::IncorrectMessage)?;
             continue;
         }
         let cur_write = min(left_skip + left_write, buf.len() - left_skip);
-        src.read_from_async(&mut buf[left_skip..left_skip + cur_write]).await.map_err(Error::IO)?;
-        left_write = left_write
-            .checked_sub(cur_write)
-            .ok_or(Error::IO(io::Error::new(ErrorKind::InvalidInput, "invalid buffer size")))?;
+        src.read_from_async(&mut buf[left_skip..left_skip + cur_write])
+            .await
+            .map_err(Error::ServerFailure)?;
+        left_write = left_write.checked_sub(cur_write).ok_or(Error::IncorrectMessage)?;
         left_skip = 0;
     }
     Ok(to_write - left_write)
@@ -547,17 +543,14 @@ pub fn read_in_slice_sync<S: AsyncRead + Unpin>(
             let n = match src.read_from_inner(&mut buf[read_count..block_size]) {
                 Ok(0) => return Ok(real_size),
                 Ok(n) => n,
-                Err(e) => return Err(Error::IO(e)),
+                Err(e) => return Err(Error::ServerFailure(e)),
             };
             read_count += n;
             real_size += n;
         }
     }
     if real_size != left_size {
-        return Err(Error::IO(io::Error::new(
-            ErrorKind::InvalidInput,
-            "invalid amount of data read",
-        )));
+        return Err(Error::IncorrectMessage);
     }
     Ok(real_size)
 }

--- a/src/parser/read_buffer.rs
+++ b/src/parser/read_buffer.rs
@@ -15,7 +15,9 @@ use std::io::{ErrorKind, Read};
 
 use tokio::io::{AsyncRead, AsyncReadExt};
 
+use crate::parser::Error::InvalidState;
 use crate::parser::{Error, Result};
+use crate::rpc;
 
 /// A buffered reader that wraps an async stream and provides synchronous reading
 /// with retry capability.
@@ -75,14 +77,21 @@ impl<S: AsyncRead + Unpin> CountBuffer<S> {
     /// connection is closed or an I/O error occurs.
     ///
     /// Returns `Ok(0)` if the write buffer is full and no more data can be read.
-    async fn fill_internal(&mut self) -> io::Result<usize> {
+    async fn fill_internal(&mut self) -> Result<usize> {
         if self.bufs[self.write].available_write() == 0 {
             return Ok(0);
         }
 
-        let bytes_read = self.socket.read(self.bufs[self.write].write_slice()).await?;
+        let bytes_read =
+            self.socket.read(self.bufs[self.write].write_slice()).await.map_err(|e| {
+                if e.kind() == ErrorKind::UnexpectedEof {
+                    Error::UnexpectedEof
+                } else {
+                    Error::Other
+                }
+            })?;
         if bytes_read == 0 {
-            return Err(io::Error::new(ErrorKind::UnexpectedEof, "Connection closed"));
+            return Err(Error::ConnectionClosed);
         }
 
         self.bufs[self.write].extend(bytes_read);
@@ -111,20 +120,20 @@ impl<S: AsyncRead + Unpin> CountBuffer<S> {
     pub async fn parse_with_retry<T>(
         &mut self,
         caller: impl Fn(&mut Self) -> Result<T>,
-    ) -> Result<T> {
+    ) -> rpc::Result<T> {
         let retry_start_read = self.bufs[self.read].bytes_read();
         let retry_start_write = self.bufs[self.write].bytes_read();
         let retry_total = self.total_bytes;
         // there is no need to check if we reach end of buffer while appending data to buffer since we have buffer, that would
         // definitely be enough to read what we are planning
         match caller(self) {
-            Err(Error::IO(err)) if err.kind() == ErrorKind::UnexpectedEof => {
+            Err(Error::UnexpectedEof) => {
                 self.retry_mode = true;
                 // called whenever we need to read more data
                 match self.fill_internal().await {
                     Ok(0) => {
                         // it is impossible scenario?
-                        Err(Error::IO(err))
+                        Err(rpc::Error::ServerFailure(Error::UnexpectedEof))
                     }
                     Ok(_) => {
                         self.bufs[self.read].reset_read(retry_start_read);
@@ -132,7 +141,7 @@ impl<S: AsyncRead + Unpin> CountBuffer<S> {
                         self.total_bytes = retry_total;
                         Box::pin(self.parse_with_retry(caller)).await
                     }
-                    Err(e) => Err(Error::IO(e)),
+                    Err(e) => Err(rpc::Error::ServerFailure(e)),
                 }
             }
             Ok(val) => {
@@ -142,14 +151,12 @@ impl<S: AsyncRead + Unpin> CountBuffer<S> {
                     self.read = (self.read + 1) % 2;
                 }
                 if self.read == self.write {
-                    return Err(Error::IO(io::Error::other(
-                        "Cannot read and write to one buffer simultaneously",
-                    )));
+                    return Err(rpc::Error::ServerFailure(Error::InvalidState));
                 }
                 self.retry_mode = false;
                 Ok(val)
             }
-            Err(err) => Err(err),
+            Err(err) => Err(rpc::Error::ServerFailure(err)),
         }
     }
 
@@ -166,8 +173,14 @@ impl<S: AsyncRead + Unpin> CountBuffer<S> {
     ///
     /// Returns the number of bytes read (equal to `dest.len()`), or an error
     /// if the connection is closed before the buffer can be filled.
-    pub(super) async fn read_from_async(&mut self, dest: &mut [u8]) -> io::Result<usize> {
-        self.socket.read_exact(dest).await?;
+    pub(super) async fn read_from_async(&mut self, dest: &mut [u8]) -> Result<usize> {
+        self.socket.read_exact(dest).await.map_err(|e| {
+            if e.kind() == ErrorKind::UnexpectedEof {
+                Error::UnexpectedEof
+            } else {
+                Error::Other
+            }
+        })?;
         self.total_bytes += dest.len();
         Ok(dest.len())
     }
@@ -193,11 +206,11 @@ impl<S: AsyncRead + Unpin> CountBuffer<S> {
     ///
     /// Returns the number of bytes read, which may be less than `dest.len()`
     /// if not enough data is available in the internal buffers.
-    pub(super) fn read_from_inner(&mut self, dest: &mut [u8]) -> io::Result<usize> {
+    pub(super) fn read_from_inner(&mut self, dest: &mut [u8]) -> Result<usize> {
         if dest.is_empty() {
             return Ok(0);
         }
-        self.read(dest)
+        self.read(dest).map_err(|_| Error::UnexpectedEof)
     }
 
     /// Returns the total number of bytes consumed from the stream since the last reset.
@@ -222,7 +235,7 @@ impl<S: AsyncRead + Unpin> CountBuffer<S> {
     ///
     /// Returns `Ok(())` if exactly `n` bytes were discarded, or an error if
     /// the connection is closed before all bytes can be discarded.
-    pub(super) async fn discard_bytes(&mut self, n: usize) -> io::Result<()> {
+    pub(super) async fn discard_bytes(&mut self, n: usize) -> Result<()> {
         let from_inner = {
             let from_inner1 = min(self.bufs[self.read].available_read(), n);
             self.bufs[self.read].consume(from_inner1);
@@ -242,7 +255,10 @@ impl<S: AsyncRead + Unpin> CountBuffer<S> {
         let mut actual = 0;
 
         loop {
-            let n = src.read(self.bufs[self.write].write_slice()).await?;
+            let n = src
+                .read(self.bufs[self.write].write_slice())
+                .await
+                .map_err(|_| Error::UnexpectedEof)?;
             if n == 0 {
                 break;
             }
@@ -253,10 +269,7 @@ impl<S: AsyncRead + Unpin> CountBuffer<S> {
 
         // probably useless, since we have guarantees from Take
         if actual != from_socket {
-            return Err(io::Error::new(
-                ErrorKind::InvalidData,
-                "Discarded not valid amount of bytes",
-            ));
+            return Err(InvalidState);
         }
 
         Ok(())

--- a/src/parser/tests/parser_struct.rs
+++ b/src/parser/tests/parser_struct.rs
@@ -2,7 +2,7 @@ use crate::parser::parser_struct::RpcParser;
 use crate::parser::tests::allocator::MockAllocator;
 use crate::parser::tests::socket::MockSocket;
 use crate::parser::Arguments;
-use crate::parser::Error;
+use crate::rpc;
 
 /// Constants for mock RPC/NFS test input construction.
 const XID: u32 = 1;
@@ -245,7 +245,7 @@ async fn parse_error_when_consumed_exceeds_frame_size() {
 
     let result = parser.parse_message().await;
     let error = result.err().unwrap();
-    assert!(matches!(error, Error::IO(io_err) if io_err.kind() == std::io::ErrorKind::InvalidData));
+    assert!(matches!(error, rpc::Error::IncorrectMessage));
 }
 
 #[tokio::test]
@@ -263,7 +263,7 @@ async fn parse_error_with_too_small_frame_size_returns_error() {
     let mut parser = RpcParser::with_capacity(socket, alloc, 32);
 
     let result = parser.parse_message().await;
-    assert!(matches!(result, Err(Error::IO(_))));
+    assert!(matches!(result, Err(rpc::Error::IncorrectMessage)));
 }
 
 #[tokio::test]
@@ -287,7 +287,7 @@ async fn parse_rejects_any_non_call_message_type() {
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x35);
 
     let result = parser.parse_message().await;
-    assert!(matches!(result, Err(Error::MessageTypeMismatch)));
+    assert!(matches!(result, Err(rpc::Error::MessageTypeMismatch)));
 }
 
 /// Ensures parser rejects fragments with size below XID width.
@@ -303,7 +303,7 @@ async fn parse_rejects_frame_smaller_than_xid() {
 
     let result = parser.parse_message().await;
     let error = result.err().unwrap();
-    assert!(matches!(error, Error::IO(err) if err.kind() == std::io::ErrorKind::InvalidData));
+    assert!(matches!(error, rpc::Error::IncorrectMessage));
 }
 
 /// Ensures parser rejects fragments above configured maximum size.
@@ -319,7 +319,7 @@ async fn parse_rejects_too_large_frame() {
 
     let result = parser.parse_message().await;
     let error = result.err().unwrap();
-    assert!(matches!(error, Error::IO(err) if err.kind() == std::io::ErrorKind::InvalidData));
+    assert!(matches!(error, rpc::Error::IncorrectMessage));
 }
 
 /// Verifies parser handles WRITE with zero opaque payload.

--- a/src/parser/tests/parser_struct.rs
+++ b/src/parser/tests/parser_struct.rs
@@ -245,7 +245,7 @@ async fn parse_error_when_consumed_exceeds_frame_size() {
 
     let result = parser.parse_message().await;
     let error = result.err().unwrap();
-    assert!(matches!(error, rpc::Error::IncorrectMessage));
+    assert!(matches!(error, rpc::Error::ServerFailure));
 }
 
 #[tokio::test]
@@ -263,7 +263,7 @@ async fn parse_error_with_too_small_frame_size_returns_error() {
     let mut parser = RpcParser::with_capacity(socket, alloc, 32);
 
     let result = parser.parse_message().await;
-    assert!(matches!(result, Err(rpc::Error::IncorrectMessage)));
+    assert!(matches!(result, Err(rpc::Error::ServerFailure)));
 }
 
 #[tokio::test]
@@ -303,7 +303,7 @@ async fn parse_rejects_frame_smaller_than_xid() {
 
     let result = parser.parse_message().await;
     let error = result.err().unwrap();
-    assert!(matches!(error, rpc::Error::IncorrectMessage));
+    assert!(matches!(error, rpc::Error::ServerFailure));
 }
 
 /// Ensures parser rejects fragments above configured maximum size.
@@ -319,7 +319,7 @@ async fn parse_rejects_too_large_frame() {
 
     let result = parser.parse_message().await;
     let error = result.err().unwrap();
-    assert!(matches!(error, rpc::Error::IncorrectMessage));
+    assert!(matches!(error, rpc::Error::ServerFailure));
 }
 
 /// Verifies parser handles WRITE with zero opaque payload.

--- a/src/parser/tests/primitive.rs
+++ b/src/parser/tests/primitive.rs
@@ -41,7 +41,7 @@ fn test_u8_array_padding_error() {
         src.write_u8(*i).unwrap();
     }
     let result = array::<3>(&mut Cursor::new(src));
-    assert!(matches!(result, Err(Error::IncorrectPadding)));
+    assert!(matches!(result, Err(Error::UnexpectedEof)));
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn test_u8_array_miss_elements() {
     let mut src = Vec::new();
     let _ = init.map(|i| src.write_u8(i).unwrap());
     let result = array::<4>(&mut Cursor::new(src));
-    assert!(matches!(result, Err(Error::IO(_))));
+    assert!(matches!(result, Err(Error::UnexpectedEof)));
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn test_string_utf8_error() {
     src.extend_from_slice(&invalid_utf8);
     src.push(0);
     let result = string(&mut Cursor::new(src));
-    assert!(matches!(result, Err(Error::IncorrectString(_))));
+    assert!(matches!(result, Err(Error::IncorrectData)));
 }
 
 #[test]
@@ -96,7 +96,7 @@ fn test_string_with_max_len_too_long() {
     src.extend(vec![0u8; padding_len]);
 
     let result = string_max_size(&mut Cursor::new(src), 10);
-    assert!(matches!(result, Err(Error::MaxElemLimit)));
+    assert!(matches!(result, Err(Error::TooMany)));
 }
 
 #[test]
@@ -104,5 +104,5 @@ fn test_read_error() {
     let mut src = Vec::new();
     src.write_u32::<BigEndian>(10).unwrap();
     let result = vector(&mut Cursor::new(src));
-    assert!(matches!(result, Err(Error::IO(_))));
+    assert!(matches!(result, Err(Error::UnexpectedEof)));
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -81,11 +81,15 @@ pub struct VersionMismatch {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Errors that can occur during parsing.
+/// Errors that can occur during processing of incoming request.
 #[derive(Debug)]
 pub enum Error {
-    IncorrectMessage,
-    ServerFailure(parser::Error),
+    /// Server inner state error occurred.
+    /// Represents `SYSTEM_ERR`.
+    ServerFailure,
+    /// Incorrect message received.
+    /// Represents `GARBAGE_ARGS`
+    IncorrectMessage(parser::Error),
     /// A message type mismatch occurred.
     MessageTypeMismatch,
     /// An RPC version mismatch occurred.

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,7 +1,6 @@
-use std::io;
-use std::string::FromUtf8Error;
-
 use num_derive::{FromPrimitive, ToPrimitive};
+
+use crate::parser;
 
 pub const RPC_VERSION: u32 = 2;
 
@@ -80,23 +79,13 @@ pub struct VersionMismatch {
     pub high: u32,
 }
 
+pub type Result<T> = std::result::Result<T, Error>;
+
 /// Errors that can occur during parsing.
 #[derive(Debug)]
 pub enum Error {
-    /// The maximum element limit was exceeded.
-    MaxElemLimit,
-    /// An I/O error occurred.
-    IO(io::Error),
-    /// An enum discriminant mismatch occurred.
-    EnumDiscMismatch,
-    /// An incorrect string was encountered during UTF-8 conversion.
-    IncorrectString(FromUtf8Error),
-    /// Incorrect padding was found.
-    IncorrectPadding,
-    /// An impossible type cast was attempted.
-    ImpossibleTypeCast,
-    /// A bad file handle was encountered.
-    BadFileHandle,
+    IncorrectMessage,
+    ServerFailure(parser::Error),
     /// A message type mismatch occurred.
     MessageTypeMismatch,
     /// An RPC version mismatch occurred.


### PR DESCRIPTION
There is mix of errors we currently use in parsing incoming request: basic `io::Error`, some errors we introduce to show types limitations in our implementation of parser and RPC protocol-based errors. Current pull request suggests a way to resolve this mixture.

I look up in code that we use and came up with this: all parsing functions basically use single function inside - `io::Read::read_exact`, which returns either `ErrorKind::UnexpectedEof` or `io::Error`, used inside corresponding `Read` implementation. Since our implementations - `parser::CountBuffer` and `parser::ReadBuffer` - does not return any errors (logically - thier functions still return `io::Result`, and we don't want to use wrappers around `io::Error` ([here](https://github.com/RMamonts/nfs-mamont/pull/52#discussion_r2809076746)), we might map errors in such cases into single - `UnexpectedEof`. It might not look good, especially because it became dependent on other objects ( `parser::CountBuffer` and `parser::ReadBuffer` - they might be hard to modify or replace in the future) , but we do need to differ some types of `io::Error` - [here](https://github.com/RMamonts/nfs-mamont/blob/80f4fd737e2f764ab8fdd2f678af434639f34a5d/src/parser/read_buffer.rs#L121). 

Also, it is not exactly clear, how much detailed we want errors to be - RPC protocol suggests that 2 different errors are enough. 

And finally, i don't really like the way it was with module relations - parser and rpc became too coupled. Probably, it is natural thing, since we do parsing incrementally (and protocol defines it so), but may be there other ways to do so.

Resolves: #72 
