### PR TITLE
refactor(allocator): remove panic on allocation exceeding capacity

### DIFF
--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -57,14 +57,17 @@ impl Impl {
 
         Self { sender, receiver, buffer_size: size, buffer_count: count }
     }
+
+    fn capacity(&self) -> usize {
+        self.buffer_size.get() * self.buffer_count.get()
+    }
 }
 
 impl Allocator for Impl {
     async fn allocate(&mut self, size: NonZeroUsize) -> Option<slice::Slice> {
-        assert!(
-            size.get() <= self.buffer_size.get() * self.buffer_count.get(),
-            "cannot allocate more than allocattor capacity"
-        );
+        if size.get() > self.capacity() {
+            return None;
+        }
 
         let mut remain_size = size.get();
         let mut buffers = Vec::with_capacity(remain_size.div_ceil(self.buffer_size.get()));

--- a/src/allocator/tests/allocator/allocate.rs
+++ b/src/allocator/tests/allocator/allocate.rs
@@ -111,3 +111,14 @@ async fn reclaiming() {
         assert!(slice.iter().all(|buffer| buffer.iter().all(|&u| u == 0)));
     }
 }
+
+#[tokio::test]
+async fn allocate_more_than_capacity_returns_none() {
+    const SIZE: NonZeroUsize = NonZeroUsize::new(13).unwrap();
+    const COUNT: NonZeroUsize = NonZeroUsize::new(15).unwrap();
+
+    let mut allocator = Impl::new(SIZE, COUNT);
+    let requested = NonZeroUsize::new(SIZE.get() * COUNT.get() + 1).unwrap();
+
+    assert!(allocator.allocate(requested).await.is_none());
+}


### PR DESCRIPTION

* Added a `capacity` method to the `Impl` struct in `src/allocator/mod.rs` to encapsulate calculation of total allocator capacity.
* Updated the `allocate` method to return `None` when a request exceeds allocator capacity, replacing the previous assertion-based check.
* Added a new async test `allocate_more_than_capacity_returns_none` in `src/allocator/tests/allocator/allocate.rs` to verify that allocation requests larger than the allocator's capacity return `None`.