### PR TITLE
fix: bugs from parser

### DIFF
--- a/src/parser/nfsv3/file.rs
+++ b/src/parser/nfsv3/file.rs
@@ -220,7 +220,7 @@ mod tests {
     fn test_file_path_padding_error() {
         const DATA: &[u8] = &[0x00, 0x00, 0x00, 0x02, b'f', b'i', 0x00];
 
-        assert!(matches!(super::file_path(&mut Cursor::new(DATA)), Err(Error::IncorrectPadding)));
+        assert!(super::file_path(&mut Cursor::new(DATA)).is_err());
     }
 
     #[test]

--- a/src/parser/nfsv3/file.rs
+++ b/src/parser/nfsv3/file.rs
@@ -219,8 +219,7 @@ mod tests {
     #[test]
     fn test_file_path_padding_error() {
         const DATA: &[u8] = &[0x00, 0x00, 0x00, 0x02, b'f', b'i', 0x00];
-
-        assert!(super::file_path(&mut Cursor::new(DATA)).is_err());
+        assert!(matches!(super::file_path(&mut Cursor::new(DATA)), Err(Error::IO(_))));
     }
 
     #[test]

--- a/src/parser/parser_struct.rs
+++ b/src/parser/parser_struct.rs
@@ -146,12 +146,8 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
                 "Frame size must include XID",
             )));
         }
-        if self.current_frame_size > DEFAULT_SIZE {
-            return Err(Error::IO(io::Error::new(
-                ErrorKind::InvalidData,
-                "Frame exceeds maximum supported length",
-            )));
-        }
+
+        //TODO("there might max frame check, but with valid MAX_FRAME_SIZE")
 
         // this is temporal check, apparently this will go to separate object Validator
         if !self.last {

--- a/src/parser/parser_struct.rs
+++ b/src/parser/parser_struct.rs
@@ -147,7 +147,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
             )));
         }
 
-        //TODO("there might max frame check, but with valid MAX_FRAME_SIZE")
+        //TODO("https://github.com/RMamonts/nfs-mamont/issues/124")
 
         // this is temporal check, apparently this will go to separate object Validator
         if !self.last {

--- a/src/parser/primitive.rs
+++ b/src/parser/primitive.rs
@@ -14,7 +14,7 @@ pub const ALIGNMENT: usize = 4;
 pub fn padding(src: &mut impl Read, n: usize) -> Result<()> {
     let mut buf = [0u8; ALIGNMENT];
     let padding = (ALIGNMENT - n % ALIGNMENT) % ALIGNMENT;
-    src.read_exact(&mut buf[..padding]).map_err(|_| Error::IncorrectPadding)
+    src.read_exact(&mut buf[..padding]).map_err(Error::IO)
 }
 
 /// Parses a `u8` (byte) from the `Read` source.

--- a/src/parser/tests/parser_struct.rs
+++ b/src/parser/tests/parser_struct.rs
@@ -306,22 +306,6 @@ async fn parse_rejects_frame_smaller_than_xid() {
     assert!(matches!(error, Error::IO(err) if err.kind() == std::io::ErrorKind::InvalidData));
 }
 
-/// Ensures parser rejects fragments above configured maximum size.
-#[tokio::test]
-async fn parse_rejects_too_large_frame() {
-    #[rustfmt::skip]
-    let buf = vec![
-        0x80, 0x00, 0x09, 0xC5, // head with invalid frame size (MAX_MESSAGE_LEN + 1)
-    ];
-    let socket = MockSocket::new(buf.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
-    let mut parser = RpcParser::with_capacity(socket, alloc, 0x10);
-
-    let result = parser.parse_message().await;
-    let error = result.err().unwrap();
-    assert!(matches!(error, Error::IO(err) if err.kind() == std::io::ErrorKind::InvalidData));
-}
-
 /// Verifies parser handles WRITE with zero opaque payload.
 #[tokio::test]
 async fn parse_write_with_empty_payload() {

--- a/src/parser/tests/primitive.rs
+++ b/src/parser/tests/primitive.rs
@@ -41,7 +41,7 @@ fn test_u8_array_padding_error() {
         src.write_u8(*i).unwrap();
     }
     let result = array::<3>(&mut Cursor::new(src));
-    assert!(matches!(result, Err(Error::IncorrectPadding)));
+    assert!(result.is_err());
 }
 
 #[test]

--- a/src/parser/tests/primitive.rs
+++ b/src/parser/tests/primitive.rs
@@ -41,7 +41,7 @@ fn test_u8_array_padding_error() {
         src.write_u8(*i).unwrap();
     }
     let result = array::<3>(&mut Cursor::new(src));
-    assert!(result.is_err());
+    assert!(matches!(result, Err(Error::IO(_))));
 }
 
 #[test]

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -86,8 +86,6 @@ pub enum Error {
     EnumDiscMismatch,
     /// An incorrect string was encountered during UTF-8 conversion.
     IncorrectString(FromUtf8Error),
-    /// Incorrect padding was found.
-    IncorrectPadding,
     /// An impossible type cast was attempted.
     ImpossibleTypeCast,
     /// A bad file handle was encountered.

--- a/src/serializer/serialize_struct.rs
+++ b/src/serializer/serialize_struct.rs
@@ -257,8 +257,7 @@ impl<T: AsyncWrite + Unpin> Serializer<T> {
             }
             Err(err) => {
                 match err {
-                    Error::IncorrectPadding
-                    | Error::ImpossibleTypeCast
+                    Error::ImpossibleTypeCast
                     | Error::BadFileHandle
                     | Error::MessageTypeMismatch
                     | Error::EnumDiscMismatch


### PR DESCRIPTION
parser fuzzing from #109 found two buds:
* invalid constant in test of maximum frame size; constant for default capacity of underlying buffer is used in place of actual size
* `rpc::Error::InvalidParsing` error cause parser fail, because it does not cause read retry in case, when more data need to be read before processing (quite rare cases when padding bytes we split between two read calls) 