### PR TITLE
refactor(parser): use Arc<Mutex<A>> for global server allocator

### DIFF
--- a/src/parser/parser_struct.rs
+++ b/src/parser/parser_struct.rs
@@ -92,9 +92,9 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     /// # Returns
     ///
     /// A new `RpcParser` instance ready to parse messages.
-    pub fn new(socket: S, allocator: A) -> Self {
+    pub fn new(socket: S, allocator: Arc<Mutex<A>>) -> Self {
         Self {
-            allocator: Arc::new(Mutex::new(allocator)),
+            allocator,
             buffer: CountBuffer::new(DEFAULT_SIZE, socket),
             last: false,
             current_frame_size: 0,
@@ -112,9 +112,9 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     /// # Returns
     ///
     /// A new `RpcParser` instance ready to parse messages.
-    pub fn with_capacity(socket: S, allocator: A, size: usize) -> Self {
+    pub fn with_capacity(socket: S, allocator: Arc<Mutex<A>>, size: usize) -> Self {
         Self {
-            allocator: Arc::new(Mutex::new(allocator)),
+            allocator,
             buffer: CountBuffer::new(size, socket),
             last: false,
             current_frame_size: 0,

--- a/src/parser/parser_struct.rs
+++ b/src/parser/parser_struct.rs
@@ -15,8 +15,10 @@
 use std::cmp::min;
 use std::io::{self, ErrorKind};
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 
 use tokio::io::AsyncRead;
+use tokio::sync::Mutex;
 
 use crate::allocator::{Allocator, Slice};
 use crate::mount::{MOUNT_PROGRAM, MOUNT_VERSION};
@@ -72,7 +74,7 @@ const DEFAULT_SIZE: usize = 2500;
 /// # }
 /// ```
 pub struct RpcParser<A: Allocator, S: AsyncRead + Unpin> {
-    allocator: A,
+    allocator: Arc<Mutex<A>>,
     buffer: CountBuffer<S>,
     last: bool,
     current_frame_size: usize,
@@ -92,7 +94,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     /// A new `RpcParser` instance ready to parse messages.
     pub fn new(socket: S, allocator: A) -> Self {
         Self {
-            allocator,
+            allocator: Arc::new(Mutex::new(allocator)),
             buffer: CountBuffer::new(DEFAULT_SIZE, socket),
             last: false,
             current_frame_size: 0,
@@ -112,7 +114,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     /// A new `RpcParser` instance ready to parse messages.
     pub fn with_capacity(socket: S, allocator: A, size: usize) -> Self {
         Self {
-            allocator,
+            allocator: Arc::new(Mutex::new(allocator)),
             buffer: CountBuffer::new(size, socket),
             last: false,
             current_frame_size: 0,
@@ -263,7 +265,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
                     READ => Arguments::Read(self.buffer.parse_with_retry(read::args).await?),
 
                     WRITE => Arguments::Write(
-                        adapter_for_write(&mut self.allocator, &mut self.buffer).await?,
+                        adapter_for_write(&self.allocator, &mut self.buffer).await?,
                     ),
 
                     CREATE => Arguments::Create(self.buffer.parse_with_retry(create::args).await?),
@@ -456,7 +458,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
 /// - Memory allocation fails
 /// - Reading the data fails
 async fn adapter_for_write<S: AsyncRead + Unpin>(
-    alloc: &mut impl Allocator,
+    alloc: &Arc<Mutex<impl Allocator>>,
     buffer: &mut CountBuffer<S>,
 ) -> Result<vfs::write::Args> {
     // Parse arguments for WRITE procedure.
@@ -465,7 +467,7 @@ async fn adapter_for_write<S: AsyncRead + Unpin>(
 
     // Attempt allocation with the given size, or fallback to NonZeroUsize::MIN.
     let non_zero_size = NonZeroUsize::new(size).unwrap_or(NonZeroUsize::MIN);
-    let mut slice = alloc.allocate(non_zero_size).await.ok_or_else(|| {
+    let mut slice = alloc.lock().await.allocate(non_zero_size).await.ok_or_else(|| {
         Error::IO(io::Error::new(ErrorKind::OutOfMemory, "cannot allocate memory"))
     })?;
 

--- a/src/parser/tests/parser_struct.rs
+++ b/src/parser/tests/parser_struct.rs
@@ -283,7 +283,7 @@ async fn parse_rejects_any_non_call_message_type() {
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
     ];
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0))) ;
+    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x35);
 
     let result = parser.parse_message().await;

--- a/src/parser/tests/parser_struct.rs
+++ b/src/parser/tests/parser_struct.rs
@@ -1,3 +1,7 @@
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
 use crate::nfsv3::{FSSTAT, NFS_PROGRAM, NFS_VERSION, WRITE};
 use crate::parser::parser_struct::RpcParser;
 use crate::parser::tests::allocator::MockAllocator;
@@ -144,7 +148,7 @@ async fn parse_two_correct() {
     buf.extend_from_slice(&first);
     buf.extend_from_slice(&second);
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = MockAllocator::new(0);
+    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x35);
     let _ = parser.parse_message().await;
     let result = parser.parse_message().await.unwrap();
@@ -164,7 +168,7 @@ async fn parse_after_error() {
     buf.extend_from_slice(&first);
     buf.extend_from_slice(&second);
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = MockAllocator::new(0);
+    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x50);
     let result = parser.parse_message().await;
     assert!(result.is_err());
@@ -191,7 +195,7 @@ async fn parse_write() {
     buf.extend_from_slice(&first);
     buf.extend_from_slice(&second);
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = MockAllocator::new(0x24);
+    let alloc = Arc::new(Mutex::new(MockAllocator::new(0x24)));
     let mut parser = RpcParser::with_capacity(socket, alloc, 72);
     let result = parser.parse_message().await;
     assert!(result.is_ok());
@@ -218,7 +222,7 @@ async fn parse_write_after_error() {
     buf.extend_from_slice(&first);
     buf.extend_from_slice(&second);
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = MockAllocator::new(0x24);
+    let alloc = Arc::new(Mutex::new(MockAllocator::new(0x24)));
     let mut parser = RpcParser::with_capacity(socket, alloc, 80);
     let result = parser.parse_message().await;
     assert!(result.is_err());
@@ -236,7 +240,7 @@ async fn parse_error_when_consumed_exceeds_frame_size() {
         0x00, 0x00, 0x00, 0x05, // invalid rpc version (must be 2)
     ];
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = MockAllocator::new(0);
+    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x20);
 
     let result = parser.parse_message().await;
@@ -255,7 +259,7 @@ async fn parse_error_with_too_small_frame_size_returns_error() {
     ];
 
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = MockAllocator::new(0);
+    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
     let mut parser = RpcParser::with_capacity(socket, alloc, 32);
 
     let result = parser.parse_message().await;
@@ -279,7 +283,7 @@ async fn parse_rejects_any_non_call_message_type() {
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
     ];
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = MockAllocator::new(0);
+    let alloc = Arc::new(Mutex::new(MockAllocator::new(0))) ;
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x35);
 
     let result = parser.parse_message().await;
@@ -294,7 +298,7 @@ async fn parse_rejects_frame_smaller_than_xid() {
         0x80, 0x00, 0x00, 0x03, // head with invalid frame size (less than 4)
     ];
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = MockAllocator::new(0);
+    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x10);
 
     let result = parser.parse_message().await;
@@ -310,7 +314,7 @@ async fn parse_rejects_too_large_frame() {
         0x80, 0x00, 0x09, 0xC5, // head with invalid frame size (MAX_MESSAGE_LEN + 1)
     ];
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = MockAllocator::new(0);
+    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x10);
 
     let result = parser.parse_message().await;
@@ -341,7 +345,7 @@ async fn parse_write_with_empty_payload() {
         0x00, 0x00, 0x00, 0x00, // opaque length
     ];
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = MockAllocator::new(1);
+    let alloc = Arc::new(Mutex::new(MockAllocator::new(1)));
     let mut parser = RpcParser::with_capacity(socket, alloc, 68);
     let result = parser.parse_message().await;
     assert!(result.is_ok());


### PR DESCRIPTION
Change parser API to use one allocator across whole server