### PR TITLE
refactor(MOUNT): remove mount interface

### DIFF
--- a/src/mount/dump.rs
+++ b/src/mount/dump.rs
@@ -1,9 +1,7 @@
-//! Defines Mount version 3 [`Dump`] interface (Procedure 2).
+//! Defines Mount version 3 Dump interface (Procedure 2).
 //!
 //! as defined in RFC 1813 section 5.2.2.
 //! <https://datatracker.ietf.org/doc/html/rfc1813#section-5.2.2>.
-
-use async_trait::async_trait;
 
 use super::MountEntry;
 
@@ -14,18 +12,4 @@ pub struct Success {
     /// The list is derived from a list maintained on the server
     /// of clients that have requested file handles with the MNT procedure.
     pub mount_list: Vec<MountEntry>,
-}
-
-/// Defines callback to pass [`Dump::dump`] result into.
-#[async_trait]
-pub trait Promise {
-    async fn keep(result: Success);
-}
-
-#[async_trait]
-pub trait Dump {
-    /// Retrieves the list of remotely mounted file systems.
-    ///
-    /// There are no MOUNT protocol errors which can be returned from this procedure.
-    async fn dump(&self, promise: impl Promise);
 }

--- a/src/mount/export.rs
+++ b/src/mount/export.rs
@@ -1,9 +1,7 @@
-//! Defines Mount version 3 [`Export`] interface (Procedure 5).
+//! Defines Mount version 3 Export interface (Procedure 5).
 //!
 //! as defined in RFC 1813 section 5.2.5.
 //! <https://datatracker.ietf.org/doc/html/rfc1813#section-5.2.5>.
-
-use async_trait::async_trait;
 
 use super::ExportEntry;
 
@@ -13,19 +11,4 @@ pub struct Success {
     /// directory and a vector of clients that are allowed
     /// to mount the specified directory.
     pub exports: Vec<ExportEntry>,
-}
-
-/// Defines callback to pass [`Export::export`] result into.
-#[async_trait]
-pub trait Promise {
-    async fn keep(result: Success);
-}
-
-#[async_trait]
-pub trait Export {
-    /// Retrieves a vector of all the exported file systems and which clients
-    /// are allowed to mount each one.
-    ///
-    /// There are no MOUNT protocol errors which can be returned from this procedure.
-    async fn export(&self, promise: impl Promise);
 }

--- a/src/mount/mnt.rs
+++ b/src/mount/mnt.rs
@@ -1,9 +1,8 @@
-//! Defines Mount version 3 [`Mnt`] interface (Procedure 1).
+//! Defines Mount version 3 Mnt interface (Procedure 1).
 //!
 //! as defined in RFC 1813 section 5.2.1.
 //! <https://datatracker.ietf.org/doc/html/rfc1813#section-5.2.1>.
 
-use async_trait::async_trait;
 use num_derive::{FromPrimitive, ToPrimitive};
 
 use crate::rpc::AuthFlavor;
@@ -44,25 +43,7 @@ pub struct Success {
 
 pub type Result = std::result::Result<Success, MntError>;
 
-/// Defines callback to pass [`Mnt::mnt`] result into.
-#[async_trait]
-pub trait Promise {
-    async fn keep(result: Result);
-}
-
 /// Arguments for the Mount operation, containing the path to be mounted.
 #[cfg_attr(test, derive(Eq, PartialEq))]
 #[derive(Debug)]
 pub struct MountArgs(pub file::Path);
-
-#[async_trait]
-pub trait Mnt {
-    /// Maps a pathname on the server to a NFS version 3 protocol file handle.
-    ///
-    /// # Parameters:
-    /// * `dirpath` --- a server pathname of a directory.
-    ///
-    /// This procedure also results in the server adding a new entry
-    /// to its mount list recording that this client has mounted the directory.
-    async fn mnt(&self, dirpath: file::Path, promise: impl Promise);
-}

--- a/src/mount/mod.rs
+++ b/src/mount/mod.rs
@@ -42,16 +42,3 @@ pub struct ExportEntry {
     /// and cannot be directly interpreted by clients.
     pub names: Vec<HostName>,
 }
-
-pub trait MountOps:
-    null::Null + mnt::Mnt + dump::Dump + umnt::Umnt + umntall::Umntall + export::Export
-{
-}
-
-pub trait MountPromises:
-    null::Promise + mnt::Promise + dump::Promise + umnt::Promise + umntall::Promise + export::Promise
-{
-}
-
-/// MOUNT v3 procedures trait.
-pub trait Mount: MountOps + MountPromises {}

--- a/src/mount/null.rs
+++ b/src/mount/null.rs
@@ -1,22 +1,4 @@
-//! Defines Mount version 3 [`Null`] interface (Procedure 0).
+//! Defines Mount version 3 Null interface (Procedure 0).
 //!
 //! as defined in RFC 1813 section 5.2.0.
 //! <https://datatracker.ietf.org/doc/html/rfc1813#section-5.2.0>.
-
-use async_trait::async_trait;
-
-/// Defines callback to pass [`Null::null`] result into.
-#[async_trait]
-pub trait Promise {
-    async fn keep();
-}
-
-#[async_trait]
-pub trait Null {
-    /// Does not do any work. It is made available to allow server response
-    /// testing and timing.
-    ///
-    /// The procedure takes no MOUNT protocol arguments and returns no MOUNT protocol response.
-    /// By convention, the procedure should never require any authentication.
-    async fn null(&self, promise: impl Promise);
-}

--- a/src/mount/umnt.rs
+++ b/src/mount/umnt.rs
@@ -1,32 +1,11 @@
-//! Defines Mount version 3 [`Umnt`] interface (Procedure 3).
+//! Defines Mount version 3 Umnt interface (Procedure 3).
 //!
 //! as defined in RFC 1813 section 5.2.3.
 //! <https://datatracker.ietf.org/doc/html/rfc1813#section-5.2.3>.
 
-use async_trait::async_trait;
-
 use crate::vfs::file;
-
-/// Defines callback to pass [`Umnt::umnt`] result into.
-#[async_trait]
-pub trait Promise {
-    async fn keep();
-}
 
 /// Arguments for the Unmount operation, containing the path to be unmounted.
 #[cfg_attr(test, derive(Eq, PartialEq))]
 #[derive(Debug)]
 pub struct UnmountArgs(pub file::Path);
-
-#[async_trait]
-pub trait Umnt {
-    /// Removes the mount list entry for the directory that was
-    /// previously the subject of a MNT call from this client.
-    ///
-    /// # Parameters:
-    /// * `dirpath` --- a server pathname of a directory.
-    ///
-    /// AUTH_UNIX authentication or better is required.
-    /// There are no MOUNT protocol errors which can be returned from this procedure.
-    async fn umnt(&self, dirpath: file::Path);
-}

--- a/src/mount/umntall.rs
+++ b/src/mount/umntall.rs
@@ -1,22 +1,4 @@
-//! Defines Mount version 3 [`Umntall`] interface (Procedure 4).
+//! Defines Mount version 3 Umntall interface (Procedure 4).
 //!
 //! as defined in RFC 1813 section 5.2.4.
 //! <https://datatracker.ietf.org/doc/html/rfc1813#section-5.2.4>.
-
-use async_trait::async_trait;
-
-/// Defines callback to pass [`Umntall::umntall`] result into.
-#[async_trait]
-pub trait Promise {
-    async fn keep();
-}
-
-#[async_trait]
-pub trait Umntall {
-    /// Removes all of the mount entries for this client previously
-    /// recorded by calls to MNT.
-    ///
-    /// AUTH_UNIX authentication or better is required.
-    /// There are no MOUNT protocol errors which can be returned from this procedure.
-    async fn umntall(&self);
-}


### PR DESCRIPTION
We don't need trait for only one server implementation, moreover it will depend on server context