### PR TITLE
Unstable demo 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,20 +125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,16 +188,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -350,7 +338,6 @@ dependencies = [
  "async-trait",
  "byteorder",
  "crossbeam-queue",
- "dashmap",
  "io-uring",
  "moka",
  "num-derive",
@@ -358,6 +345,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "whirlwind",
 ]
 
 [[package]]
@@ -836,6 +824,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "whirlwind"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19bdd6495360c0280cb4910c4dc98472cf2a8e3a9fe0f1b55290956fa312dc07"
+dependencies = [
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +65,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +97,33 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "lazy_static"
@@ -119,8 +182,10 @@ dependencies = [
 name = "nfs-mamont"
 version = "0.0.0"
 dependencies = [
+ "async-channel",
  "async-trait",
  "byteorder",
+ "crossbeam-queue",
  "num-derive",
  "num-traits",
  "tokio",
@@ -162,6 +227,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "crossbeam-queue",
+ "libc",
  "num-derive",
  "num-traits",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "byteorder",
  "crossbeam-queue",
  "io-uring",
+ "libc",
  "moka",
  "num-derive",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "io-uring"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd7bddefd0a8833b88a4b68f90dae22c7450d11b354198baee3874fd811b344"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +197,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "crossbeam-queue",
+ "io-uring",
  "num-derive",
  "num-traits",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +53,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +86,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +117,26 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -120,10 +170,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "io-uring"
@@ -137,10 +251,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -190,6 +326,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "nfs-mamont"
 version = "0.0.0"
 dependencies = [
@@ -197,7 +350,9 @@ dependencies = [
  "async-trait",
  "byteorder",
  "crossbeam-queue",
+ "dashmap",
  "io-uring",
+ "moka",
  "num-derive",
  "num-traits",
  "tokio",
@@ -276,6 +431,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +463,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "redox_syscall"
@@ -320,10 +497,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -370,6 +601,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "thread_local"
@@ -476,6 +713,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "uuid"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +740,103 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
@@ -501,3 +852,97 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,6 @@ dependencies = [
  "async-trait",
  "byteorder",
  "crossbeam-queue",
- "libc",
  "num-derive",
  "num-traits",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 async-channel = "2.5.0"
 crossbeam-queue = "0.3.12"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+io-uring = "0.7"
+
 [dev-dependencies]
 [package.metadata.cargo-udeps.ignore]
 tempfile = "3.26.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ tracing = { version = "0.1", features = ["release_max_level_off"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 async-channel = "2.5.0"
 crossbeam-queue = "0.3.12"
-libc = "0.2"
 
 [dev-dependencies]
 [package.metadata.cargo-udeps.ignore]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ tracing = { version = "0.1", features = ["release_max_level_off"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 async-channel = "2.5.0"
 crossbeam-queue = "0.3.12"
+dashmap = "6.1.0"
+moka = { version = "0.12.11", features = ["sync"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { version = "0.1", features = ["release_max_level_off"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 async-channel = "2.5.0"
 crossbeam-queue = "0.3.12"
-dashmap = "6.1.0"
+whirlwind = "0.1.1"
 moka = { version = "0.12.11", features = ["sync"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tracing = { version = "0.1", features = ["release_max_level_off"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 async-channel = "2.5.0"
 crossbeam-queue = "0.3.12"
+libc = "0.2"
 
 [dev-dependencies]
 [package.metadata.cargo-udeps.ignore]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ moka = { version = "0.12.11", features = ["sync"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = "0.7"
+libc = "0.2"
 
 [dev-dependencies]
 [package.metadata.cargo-udeps.ignore]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ num-derive = "0.4.2"
 num-traits = "0.2.19"
 tracing = { version = "0.1", features = ["release_max_level_off"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+async-channel = "2.5.0"
+crossbeam-queue = "0.3.12"
 
 [dev-dependencies]
 [package.metadata.cargo-udeps.ignore]

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -52,6 +52,7 @@ const DEFAULT_SET_ATTR: set_attr::NewAttr = set_attr::NewAttr {
 #[derive(Debug)]
 pub struct MirrorFS {
     fsmap: RwLock<FsMap>,
+    root_path: PathBuf,
     generation: u64,
 }
 
@@ -62,7 +63,7 @@ impl MirrorFS {
         let generation =
             SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO).as_nanos()
                 as u64;
-        Self { fsmap: RwLock::new(FsMap::new(root)), generation }
+        Self { fsmap: RwLock::new(FsMap::new(root.clone())), root_path: root, generation }
     }
 
     /// Returns the root handle.
@@ -88,6 +89,25 @@ impl MirrorFS {
 
     async fn ensure_handle_for_path(&self, path: &Path) -> Result<file::Handle, vfs::Error> {
         self.fsmap.write().await.ensure_handle_for_path(path)
+    }
+
+    async fn ensure_handles_for_paths(
+        &self,
+        paths: &[PathBuf],
+    ) -> Result<Vec<file::Handle>, vfs::Error> {
+        let mut fsmap = self.fsmap.write().await;
+        let mut handles = Vec::with_capacity(paths.len());
+        for path in paths {
+            handles.push(fsmap.ensure_handle_for_path(path)?);
+        }
+        Ok(handles)
+    }
+
+    async fn cache_handles_for_paths(&self, paths: &[PathBuf]) {
+        let mut fsmap = self.fsmap.write().await;
+        for path in paths {
+            let _ = fsmap.ensure_handle_for_path(path);
+        }
     }
 
     async fn remove_cached_path(&self, path: &Path) {
@@ -313,7 +333,6 @@ impl MirrorFS {
     }
 
     async fn exported_root_path(&self) -> Result<PathBuf, vfs::Error> {
-        let root = self.root_handle().await;
-        self.path_for_handle(&root).await
+        Ok(self.root_path.clone())
     }
 }

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -56,6 +56,7 @@ const READ_AHEAD_CACHE_LIMIT: usize = 1024;
 const READ_AHEAD_PER_FILE_LIMIT: usize = 16;
 const READ_AHEAD_CACHE_TTL: Duration = Duration::from_secs(30);
 const READ_AHEAD_SEQUENCE_WINDOW: Duration = Duration::from_secs(6);
+const READDIRPLUS_ATTR_PARALLELISM: usize = 16;
 const DEFAULT_SET_ATTR: set_attr::NewAttr = set_attr::NewAttr {
     mode: None,
     uid: None,
@@ -72,6 +73,7 @@ pub struct MirrorFS {
     attr_cache: AttributeCache,
     dir_listing_cache: DirectoryListingCache,
     read_ahead_cache: ReadAheadCache,
+    pending_unstable_writes: Arc<tokio::sync::Mutex<HashSet<PathBuf>>>,
     root_path: PathBuf,
     generation: u64,
 }
@@ -204,6 +206,7 @@ impl MirrorFS {
             attr_cache: AttributeCache::new(),
             dir_listing_cache: DirectoryListingCache::new(),
             read_ahead_cache: ReadAheadCache::new(),
+            pending_unstable_writes: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
             root_path: root,
             generation,
         }
@@ -269,6 +272,7 @@ impl MirrorFS {
         self.invalidate_read_file_cache_path(path).await;
         self.invalidate_attr_cache_path(path).await;
         self.invalidate_read_ahead_path(path).await;
+        self.clear_pending_unstable_write(path).await;
     }
 
     async fn rename_cached_path(&self, from: &Path, to: &Path) -> Result<(), vfs::Error> {
@@ -279,7 +283,17 @@ impl MirrorFS {
         self.invalidate_attr_cache_path(to).await;
         self.invalidate_read_ahead_path(from).await;
         self.invalidate_read_ahead_path(to).await;
+        self.clear_pending_unstable_write(from).await;
+        self.clear_pending_unstable_write(to).await;
         Ok(())
+    }
+
+    async fn mark_pending_unstable_write(&self, path: &Path) {
+        self.pending_unstable_writes.lock().await.insert(path.to_path_buf());
+    }
+
+    async fn clear_pending_unstable_write(&self, path: &Path) {
+        self.pending_unstable_writes.lock().await.remove(path);
     }
 
     async fn attr_for_path(&self, path: &Path) -> Result<file::Attr, vfs::Error> {
@@ -390,6 +404,57 @@ impl MirrorFS {
             self.attr_cache.keys.remove(&key).await;
             self.attr_cache.key_index.write().await.remove(&key);
         }
+    }
+
+    async fn attrs_for_paths_parallel(&self, paths: &[PathBuf]) -> Result<Vec<file::Attr>, vfs::Error> {
+        if paths.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut attrs: Vec<Option<file::Attr>> = (0..paths.len()).map(|_| None).collect();
+        let mut misses: Vec<(usize, PathBuf)> = Vec::new();
+
+        for (idx, path) in paths.iter().enumerate() {
+            if let Some(entry) = self.attr_cache.attrs.get(path) {
+                attrs[idx] = Some(Self::attr_from_metadata(&entry.metadata));
+                continue;
+            }
+
+            self.attr_cache.keys.remove(path).await;
+            self.attr_cache.key_index.write().await.remove(path);
+            misses.push((idx, path.clone()));
+        }
+
+        for batch in misses.chunks(READDIRPLUS_ATTR_PARALLELISM) {
+            let mut tasks = tokio::task::JoinSet::new();
+
+            for (idx, path) in batch.iter().cloned() {
+                tasks.spawn(async move {
+                    let path_for_meta = path.clone();
+                    let metadata = tokio::task::spawn_blocking(move || std::fs::symlink_metadata(path_for_meta))
+                        .await
+                        .map_err(|_| vfs::Error::IO)?
+                        .map_err(|error| Self::io_error_to_vfs(&error))?;
+                    Ok::<(usize, PathBuf, Metadata), vfs::Error>((idx, path, metadata))
+                });
+            }
+
+            while let Some(task_result) = tasks.join_next().await {
+                let (idx, path, metadata) = task_result.map_err(|_| vfs::Error::IO)??;
+                let attr = Self::attr_from_metadata(&metadata);
+
+                self.attr_cache
+                    .attrs
+                    .insert(path.clone(), Arc::new(CachedAttrEntry { metadata }));
+                self.attr_cache.keys.insert(path.clone()).await;
+                self.attr_cache.key_index.write().await.insert(path);
+                attrs[idx] = Some(attr);
+            }
+        }
+
+        self.maybe_compact_attr_keys().await;
+
+        attrs.into_iter().map(|attr| attr.ok_or(vfs::Error::IO)).collect()
     }
 
     async fn read_ahead_copy_hit(

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -8,7 +8,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use dashmap::DashMap;
 use moka::sync::Cache;
-use tokio::sync::RwLock;
 
 use nfs_mamont::consts::nfsv3::{NFS3_COOKIEVERFSIZE, NFS3_CREATEVERFSIZE};
 use nfs_mamont::vfs;
@@ -58,7 +57,7 @@ const DEFAULT_SET_ATTR: set_attr::NewAttr = set_attr::NewAttr {
 /// A file system implementation that mirrors a local directory.
 #[derive(Debug)]
 pub struct MirrorFS {
-    fsmap: RwLock<FsMap>,
+    fsmap: FsMap,
     read_file_cache: ReadFileCache,
     attr_cache: AttributeCache,
     root_path: PathBuf,
@@ -111,7 +110,7 @@ impl MirrorFS {
             SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO).as_nanos()
                 as u64;
         Self {
-            fsmap: RwLock::new(FsMap::new(root.clone())),
+            fsmap: FsMap::new(root.clone()),
             read_file_cache: ReadFileCache::new(),
             attr_cache: AttributeCache::new(),
             root_path: root,
@@ -121,7 +120,7 @@ impl MirrorFS {
 
     /// Returns the root handle.
     pub async fn root_handle(&self) -> file::Handle {
-        self.fsmap.read().await.root_handle()
+        self.fsmap.root_handle()
     }
 
     fn write_verifier(&self) -> write::Verifier {
@@ -136,41 +135,45 @@ impl MirrorFS {
     }
 
     async fn path_for_handle(&self, handle: &file::Handle) -> Result<PathBuf, vfs::Error> {
-        let fsmap = self.fsmap.read().await;
-        fsmap.path_for_handle(handle)
+        let candidates = self.fsmap.path_candidates_for_handle(handle)?;
+        for candidate in candidates {
+            if self.attr_for_path(&candidate).await.is_ok() {
+                return Ok(candidate);
+            }
+        }
+        Err(vfs::Error::StaleFile)
     }
 
     async fn ensure_handle_for_path(&self, path: &Path) -> Result<file::Handle, vfs::Error> {
-        self.fsmap.write().await.ensure_handle_for_path(path)
+        let attr = self.attr_for_path(path).await?;
+        self.fsmap.ensure_handle_for_attr(path, &attr)
     }
 
     async fn ensure_handles_for_paths(
         &self,
         paths: &[PathBuf],
     ) -> Result<Vec<file::Handle>, vfs::Error> {
-        let mut fsmap = self.fsmap.write().await;
         let mut handles = Vec::with_capacity(paths.len());
         for path in paths {
-            handles.push(fsmap.ensure_handle_for_path(path)?);
+            handles.push(self.ensure_handle_for_path(path).await?);
         }
         Ok(handles)
     }
 
     async fn cache_handles_for_paths(&self, paths: &[PathBuf]) {
-        let mut fsmap = self.fsmap.write().await;
         for path in paths {
-            let _ = fsmap.ensure_handle_for_path(path);
+            let _ = self.ensure_handle_for_path(path).await;
         }
     }
 
     async fn remove_cached_path(&self, path: &Path) {
-        self.fsmap.write().await.remove_path(path);
+        self.fsmap.remove_path(path);
         self.invalidate_read_file_cache_path(path).await;
         self.invalidate_attr_cache_path(path).await;
     }
 
     async fn rename_cached_path(&self, from: &Path, to: &Path) -> Result<(), vfs::Error> {
-        self.fsmap.write().await.rename_path(from, to)?;
+        self.fsmap.rename_path(from, to)?;
         self.invalidate_read_file_cache_path(from).await;
         self.invalidate_read_file_cache_path(to).await;
         self.invalidate_attr_cache_path(from).await;

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -1,10 +1,13 @@
+use std::collections::{HashMap, VecDeque};
+use std::fs::File;
 use std::fs::Metadata;
 use std::io::ErrorKind;
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 use nfs_mamont::consts::nfsv3::{NFS3_COOKIEVERFSIZE, NFS3_CREATEVERFSIZE};
 use nfs_mamont::vfs;
@@ -39,6 +42,7 @@ mod write_impl;
 
 const READ_WRITE_MAX: u32 = 64 * 1024;
 const READ_DIR_PREF: u32 = 8 * 1024;
+const READ_FILE_CACHE_LIMIT: usize = 1024;
 const DEFAULT_SET_ATTR: set_attr::NewAttr = set_attr::NewAttr {
     mode: None,
     uid: None,
@@ -52,8 +56,15 @@ const DEFAULT_SET_ATTR: set_attr::NewAttr = set_attr::NewAttr {
 #[derive(Debug)]
 pub struct MirrorFS {
     fsmap: RwLock<FsMap>,
+    read_file_cache: Mutex<ReadFileCache>,
     root_path: PathBuf,
     generation: u64,
+}
+
+#[derive(Debug, Default)]
+struct ReadFileCache {
+    files: HashMap<PathBuf, Arc<File>>,
+    order: VecDeque<PathBuf>,
 }
 
 impl MirrorFS {
@@ -63,7 +74,12 @@ impl MirrorFS {
         let generation =
             SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO).as_nanos()
                 as u64;
-        Self { fsmap: RwLock::new(FsMap::new(root.clone())), root_path: root, generation }
+        Self {
+            fsmap: RwLock::new(FsMap::new(root.clone())),
+            read_file_cache: Mutex::new(ReadFileCache::default()),
+            root_path: root,
+            generation,
+        }
     }
 
     /// Returns the root handle.
@@ -112,10 +128,62 @@ impl MirrorFS {
 
     async fn remove_cached_path(&self, path: &Path) {
         self.fsmap.write().await.remove_path(path);
+        self.invalidate_read_file_cache_path(path).await;
     }
 
     async fn rename_cached_path(&self, from: &Path, to: &Path) -> Result<(), vfs::Error> {
-        self.fsmap.write().await.rename_path(from, to)
+        self.fsmap.write().await.rename_path(from, to)?;
+        self.invalidate_read_file_cache_path(from).await;
+        self.invalidate_read_file_cache_path(to).await;
+        Ok(())
+    }
+
+    async fn get_cached_read_file(&self, path: &Path) -> Result<Arc<File>, vfs::Error> {
+        {
+            let mut cache = self.read_file_cache.lock().await;
+            if let Some(file) = cache.files.get(path).cloned() {
+                Self::touch_read_cache_entry(&mut cache.order, path);
+                return Ok(file);
+            }
+        }
+
+        let path_buf = path.to_path_buf();
+        let opened = tokio::task::spawn_blocking(move || File::open(path_buf))
+            .await
+            .map_err(|_| vfs::Error::IO)?
+            .map_err(|error| Self::io_error_to_vfs(&error))?;
+        let opened = Arc::new(opened);
+
+        let mut cache = self.read_file_cache.lock().await;
+        if let Some(existing) = cache.files.get(path).cloned() {
+            Self::touch_read_cache_entry(&mut cache.order, path);
+            return Ok(existing);
+        }
+
+        cache.files.insert(path.to_path_buf(), opened.clone());
+        Self::touch_read_cache_entry(&mut cache.order, path);
+
+        while cache.files.len() > READ_FILE_CACHE_LIMIT {
+            let Some(evicted_path) = cache.order.pop_front() else {
+                break;
+            };
+            cache.files.remove(&evicted_path);
+        }
+
+        Ok(opened)
+    }
+
+    async fn invalidate_read_file_cache_path(&self, path: &Path) {
+        let mut cache = self.read_file_cache.lock().await;
+        cache.files.retain(|known_path, _| !(known_path == path || known_path.starts_with(path)));
+        cache.order.retain(|known_path| known_path != path && !known_path.starts_with(path));
+    }
+
+    fn touch_read_cache_entry(order: &mut VecDeque<PathBuf>, path: &Path) {
+        if let Some(pos) = order.iter().position(|entry| entry == path) {
+            order.remove(pos);
+        }
+        order.push_back(path.to_path_buf());
     }
 
     fn ensure_name_allowed(name: &file::Name) -> Result<(), vfs::Error> {

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -43,7 +43,7 @@ mod set_attr_impl;
 mod symlink_impl;
 mod write_impl;
 
-const READ_WRITE_MAX: u32 = 1024 * 1024;
+pub const READ_WRITE_MAX: u32 = 1024 * 1024;
 const READ_DIR_PREF: u32 = 8 * 1024;
 const READ_FILE_CACHE_LIMIT: usize = 1024;
 const ATTRIBUTE_CACHE_LIMIT: usize = 16 * 1024;

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -1,12 +1,12 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs::File;
 use std::fs::Metadata;
 use std::io::ErrorKind;
 use std::os::unix::fs::DirEntryExt;
-use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
+use std::os::unix::fs::{FileExt, FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use moka::sync::Cache;
 use tokio::sync::RwLock;
@@ -47,9 +47,14 @@ pub const READ_WRITE_MAX: u32 = 1024 * 1024;
 const READ_DIR_PREF: u32 = 8 * 1024;
 const READ_FILE_CACHE_LIMIT: usize = 1024;
 const ATTRIBUTE_CACHE_LIMIT: usize = 16 * 1024;
-const ATTRIBUTE_CACHE_TTL: Duration = Duration::from_secs(3);
+const ATTRIBUTE_CACHE_TTL: Duration = Duration::from_secs(60);
 const DIRECTORY_LISTING_CACHE_LIMIT: usize = 1024;
 const DIRECTORY_LISTING_CACHE_TTL: Duration = Duration::from_millis(700);
+const READ_AHEAD_BLOCK_SIZE: usize = READ_WRITE_MAX as usize;
+const READ_AHEAD_CACHE_LIMIT: usize = 256;
+const READ_AHEAD_PER_FILE_LIMIT: usize = 4;
+const READ_AHEAD_CACHE_TTL: Duration = Duration::from_secs(15);
+const READ_AHEAD_SEQUENCE_WINDOW: Duration = Duration::from_secs(2);
 const DEFAULT_SET_ATTR: set_attr::NewAttr = set_attr::NewAttr {
     mode: None,
     uid: None,
@@ -65,6 +70,7 @@ pub struct MirrorFS {
     read_file_cache: ReadFileCache,
     attr_cache: AttributeCache,
     dir_listing_cache: DirectoryListingCache,
+    read_ahead_cache: ReadAheadCache,
     root_path: PathBuf,
     generation: u64,
 }
@@ -102,6 +108,26 @@ struct AttributeCache {
     key_index: RwLock<BTreeSet<PathBuf>>,
 }
 
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct ReadAheadKey {
+    path: PathBuf,
+    offset: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ReadSequenceState {
+    next_offset: u64,
+    last_seen: Instant,
+}
+
+#[derive(Clone)]
+struct ReadAheadCache {
+    blocks: Cache<ReadAheadKey, Arc<[u8]>>,
+    key_index: Arc<RwLock<BTreeSet<ReadAheadKey>>>,
+    inflight: Arc<tokio::sync::Mutex<HashSet<ReadAheadKey>>>,
+    sequence: Arc<tokio::sync::Mutex<HashMap<PathBuf, ReadSequenceState>>>,
+}
+
 impl ReadFileCache {
     fn new() -> Self {
         Self {
@@ -136,6 +162,34 @@ impl DirectoryListingCache {
     }
 }
 
+impl ReadAheadCache {
+    fn new() -> Self {
+        Self {
+            blocks: Cache::builder()
+                .max_capacity(READ_AHEAD_CACHE_LIMIT as u64)
+                .time_to_live(READ_AHEAD_CACHE_TTL)
+                .build(),
+            key_index: Arc::new(RwLock::new(BTreeSet::new())),
+            inflight: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
+            sequence: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        }
+    }
+
+    async fn maybe_compact_keys(&self) {
+        if self.key_index.read().await.len() <= READ_AHEAD_CACHE_LIMIT * 4 {
+            return;
+        }
+
+        let keys: Vec<ReadAheadKey> = self.key_index.read().await.iter().cloned().collect();
+        let stale: Vec<ReadAheadKey> =
+            keys.into_iter().filter(|key| self.blocks.get(key).is_none()).collect();
+
+        for key in stale {
+            self.key_index.write().await.remove(&key);
+        }
+    }
+}
+
 impl MirrorFS {
     /// Creates a new mirror file system with the given root path.
     pub fn new(root: PathBuf) -> Self {
@@ -148,6 +202,7 @@ impl MirrorFS {
             read_file_cache: ReadFileCache::new(),
             attr_cache: AttributeCache::new(),
             dir_listing_cache: DirectoryListingCache::new(),
+            read_ahead_cache: ReadAheadCache::new(),
             root_path: root,
             generation,
         }
@@ -170,10 +225,17 @@ impl MirrorFS {
     }
 
     async fn path_for_handle(&self, handle: &file::Handle) -> Result<PathBuf, vfs::Error> {
+        self.path_and_attr_for_handle(handle).await.map(|(path, _)| path)
+    }
+
+    async fn path_and_attr_for_handle(
+        &self,
+        handle: &file::Handle,
+    ) -> Result<(PathBuf, file::Attr), vfs::Error> {
         let candidates = self.fsmap.path_candidates_for_handle(handle).await?;
         for candidate in candidates {
-            if self.attr_for_path(&candidate).await.is_ok() {
-                return Ok(candidate);
+            if let Ok(attr) = self.attr_for_path(&candidate).await {
+                return Ok((candidate, attr));
             }
         }
         Err(vfs::Error::StaleFile)
@@ -205,6 +267,7 @@ impl MirrorFS {
         self.fsmap.remove_path(path).await;
         self.invalidate_read_file_cache_path(path).await;
         self.invalidate_attr_cache_path(path).await;
+        self.invalidate_read_ahead_path(path).await;
     }
 
     async fn rename_cached_path(&self, from: &Path, to: &Path) -> Result<(), vfs::Error> {
@@ -213,6 +276,8 @@ impl MirrorFS {
         self.invalidate_read_file_cache_path(to).await;
         self.invalidate_attr_cache_path(from).await;
         self.invalidate_attr_cache_path(to).await;
+        self.invalidate_read_ahead_path(from).await;
+        self.invalidate_read_ahead_path(to).await;
         Ok(())
     }
 
@@ -275,6 +340,7 @@ impl MirrorFS {
                 .cloned()
                 .collect()
         };
+
         for key in keys {
             self.read_file_cache.files.invalidate(&key);
             self.read_file_cache.keys.remove(&key).await;
@@ -323,6 +389,135 @@ impl MirrorFS {
             self.attr_cache.keys.remove(&key).await;
             self.attr_cache.key_index.write().await.remove(&key);
         }
+    }
+
+    async fn read_ahead_copy_hit(
+        &self,
+        path: &Path,
+        offset: u64,
+        requested: usize,
+        data: &mut nfs_mamont::Slice,
+    ) -> Option<usize> {
+        let key = ReadAheadKey { path: path.to_path_buf(), offset };
+        let block = self.read_ahead_cache.blocks.get(&key)?;
+
+        let mut copied = 0usize;
+        let max_copy = requested.min(block.len());
+        for chunk in data.iter_mut() {
+            if copied >= max_copy {
+                break;
+            }
+
+            let take = chunk.len().min(max_copy - copied);
+            chunk[..take].copy_from_slice(&block[copied..copied + take]);
+            copied += take;
+        }
+
+        Some(copied)
+    }
+
+    async fn update_read_sequence(&self, path: &Path, start: u64, end: u64) -> bool {
+        let now = Instant::now();
+        let mut sequence = self.read_ahead_cache.sequence.lock().await;
+        let sequential = sequence
+            .get(path)
+            .map(|state| {
+                state.next_offset == start
+                    && now.saturating_duration_since(state.last_seen) <= READ_AHEAD_SEQUENCE_WINDOW
+            })
+            .unwrap_or(false);
+
+        sequence.insert(path.to_path_buf(), ReadSequenceState { next_offset: end, last_seen: now });
+
+        if sequence.len() > READ_AHEAD_CACHE_LIMIT * 8 {
+            sequence.retain(|_, state| {
+                now.saturating_duration_since(state.last_seen)
+                    <= READ_AHEAD_SEQUENCE_WINDOW.saturating_mul(4)
+            });
+        }
+
+        sequential
+    }
+
+    async fn schedule_read_ahead(&self, path: &Path, file: Arc<File>, offset: u64, file_len: u64) {
+        if offset >= file_len {
+            return;
+        }
+
+        let prefetch_size = (file_len - offset).min(READ_AHEAD_BLOCK_SIZE as u64) as usize;
+        if prefetch_size == 0 {
+            return;
+        }
+
+        let key = ReadAheadKey { path: path.to_path_buf(), offset };
+        if self.read_ahead_cache.blocks.get(&key).is_some() {
+            return;
+        }
+
+        {
+            let key_index = self.read_ahead_cache.key_index.read().await;
+            let existing_for_file = key_index.iter().filter(|known| known.path == key.path).count();
+            if existing_for_file >= READ_AHEAD_PER_FILE_LIMIT {
+                return;
+            }
+        }
+
+        {
+            let mut inflight = self.read_ahead_cache.inflight.lock().await;
+            if !inflight.insert(key.clone()) {
+                return;
+            }
+        }
+
+        let cache = self.read_ahead_cache.clone();
+        tokio::spawn(async move {
+            let result = tokio::task::spawn_blocking(move || {
+                let mut loaded = vec![0u8; prefetch_size];
+                let mut total = 0usize;
+
+                while total < prefetch_size {
+                    let read = file.read_at(&mut loaded[total..], offset + total as u64)?;
+                    if read == 0 {
+                        break;
+                    }
+                    total += read;
+                }
+
+                loaded.truncate(total);
+                Ok::<Vec<u8>, std::io::Error>(loaded)
+            })
+            .await;
+
+            if let Ok(Ok(loaded)) = result {
+                if !loaded.is_empty() {
+                    cache.blocks.insert(key.clone(), Arc::<[u8]>::from(loaded));
+                    cache.key_index.write().await.insert(key.clone());
+                    cache.maybe_compact_keys().await;
+                }
+            }
+
+            cache.inflight.lock().await.remove(&key);
+        });
+    }
+
+    async fn invalidate_read_ahead_path(&self, path: &Path) {
+        let keys: Vec<ReadAheadKey> = {
+            let index = self.read_ahead_cache.key_index.read().await;
+            index
+                .iter()
+                .filter(|known| known.path == path || known.path.starts_with(path))
+                .cloned()
+                .collect()
+        };
+
+        for key in keys {
+            self.read_ahead_cache.blocks.invalidate(&key);
+            self.read_ahead_cache.key_index.write().await.remove(&key);
+            self.read_ahead_cache.inflight.lock().await.remove(&key);
+        }
+
+        let mut sequence = self.read_ahead_cache.sequence.lock().await;
+        sequence.retain(|known_path, _| !(known_path == path || known_path.starts_with(path)));
     }
 
     fn ensure_name_allowed(name: &file::Name) -> Result<(), vfs::Error> {

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -5,9 +5,11 @@ use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::collections::BTreeSet;
 
-use dashmap::DashMap;
 use moka::sync::Cache;
+use tokio::sync::RwLock;
+use whirlwind::ShardSet;
 
 use nfs_mamont::consts::nfsv3::{NFS3_COOKIEVERFSIZE, NFS3_CREATEVERFSIZE};
 use nfs_mamont::vfs;
@@ -55,7 +57,6 @@ const DEFAULT_SET_ATTR: set_attr::NewAttr = set_attr::NewAttr {
 };
 
 /// A file system implementation that mirrors a local directory.
-#[derive(Debug)]
 pub struct MirrorFS {
     fsmap: FsMap,
     read_file_cache: ReadFileCache,
@@ -64,10 +65,10 @@ pub struct MirrorFS {
     generation: u64,
 }
 
-#[derive(Debug)]
 struct ReadFileCache {
     files: Cache<PathBuf, Arc<File>>,
-    keys: DashMap<PathBuf, ()>,
+    keys: ShardSet<PathBuf>,
+    key_index: RwLock<BTreeSet<PathBuf>>,
 }
 
 #[derive(Debug)]
@@ -75,17 +76,18 @@ struct CachedAttrEntry {
     metadata: Metadata,
 }
 
-#[derive(Debug)]
 struct AttributeCache {
     attrs: Cache<PathBuf, Arc<CachedAttrEntry>>,
-    keys: DashMap<PathBuf, ()>,
+    keys: ShardSet<PathBuf>,
+    key_index: RwLock<BTreeSet<PathBuf>>,
 }
 
 impl ReadFileCache {
     fn new() -> Self {
         Self {
             files: Cache::builder().max_capacity(READ_FILE_CACHE_LIMIT as u64).build(),
-            keys: DashMap::new(),
+            keys: ShardSet::new(),
+            key_index: RwLock::new(BTreeSet::new()),
         }
     }
 }
@@ -97,7 +99,8 @@ impl AttributeCache {
                 .max_capacity(ATTRIBUTE_CACHE_LIMIT as u64)
                 .time_to_live(ATTRIBUTE_CACHE_TTL)
                 .build(),
-            keys: DashMap::new(),
+            keys: ShardSet::new(),
+            key_index: RwLock::new(BTreeSet::new()),
         }
     }
 }
@@ -135,7 +138,7 @@ impl MirrorFS {
     }
 
     async fn path_for_handle(&self, handle: &file::Handle) -> Result<PathBuf, vfs::Error> {
-        let candidates = self.fsmap.path_candidates_for_handle(handle)?;
+        let candidates = self.fsmap.path_candidates_for_handle(handle).await?;
         for candidate in candidates {
             if self.attr_for_path(&candidate).await.is_ok() {
                 return Ok(candidate);
@@ -146,7 +149,7 @@ impl MirrorFS {
 
     async fn ensure_handle_for_path(&self, path: &Path) -> Result<file::Handle, vfs::Error> {
         let attr = self.attr_for_path(path).await?;
-        self.fsmap.ensure_handle_for_attr(path, &attr)
+        self.fsmap.ensure_handle_for_attr(path, &attr).await
     }
 
     async fn ensure_handles_for_paths(
@@ -167,13 +170,13 @@ impl MirrorFS {
     }
 
     async fn remove_cached_path(&self, path: &Path) {
-        self.fsmap.remove_path(path);
+        self.fsmap.remove_path(path).await;
         self.invalidate_read_file_cache_path(path).await;
         self.invalidate_attr_cache_path(path).await;
     }
 
     async fn rename_cached_path(&self, from: &Path, to: &Path) -> Result<(), vfs::Error> {
-        self.fsmap.rename_path(from, to)?;
+        self.fsmap.rename_path(from, to).await?;
         self.invalidate_read_file_cache_path(from).await;
         self.invalidate_read_file_cache_path(to).await;
         self.invalidate_attr_cache_path(from).await;
@@ -185,7 +188,8 @@ impl MirrorFS {
         if let Some(entry) = self.attr_cache.attrs.get(path) {
             return Ok(Self::attr_from_metadata(&entry.metadata));
         }
-        self.attr_cache.keys.remove(path);
+        self.attr_cache.keys.remove(&path.to_path_buf()).await;
+        self.attr_cache.key_index.write().await.remove(path);
 
         let path_buf = path.to_path_buf();
         let metadata = tokio::task::spawn_blocking(move || {
@@ -198,8 +202,9 @@ impl MirrorFS {
 
         let key = path.to_path_buf();
         self.attr_cache.attrs.insert(key.clone(), Arc::new(CachedAttrEntry { metadata }));
-        self.attr_cache.keys.insert(key, ());
-        self.maybe_compact_attr_keys();
+        self.attr_cache.keys.insert(key.clone()).await;
+        self.attr_cache.key_index.write().await.insert(key);
+        self.maybe_compact_attr_keys().await;
 
         Ok(attr)
     }
@@ -222,87 +227,72 @@ impl MirrorFS {
 
         let key = path.to_path_buf();
         self.read_file_cache.files.insert(key.clone(), opened.clone());
-        self.read_file_cache.keys.insert(key, ());
-        self.maybe_compact_read_file_keys();
+        self.read_file_cache.keys.insert(key.clone()).await;
+        self.read_file_cache.key_index.write().await.insert(key);
+        self.maybe_compact_read_file_keys().await;
 
         Ok(opened)
     }
 
     async fn invalidate_read_file_cache_path(&self, path: &Path) {
-        let keys: Vec<PathBuf> = self
-            .read_file_cache
-            .keys
-            .iter()
-            .filter(|entry| {
-                let known_path = entry.key();
-                known_path == path || known_path.starts_with(path)
-            })
-            .map(|entry| entry.key().clone())
-            .collect();
+        let keys: Vec<PathBuf> = {
+            let index = self.read_file_cache.key_index.read().await;
+            index
+                .iter()
+                .filter(|known_path| *known_path == path || known_path.starts_with(path))
+                .cloned()
+                .collect()
+        };
         for key in keys {
             self.read_file_cache.files.invalidate(&key);
-            self.read_file_cache.keys.remove(&key);
+            self.read_file_cache.keys.remove(&key).await;
+            self.read_file_cache.key_index.write().await.remove(&key);
         }
     }
 
     async fn invalidate_attr_cache_path(&self, path: &Path) {
-        let keys: Vec<PathBuf> = self
-            .attr_cache
-            .keys
-            .iter()
-            .filter(|entry| {
-                let known_path = entry.key();
-                known_path == path || known_path.starts_with(path)
-            })
-            .map(|entry| entry.key().clone())
-            .collect();
+        let keys: Vec<PathBuf> = {
+            let index = self.attr_cache.key_index.read().await;
+            index
+                .iter()
+                .filter(|known_path| *known_path == path || known_path.starts_with(path))
+                .cloned()
+                .collect()
+        };
         for key in keys {
             self.attr_cache.attrs.invalidate(&key);
-            self.attr_cache.keys.remove(&key);
+            self.attr_cache.keys.remove(&key).await;
+            self.attr_cache.key_index.write().await.remove(&key);
         }
     }
 
-    fn maybe_compact_read_file_keys(&self) {
-        if self.read_file_cache.keys.len() <= READ_FILE_CACHE_LIMIT * 4 {
+    async fn maybe_compact_read_file_keys(&self) {
+        if self.read_file_cache.key_index.read().await.len() <= READ_FILE_CACHE_LIMIT * 4 {
             return;
         }
-        let stale_keys: Vec<PathBuf> = self
-            .read_file_cache
-            .keys
-            .iter()
-            .filter_map(|entry| {
-                let key = entry.key().clone();
-                if self.read_file_cache.files.get(&key).is_none() {
-                    Some(key)
-                } else {
-                    None
-                }
-            })
+        let keys: Vec<PathBuf> = self.read_file_cache.key_index.read().await.iter().cloned().collect();
+        let stale_keys: Vec<PathBuf> = keys
+            .into_iter()
+            .filter(|key| self.read_file_cache.files.get(key).is_none())
             .collect();
         for key in stale_keys {
-            self.read_file_cache.keys.remove(&key);
+            self.read_file_cache.keys.remove(&key).await;
+            self.read_file_cache.key_index.write().await.remove(&key);
         }
     }
 
-    fn maybe_compact_attr_keys(&self) {
-        if self.attr_cache.keys.len() <= ATTRIBUTE_CACHE_LIMIT * 4 {
+    async fn maybe_compact_attr_keys(&self) {
+        if self.attr_cache.key_index.read().await.len() <= ATTRIBUTE_CACHE_LIMIT * 4 {
             return;
         }
-        let stale_keys: Vec<PathBuf> = self
-            .attr_cache
-            .keys
-            .iter()
-            .filter_map(|entry| {
-                let key = entry.key().clone();
-                if self.attr_cache.attrs.get(&key).is_none() {
-                    Some(key)
-                } else {
-                    None
-                }
-            })
+        let keys: Vec<PathBuf> = self.attr_cache.key_index.read().await.iter().cloned().collect();
+        let stale_keys: Vec<PathBuf> = keys
+            .into_iter()
+            .filter(|key| self.attr_cache.attrs.get(key).is_none())
             .collect();
         for key in stale_keys {
-            self.attr_cache.keys.remove(&key);
+            self.attr_cache.keys.remove(&key).await;
+            self.attr_cache.key_index.write().await.remove(&key);
         }
     }
 

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -1,13 +1,14 @@
-use std::collections::{HashMap, VecDeque};
 use std::fs::File;
 use std::fs::Metadata;
 use std::io::ErrorKind;
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use tokio::sync::{Mutex, RwLock};
+use dashmap::DashMap;
+use moka::sync::Cache;
+use tokio::sync::RwLock;
 
 use nfs_mamont::consts::nfsv3::{NFS3_COOKIEVERFSIZE, NFS3_CREATEVERFSIZE};
 use nfs_mamont::vfs;
@@ -58,28 +59,48 @@ const DEFAULT_SET_ATTR: set_attr::NewAttr = set_attr::NewAttr {
 #[derive(Debug)]
 pub struct MirrorFS {
     fsmap: RwLock<FsMap>,
-    read_file_cache: Mutex<ReadFileCache>,
-    attr_cache: Mutex<AttributeCache>,
+    read_file_cache: ReadFileCache,
+    attr_cache: AttributeCache,
     root_path: PathBuf,
     generation: u64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct ReadFileCache {
-    files: HashMap<PathBuf, Arc<File>>,
-    order: VecDeque<PathBuf>,
+    files: Cache<PathBuf, Arc<File>>,
+    keys: DashMap<PathBuf, ()>,
 }
 
 #[derive(Debug)]
 struct CachedAttrEntry {
     metadata: Metadata,
-    expires_at: Instant,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct AttributeCache {
-    attrs: HashMap<PathBuf, CachedAttrEntry>,
-    order: VecDeque<PathBuf>,
+    attrs: Cache<PathBuf, Arc<CachedAttrEntry>>,
+    keys: DashMap<PathBuf, ()>,
+}
+
+impl ReadFileCache {
+    fn new() -> Self {
+        Self {
+            files: Cache::builder().max_capacity(READ_FILE_CACHE_LIMIT as u64).build(),
+            keys: DashMap::new(),
+        }
+    }
+}
+
+impl AttributeCache {
+    fn new() -> Self {
+        Self {
+            attrs: Cache::builder()
+                .max_capacity(ATTRIBUTE_CACHE_LIMIT as u64)
+                .time_to_live(ATTRIBUTE_CACHE_TTL)
+                .build(),
+            keys: DashMap::new(),
+        }
+    }
 }
 
 impl MirrorFS {
@@ -91,8 +112,8 @@ impl MirrorFS {
                 as u64;
         Self {
             fsmap: RwLock::new(FsMap::new(root.clone())),
-            read_file_cache: Mutex::new(ReadFileCache::default()),
-            attr_cache: Mutex::new(AttributeCache::default()),
+            read_file_cache: ReadFileCache::new(),
+            attr_cache: AttributeCache::new(),
             root_path: root,
             generation,
         }
@@ -158,19 +179,10 @@ impl MirrorFS {
     }
 
     async fn attr_for_path(&self, path: &Path) -> Result<file::Attr, vfs::Error> {
-        let now = Instant::now();
-        {
-            let mut cache = self.attr_cache.lock().await;
-            if let Some(entry) = cache.attrs.get(path) {
-                if entry.expires_at > now {
-                    let attr = Self::attr_from_metadata(&entry.metadata);
-                    Self::touch_attr_cache_entry(&mut cache.order, path);
-                    return Ok(attr);
-                }
-            }
-            cache.attrs.remove(path);
-            cache.order.retain(|known_path| known_path != path);
+        if let Some(entry) = self.attr_cache.attrs.get(path) {
+            return Ok(Self::attr_from_metadata(&entry.metadata));
         }
+        self.attr_cache.keys.remove(path);
 
         let path_buf = path.to_path_buf();
         let metadata = tokio::task::spawn_blocking(move || {
@@ -181,30 +193,17 @@ impl MirrorFS {
 
         let attr = Self::attr_from_metadata(&metadata);
 
-        let mut cache = self.attr_cache.lock().await;
-        cache.attrs.insert(
-            path.to_path_buf(),
-            CachedAttrEntry { metadata, expires_at: Instant::now() + ATTRIBUTE_CACHE_TTL },
-        );
-        Self::touch_attr_cache_entry(&mut cache.order, path);
-
-        while cache.attrs.len() > ATTRIBUTE_CACHE_LIMIT {
-            let Some(evicted_path) = cache.order.pop_front() else {
-                break;
-            };
-            cache.attrs.remove(&evicted_path);
-        }
+        let key = path.to_path_buf();
+        self.attr_cache.attrs.insert(key.clone(), Arc::new(CachedAttrEntry { metadata }));
+        self.attr_cache.keys.insert(key, ());
+        self.maybe_compact_attr_keys();
 
         Ok(attr)
     }
 
     async fn get_cached_read_file(&self, path: &Path) -> Result<Arc<File>, vfs::Error> {
-        {
-            let mut cache = self.read_file_cache.lock().await;
-            if let Some(file) = cache.files.get(path).cloned() {
-                Self::touch_read_cache_entry(&mut cache.order, path);
-                return Ok(file);
-            }
+        if let Some(file) = self.read_file_cache.files.get(path) {
+            return Ok(file);
         }
 
         let path_buf = path.to_path_buf();
@@ -214,49 +213,94 @@ impl MirrorFS {
             .map_err(|error| Self::io_error_to_vfs(&error))?;
         let opened = Arc::new(opened);
 
-        let mut cache = self.read_file_cache.lock().await;
-        if let Some(existing) = cache.files.get(path).cloned() {
-            Self::touch_read_cache_entry(&mut cache.order, path);
+        if let Some(existing) = self.read_file_cache.files.get(path) {
             return Ok(existing);
         }
 
-        cache.files.insert(path.to_path_buf(), opened.clone());
-        Self::touch_read_cache_entry(&mut cache.order, path);
-
-        while cache.files.len() > READ_FILE_CACHE_LIMIT {
-            let Some(evicted_path) = cache.order.pop_front() else {
-                break;
-            };
-            cache.files.remove(&evicted_path);
-        }
+        let key = path.to_path_buf();
+        self.read_file_cache.files.insert(key.clone(), opened.clone());
+        self.read_file_cache.keys.insert(key, ());
+        self.maybe_compact_read_file_keys();
 
         Ok(opened)
     }
 
     async fn invalidate_read_file_cache_path(&self, path: &Path) {
-        let mut cache = self.read_file_cache.lock().await;
-        cache.files.retain(|known_path, _| !(known_path == path || known_path.starts_with(path)));
-        cache.order.retain(|known_path| known_path != path && !known_path.starts_with(path));
+        let keys: Vec<PathBuf> = self
+            .read_file_cache
+            .keys
+            .iter()
+            .filter(|entry| {
+                let known_path = entry.key();
+                known_path == path || known_path.starts_with(path)
+            })
+            .map(|entry| entry.key().clone())
+            .collect();
+        for key in keys {
+            self.read_file_cache.files.invalidate(&key);
+            self.read_file_cache.keys.remove(&key);
+        }
     }
 
     async fn invalidate_attr_cache_path(&self, path: &Path) {
-        let mut cache = self.attr_cache.lock().await;
-        cache.attrs.retain(|known_path, _| !(known_path == path || known_path.starts_with(path)));
-        cache.order.retain(|known_path| known_path != path && !known_path.starts_with(path));
+        let keys: Vec<PathBuf> = self
+            .attr_cache
+            .keys
+            .iter()
+            .filter(|entry| {
+                let known_path = entry.key();
+                known_path == path || known_path.starts_with(path)
+            })
+            .map(|entry| entry.key().clone())
+            .collect();
+        for key in keys {
+            self.attr_cache.attrs.invalidate(&key);
+            self.attr_cache.keys.remove(&key);
+        }
     }
 
-    fn touch_read_cache_entry(order: &mut VecDeque<PathBuf>, path: &Path) {
-        if let Some(pos) = order.iter().position(|entry| entry == path) {
-            order.remove(pos);
+    fn maybe_compact_read_file_keys(&self) {
+        if self.read_file_cache.keys.len() <= READ_FILE_CACHE_LIMIT * 4 {
+            return;
         }
-        order.push_back(path.to_path_buf());
+        let stale_keys: Vec<PathBuf> = self
+            .read_file_cache
+            .keys
+            .iter()
+            .filter_map(|entry| {
+                let key = entry.key().clone();
+                if self.read_file_cache.files.get(&key).is_none() {
+                    Some(key)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for key in stale_keys {
+            self.read_file_cache.keys.remove(&key);
+        }
     }
 
-    fn touch_attr_cache_entry(order: &mut VecDeque<PathBuf>, path: &Path) {
-        if let Some(pos) = order.iter().position(|entry| entry == path) {
-            order.remove(pos);
+    fn maybe_compact_attr_keys(&self) {
+        if self.attr_cache.keys.len() <= ATTRIBUTE_CACHE_LIMIT * 4 {
+            return;
         }
-        order.push_back(path.to_path_buf());
+        let stale_keys: Vec<PathBuf> = self
+            .attr_cache
+            .keys
+            .iter()
+            .filter_map(|entry| {
+                let key = entry.key().clone();
+                if self.attr_cache.attrs.get(&key).is_none() {
+                    Some(key)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for key in stale_keys {
+            self.attr_cache.keys.remove(&key);
+        }
     }
 
     fn ensure_name_allowed(name: &file::Name) -> Result<(), vfs::Error> {

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::fs::Metadata;
 use std::io::ErrorKind;
+use std::os::unix::fs::DirEntryExt;
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -47,6 +48,8 @@ const READ_DIR_PREF: u32 = 8 * 1024;
 const READ_FILE_CACHE_LIMIT: usize = 1024;
 const ATTRIBUTE_CACHE_LIMIT: usize = 16 * 1024;
 const ATTRIBUTE_CACHE_TTL: Duration = Duration::from_secs(3);
+const DIRECTORY_LISTING_CACHE_LIMIT: usize = 1024;
+const DIRECTORY_LISTING_CACHE_TTL: Duration = Duration::from_millis(700);
 const DEFAULT_SET_ATTR: set_attr::NewAttr = set_attr::NewAttr {
     mode: None,
     uid: None,
@@ -61,8 +64,25 @@ pub struct MirrorFS {
     fsmap: FsMap,
     read_file_cache: ReadFileCache,
     attr_cache: AttributeCache,
+    dir_listing_cache: DirectoryListingCache,
     root_path: PathBuf,
     generation: u64,
+}
+
+#[derive(Clone)]
+struct DirectoryEntrySnapshot {
+    name: file::Name,
+    path: PathBuf,
+    file_id: u64,
+}
+
+struct DirectoryListingSnapshot {
+    verifier: read_dir::CookieVerifier,
+    entries: Arc<[DirectoryEntrySnapshot]>,
+}
+
+struct DirectoryListingCache {
+    listings: Cache<PathBuf, Arc<DirectoryListingSnapshot>>,
 }
 
 struct ReadFileCache {
@@ -105,6 +125,17 @@ impl AttributeCache {
     }
 }
 
+impl DirectoryListingCache {
+    fn new() -> Self {
+        Self {
+            listings: Cache::builder()
+                .max_capacity(DIRECTORY_LISTING_CACHE_LIMIT as u64)
+                .time_to_live(DIRECTORY_LISTING_CACHE_TTL)
+                .build(),
+        }
+    }
+}
+
 impl MirrorFS {
     /// Creates a new mirror file system with the given root path.
     pub fn new(root: PathBuf) -> Self {
@@ -116,6 +147,7 @@ impl MirrorFS {
             fsmap: FsMap::new(root.clone()),
             read_file_cache: ReadFileCache::new(),
             attr_cache: AttributeCache::new(),
+            dir_listing_cache: DirectoryListingCache::new(),
             root_path: root,
             generation,
         }
@@ -478,10 +510,31 @@ impl MirrorFS {
         Ok(())
     }
 
-    async fn list_directory_entries(
+    async fn directory_entries_for(
         &self,
         dir_path: &Path,
-    ) -> Result<Vec<(file::Name, PathBuf, Metadata)>, vfs::Error> {
+        verifier: read_dir::CookieVerifier,
+    ) -> Result<Arc<[DirectoryEntrySnapshot]>, vfs::Error> {
+        if let Some(cached) = self.dir_listing_cache.listings.get(dir_path) {
+            if cached.verifier == verifier {
+                return Ok(Arc::clone(&cached.entries));
+            }
+        }
+
+        let entries = Self::load_directory_entries(dir_path).await?;
+        let key = dir_path.to_path_buf();
+        let snapshot = Arc::new(DirectoryListingSnapshot {
+            verifier,
+            entries: Arc::<[DirectoryEntrySnapshot]>::from(entries),
+        });
+        let result = Arc::clone(&snapshot.entries);
+        self.dir_listing_cache.listings.insert(key, snapshot);
+        Ok(result)
+    }
+
+    async fn load_directory_entries(
+        dir_path: &Path,
+    ) -> Result<Vec<DirectoryEntrySnapshot>, vfs::Error> {
         let dir_path = dir_path.to_path_buf();
         tokio::task::spawn_blocking(move || {
             let mut entries = Vec::new();
@@ -493,12 +546,12 @@ impl MirrorFS {
                 let name = file::Name::new(file_name.to_string_lossy().into_owned())
                     .map_err(|_| vfs::Error::InvalidArgument)?;
                 let path = item.path();
-                let metadata = item.metadata().map_err(|error| Self::io_error_to_vfs(&error))?;
-                entries.push((name, path, metadata));
+                let file_id = item.ino();
+                entries.push(DirectoryEntrySnapshot { name, path, file_id });
             }
 
-            entries.sort_by(|left, right| left.0.as_str().cmp(right.0.as_str()));
-            Ok::<Vec<(file::Name, PathBuf, Metadata)>, vfs::Error>(entries)
+            entries.sort_by(|left, right| left.name.as_str().cmp(right.name.as_str()));
+            Ok::<Vec<DirectoryEntrySnapshot>, vfs::Error>(entries)
         })
         .await
         .map_err(|_| vfs::Error::IO)?

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -43,7 +43,7 @@ mod set_attr_impl;
 mod symlink_impl;
 mod write_impl;
 
-const READ_WRITE_MAX: u32 = 64 * 1024;
+const READ_WRITE_MAX: u32 = 1024 * 1024;
 const READ_DIR_PREF: u32 = 8 * 1024;
 const READ_FILE_CACHE_LIMIT: usize = 1024;
 const ATTRIBUTE_CACHE_LIMIT: usize = 16 * 1024;

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -12,7 +12,6 @@ use nfs_mamont::vfs::file;
 use nfs_mamont::vfs::read_dir;
 use nfs_mamont::vfs::set_attr;
 use nfs_mamont::vfs::write;
-use nfs_mamont::Slice;
 
 use crate::fs_map::FsMap;
 
@@ -206,18 +205,6 @@ impl MirrorFS {
         } else {
             Err(vfs::Error::InvalidArgument)
         }
-    }
-
-    fn collect_slice_bytes(slice: &Slice, size: u32) -> Vec<u8> {
-        let mut data = Vec::with_capacity(size as usize);
-        for part in slice {
-            data.extend_from_slice(part);
-            if data.len() >= size as usize {
-                data.truncate(size as usize);
-                break;
-            }
-        }
-        data
     }
 
     fn file_attr(path: &Path) -> Option<file::Attr> {

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -112,7 +112,7 @@ struct AttributeCache {
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct ReadAheadKey {
     path: PathBuf,
-    offset: u64,
+    block_index: u64,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -399,22 +399,58 @@ impl MirrorFS {
         requested: usize,
         data: &mut nfs_mamont::Slice,
     ) -> Option<usize> {
-        let key = ReadAheadKey { path: path.to_path_buf(), offset };
-        let block = self.read_ahead_cache.blocks.get(&key)?;
+        if requested == 0 {
+            return Some(0);
+        }
 
+        let block_size = READ_AHEAD_BLOCK_SIZE as u64;
         let mut copied = 0usize;
-        let max_copy = requested.min(block.len());
-        for chunk in data.iter_mut() {
-            if copied >= max_copy {
+        let mut current_offset = offset;
+
+        while copied < requested {
+            let block_index = current_offset / block_size;
+            let block_offset = (current_offset % block_size) as usize;
+            let key = ReadAheadKey { path: path.to_path_buf(), block_index };
+            let block = match self.read_ahead_cache.blocks.get(&key) {
+                Some(block) => block,
+                None => break,
+            };
+
+            if block_offset >= block.len() {
                 break;
             }
 
-            let take = chunk.len().min(max_copy - copied);
-            chunk[..take].copy_from_slice(&block[copied..copied + take]);
-            copied += take;
+            let available = block.len() - block_offset;
+            let to_copy = available.min(requested - copied);
+            if to_copy == 0 {
+                break;
+            }
+
+            let mut left = to_copy;
+            let mut dst_pos = copied;
+            let mut src_pos = block_offset;
+            for chunk in data.iter_mut() {
+                if left == 0 {
+                    break;
+                }
+                if dst_pos >= chunk.len() {
+                    dst_pos -= chunk.len();
+                    continue;
+                }
+
+                let writable = (chunk.len() - dst_pos).min(left);
+                chunk[dst_pos..dst_pos + writable]
+                    .copy_from_slice(&block[src_pos..src_pos + writable]);
+                left -= writable;
+                src_pos += writable;
+                dst_pos = 0;
+            }
+
+            copied += to_copy;
+            current_offset = current_offset.saturating_add(to_copy as u64);
         }
 
-        Some(copied)
+        if copied == 0 { None } else { Some(copied) }
     }
 
     async fn update_read_sequence(&self, path: &Path, start: u64, end: u64) -> bool {
@@ -440,17 +476,24 @@ impl MirrorFS {
         sequential
     }
 
-    async fn schedule_read_ahead(&self, path: &Path, file: Arc<File>, offset: u64, file_len: u64) {
-        if offset >= file_len {
+    async fn schedule_read_ahead(
+        &self,
+        path: &Path,
+        file: Arc<File>,
+        block_index: u64,
+        file_len: u64,
+    ) {
+        let block_start = block_index.saturating_mul(READ_AHEAD_BLOCK_SIZE as u64);
+        if block_start >= file_len {
             return;
         }
 
-        let prefetch_size = (file_len - offset).min(READ_AHEAD_BLOCK_SIZE as u64) as usize;
+        let prefetch_size = (file_len - block_start).min(READ_AHEAD_BLOCK_SIZE as u64) as usize;
         if prefetch_size == 0 {
             return;
         }
 
-        let key = ReadAheadKey { path: path.to_path_buf(), offset };
+        let key = ReadAheadKey { path: path.to_path_buf(), block_index };
         if self.read_ahead_cache.blocks.get(&key).is_some() {
             return;
         }
@@ -477,7 +520,7 @@ impl MirrorFS {
                 let mut total = 0usize;
 
                 while total < prefetch_size {
-                    let read = file.read_at(&mut loaded[total..], offset + total as u64)?;
+                    let read = file.read_at(&mut loaded[total..], block_start + total as u64)?;
                     if read == 0 {
                         break;
                     }
@@ -505,16 +548,17 @@ impl MirrorFS {
         &self,
         path: &Path,
         file: Arc<File>,
-        start_offset: u64,
+        start_block_index: u64,
         file_len: u64,
     ) {
         for block in 0..READ_AHEAD_WINDOW_BLOCKS {
-            let offset = start_offset.saturating_add((block * READ_AHEAD_BLOCK_SIZE) as u64);
-            if offset >= file_len {
+            let block_index = start_block_index.saturating_add(block as u64);
+            let block_start = block_index.saturating_mul(READ_AHEAD_BLOCK_SIZE as u64);
+            if block_start >= file_len {
                 break;
             }
 
-            self.schedule_read_ahead(path, file.clone(), offset, file_len).await;
+            self.schedule_read_ahead(path, file.clone(), block_index, file_len).await;
         }
     }
 

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs::File;
 use std::fs::Metadata;
 use std::io::ErrorKind;
@@ -6,7 +7,6 @@ use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use std::collections::BTreeSet;
 
 use moka::sync::Cache;
 use tokio::sync::RwLock;
@@ -302,11 +302,10 @@ impl MirrorFS {
         if self.read_file_cache.key_index.read().await.len() <= READ_FILE_CACHE_LIMIT * 4 {
             return;
         }
-        let keys: Vec<PathBuf> = self.read_file_cache.key_index.read().await.iter().cloned().collect();
-        let stale_keys: Vec<PathBuf> = keys
-            .into_iter()
-            .filter(|key| self.read_file_cache.files.get(key).is_none())
-            .collect();
+        let keys: Vec<PathBuf> =
+            self.read_file_cache.key_index.read().await.iter().cloned().collect();
+        let stale_keys: Vec<PathBuf> =
+            keys.into_iter().filter(|key| self.read_file_cache.files.get(key).is_none()).collect();
         for key in stale_keys {
             self.read_file_cache.keys.remove(&key).await;
             self.read_file_cache.key_index.write().await.remove(&key);
@@ -318,10 +317,8 @@ impl MirrorFS {
             return;
         }
         let keys: Vec<PathBuf> = self.attr_cache.key_index.read().await.iter().cloned().collect();
-        let stale_keys: Vec<PathBuf> = keys
-            .into_iter()
-            .filter(|key| self.attr_cache.attrs.get(key).is_none())
-            .collect();
+        let stale_keys: Vec<PathBuf> =
+            keys.into_iter().filter(|key| self.attr_cache.attrs.get(key).is_none()).collect();
         for key in stale_keys {
             self.attr_cache.keys.remove(&key).await;
             self.attr_cache.key_index.write().await.remove(&key);
@@ -538,7 +535,8 @@ impl MirrorFS {
         let dir_path = dir_path.to_path_buf();
         tokio::task::spawn_blocking(move || {
             let mut entries = Vec::new();
-            let listing = std::fs::read_dir(dir_path).map_err(|error| Self::io_error_to_vfs(&error))?;
+            let listing =
+                std::fs::read_dir(dir_path).map_err(|error| Self::io_error_to_vfs(&error))?;
 
             for item in listing {
                 let item = item.map_err(|error| Self::io_error_to_vfs(&error))?;

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -51,10 +51,11 @@ const ATTRIBUTE_CACHE_TTL: Duration = Duration::from_secs(60);
 const DIRECTORY_LISTING_CACHE_LIMIT: usize = 1024;
 const DIRECTORY_LISTING_CACHE_TTL: Duration = Duration::from_millis(700);
 const READ_AHEAD_BLOCK_SIZE: usize = READ_WRITE_MAX as usize;
-const READ_AHEAD_CACHE_LIMIT: usize = 256;
-const READ_AHEAD_PER_FILE_LIMIT: usize = 4;
-const READ_AHEAD_CACHE_TTL: Duration = Duration::from_secs(15);
-const READ_AHEAD_SEQUENCE_WINDOW: Duration = Duration::from_secs(2);
+const READ_AHEAD_WINDOW_BLOCKS: usize = 8;
+const READ_AHEAD_CACHE_LIMIT: usize = 1024;
+const READ_AHEAD_PER_FILE_LIMIT: usize = 16;
+const READ_AHEAD_CACHE_TTL: Duration = Duration::from_secs(30);
+const READ_AHEAD_SEQUENCE_WINDOW: Duration = Duration::from_secs(6);
 const DEFAULT_SET_ATTR: set_attr::NewAttr = set_attr::NewAttr {
     mode: None,
     uid: None,
@@ -498,6 +499,23 @@ impl MirrorFS {
 
             cache.inflight.lock().await.remove(&key);
         });
+    }
+
+    async fn schedule_read_ahead_window(
+        &self,
+        path: &Path,
+        file: Arc<File>,
+        start_offset: u64,
+        file_len: u64,
+    ) {
+        for block in 0..READ_AHEAD_WINDOW_BLOCKS {
+            let offset = start_offset.saturating_add((block * READ_AHEAD_BLOCK_SIZE) as u64);
+            if offset >= file_len {
+                break;
+            }
+
+            self.schedule_read_ahead(path, file.clone(), offset, file_len).await;
+        }
     }
 
     async fn invalidate_read_ahead_path(&self, path: &Path) {

--- a/examples/mirror_fs/fs.rs
+++ b/examples/mirror_fs/fs.rs
@@ -5,7 +5,7 @@ use std::io::ErrorKind;
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use tokio::sync::{Mutex, RwLock};
 
@@ -43,6 +43,8 @@ mod write_impl;
 const READ_WRITE_MAX: u32 = 64 * 1024;
 const READ_DIR_PREF: u32 = 8 * 1024;
 const READ_FILE_CACHE_LIMIT: usize = 1024;
+const ATTRIBUTE_CACHE_LIMIT: usize = 16 * 1024;
+const ATTRIBUTE_CACHE_TTL: Duration = Duration::from_secs(3);
 const DEFAULT_SET_ATTR: set_attr::NewAttr = set_attr::NewAttr {
     mode: None,
     uid: None,
@@ -57,6 +59,7 @@ const DEFAULT_SET_ATTR: set_attr::NewAttr = set_attr::NewAttr {
 pub struct MirrorFS {
     fsmap: RwLock<FsMap>,
     read_file_cache: Mutex<ReadFileCache>,
+    attr_cache: Mutex<AttributeCache>,
     root_path: PathBuf,
     generation: u64,
 }
@@ -64,6 +67,18 @@ pub struct MirrorFS {
 #[derive(Debug, Default)]
 struct ReadFileCache {
     files: HashMap<PathBuf, Arc<File>>,
+    order: VecDeque<PathBuf>,
+}
+
+#[derive(Debug)]
+struct CachedAttrEntry {
+    metadata: Metadata,
+    expires_at: Instant,
+}
+
+#[derive(Debug, Default)]
+struct AttributeCache {
+    attrs: HashMap<PathBuf, CachedAttrEntry>,
     order: VecDeque<PathBuf>,
 }
 
@@ -77,6 +92,7 @@ impl MirrorFS {
         Self {
             fsmap: RwLock::new(FsMap::new(root.clone())),
             read_file_cache: Mutex::new(ReadFileCache::default()),
+            attr_cache: Mutex::new(AttributeCache::default()),
             root_path: root,
             generation,
         }
@@ -129,13 +145,57 @@ impl MirrorFS {
     async fn remove_cached_path(&self, path: &Path) {
         self.fsmap.write().await.remove_path(path);
         self.invalidate_read_file_cache_path(path).await;
+        self.invalidate_attr_cache_path(path).await;
     }
 
     async fn rename_cached_path(&self, from: &Path, to: &Path) -> Result<(), vfs::Error> {
         self.fsmap.write().await.rename_path(from, to)?;
         self.invalidate_read_file_cache_path(from).await;
         self.invalidate_read_file_cache_path(to).await;
+        self.invalidate_attr_cache_path(from).await;
+        self.invalidate_attr_cache_path(to).await;
         Ok(())
+    }
+
+    async fn attr_for_path(&self, path: &Path) -> Result<file::Attr, vfs::Error> {
+        let now = Instant::now();
+        {
+            let mut cache = self.attr_cache.lock().await;
+            if let Some(entry) = cache.attrs.get(path) {
+                if entry.expires_at > now {
+                    let attr = Self::attr_from_metadata(&entry.metadata);
+                    Self::touch_attr_cache_entry(&mut cache.order, path);
+                    return Ok(attr);
+                }
+            }
+            cache.attrs.remove(path);
+            cache.order.retain(|known_path| known_path != path);
+        }
+
+        let path_buf = path.to_path_buf();
+        let metadata = tokio::task::spawn_blocking(move || {
+            std::fs::symlink_metadata(path_buf).map_err(|error| Self::io_error_to_vfs(&error))
+        })
+        .await
+        .map_err(|_| vfs::Error::IO)??;
+
+        let attr = Self::attr_from_metadata(&metadata);
+
+        let mut cache = self.attr_cache.lock().await;
+        cache.attrs.insert(
+            path.to_path_buf(),
+            CachedAttrEntry { metadata, expires_at: Instant::now() + ATTRIBUTE_CACHE_TTL },
+        );
+        Self::touch_attr_cache_entry(&mut cache.order, path);
+
+        while cache.attrs.len() > ATTRIBUTE_CACHE_LIMIT {
+            let Some(evicted_path) = cache.order.pop_front() else {
+                break;
+            };
+            cache.attrs.remove(&evicted_path);
+        }
+
+        Ok(attr)
     }
 
     async fn get_cached_read_file(&self, path: &Path) -> Result<Arc<File>, vfs::Error> {
@@ -179,7 +239,20 @@ impl MirrorFS {
         cache.order.retain(|known_path| known_path != path && !known_path.starts_with(path));
     }
 
+    async fn invalidate_attr_cache_path(&self, path: &Path) {
+        let mut cache = self.attr_cache.lock().await;
+        cache.attrs.retain(|known_path, _| !(known_path == path || known_path.starts_with(path)));
+        cache.order.retain(|known_path| known_path != path && !known_path.starts_with(path));
+    }
+
     fn touch_read_cache_entry(order: &mut VecDeque<PathBuf>, path: &Path) {
+        if let Some(pos) = order.iter().position(|entry| entry == path) {
+            order.remove(pos);
+        }
+        order.push_back(path.to_path_buf());
+    }
+
+    fn touch_attr_cache_entry(order: &mut VecDeque<PathBuf>, path: &Path) {
         if let Some(pos) = order.iter().position(|entry| entry == path) {
             order.remove(pos);
         }
@@ -368,25 +441,30 @@ impl MirrorFS {
         Ok(())
     }
 
-    fn list_directory_entries(
+    async fn list_directory_entries(
         &self,
         dir_path: &Path,
     ) -> Result<Vec<(file::Name, PathBuf, Metadata)>, vfs::Error> {
-        let mut entries = Vec::new();
-        let listing = std::fs::read_dir(dir_path).map_err(|error| Self::io_error_to_vfs(&error))?;
+        let dir_path = dir_path.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            let mut entries = Vec::new();
+            let listing = std::fs::read_dir(dir_path).map_err(|error| Self::io_error_to_vfs(&error))?;
 
-        for item in listing {
-            let item = item.map_err(|error| Self::io_error_to_vfs(&error))?;
-            let file_name = item.file_name();
-            let name = file::Name::new(file_name.to_string_lossy().into_owned())
-                .map_err(|_| vfs::Error::InvalidArgument)?;
-            let path = item.path();
-            let metadata = item.metadata().map_err(|error| Self::io_error_to_vfs(&error))?;
-            entries.push((name, path, metadata));
-        }
+            for item in listing {
+                let item = item.map_err(|error| Self::io_error_to_vfs(&error))?;
+                let file_name = item.file_name();
+                let name = file::Name::new(file_name.to_string_lossy().into_owned())
+                    .map_err(|_| vfs::Error::InvalidArgument)?;
+                let path = item.path();
+                let metadata = item.metadata().map_err(|error| Self::io_error_to_vfs(&error))?;
+                entries.push((name, path, metadata));
+            }
 
-        entries.sort_by(|left, right| left.0.as_str().cmp(right.0.as_str()));
-        Ok(entries)
+            entries.sort_by(|left, right| left.0.as_str().cmp(right.0.as_str()));
+            Ok::<Vec<(file::Name, PathBuf, Metadata)>, vfs::Error>(entries)
+        })
+        .await
+        .map_err(|_| vfs::Error::IO)?
     }
 
     async fn child_path(

--- a/examples/mirror_fs/fs/access_impl.rs
+++ b/examples/mirror_fs/fs/access_impl.rs
@@ -1,11 +1,8 @@
-use async_trait::async_trait;
-
 use nfs_mamont::vfs::access;
 use nfs_mamont::vfs::file;
 
 use super::MirrorFS;
 
-#[async_trait]
 impl access::Access for MirrorFS {
     async fn access(&self, args: access::Args) -> Result<access::Success, access::Fail> {
         let path = match self.path_for_handle(&args.file).await {

--- a/examples/mirror_fs/fs/commit_impl.rs
+++ b/examples/mirror_fs/fs/commit_impl.rs
@@ -17,23 +17,32 @@ impl commit::Commit for MirrorFS {
                 });
             }
         };
-        let before_meta = std::fs::symlink_metadata(&path).ok();
-        let before = before_meta.as_ref().map(Self::wcc_attr_from_metadata);
-        if let Some(attr) = before_meta.as_ref().map(Self::attr_from_metadata) {
-            if let Err(error) = Self::validate_regular(&attr) {
-                return Err(commit::Fail { error, file_wcc: Self::wcc_data(&path, before) });
-            }
-        }
 
         let file = match OpenOptions::new().write(true).open(&path).await {
             Ok(file) => file,
             Err(error) => {
                 return Err(commit::Fail {
                     error: Self::io_error_to_vfs(&error),
-                    file_wcc: Self::wcc_data(&path, before),
+                    file_wcc: vfs::WccData { before: None, after: None },
                 });
             }
         };
+
+        let before_meta = match file.metadata().await {
+            Ok(meta) => meta,
+            Err(error) => {
+                return Err(commit::Fail {
+                    error: Self::io_error_to_vfs(&error),
+                    file_wcc: vfs::WccData { before: None, after: None },
+                });
+            }
+        };
+        let before = Some(Self::wcc_attr_from_metadata(&before_meta));
+        let attr = Self::attr_from_metadata(&before_meta);
+        if let Err(error) = Self::validate_regular(&attr) {
+            return Err(commit::Fail { error, file_wcc: Self::wcc_data(&path, before) });
+        }
+
         if let Err(error) = file.sync_all().await {
             return Err(commit::Fail {
                 error: Self::io_error_to_vfs(&error),

--- a/examples/mirror_fs/fs/commit_impl.rs
+++ b/examples/mirror_fs/fs/commit_impl.rs
@@ -48,6 +48,8 @@ impl commit::Commit for MirrorFS {
             });
         }
 
+        self.clear_pending_unstable_write(&path).await;
+
         Ok(commit::Success {
             file_wcc: Self::wcc_data(&path, before),
             verifier: self.write_verifier(),

--- a/examples/mirror_fs/fs/commit_impl.rs
+++ b/examples/mirror_fs/fs/commit_impl.rs
@@ -1,11 +1,9 @@
-use async_trait::async_trait;
 use tokio::fs::OpenOptions;
 
 use nfs_mamont::vfs::commit;
 
 use super::*;
 
-#[async_trait]
 impl commit::Commit for MirrorFS {
     async fn commit(&self, args: commit::Args) -> Result<commit::Success, commit::Fail> {
         let path = match self.path_for_handle(&args.file).await {

--- a/examples/mirror_fs/fs/create_impl.rs
+++ b/examples/mirror_fs/fs/create_impl.rs
@@ -41,33 +41,24 @@ impl create::Create for MirrorFS {
 
         let mut child_path = dir_path.clone();
         child_path.push(args.object.name.as_str());
-        let existed = std::fs::symlink_metadata(&child_path).is_ok();
 
         let apply_attr = match &args.how {
             create::How::Unchecked(attr) => {
-                if !existed {
-                    if let Err(error) = OpenOptions::new()
-                        .write(true)
-                        .create(true)
-                        .truncate(false)
-                        .open(&child_path)
-                        .await
-                    {
-                        return Err(create::Fail {
-                            error: Self::io_error_to_vfs(&error),
-                            wcc_data: Self::wcc_data(&dir_path, before),
-                        });
-                    }
+                if let Err(error) = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .open(&child_path)
+                    .await
+                {
+                    return Err(create::Fail {
+                        error: Self::io_error_to_vfs(&error),
+                        wcc_data: Self::wcc_data(&dir_path, before),
+                    });
                 }
                 attr
             }
             create::How::Guarded(attr) => {
-                if existed {
-                    return Err(create::Fail {
-                        error: vfs::Error::Exist,
-                        wcc_data: Self::wcc_data(&dir_path, before),
-                    });
-                }
                 if let Err(error) =
                     OpenOptions::new().write(true).create_new(true).open(&child_path).await
                 {

--- a/examples/mirror_fs/fs/create_impl.rs
+++ b/examples/mirror_fs/fs/create_impl.rs
@@ -1,11 +1,9 @@
-use async_trait::async_trait;
 use tokio::fs::OpenOptions;
 
 use nfs_mamont::vfs::{self, create};
 
 use super::{MirrorFS, DEFAULT_SET_ATTR};
 
-#[async_trait]
 impl create::Create for MirrorFS {
     async fn create(&self, args: create::Args) -> Result<create::Success, create::Fail> {
         if let Err(error) = Self::ensure_name_allowed(&args.object.name) {

--- a/examples/mirror_fs/fs/create_impl.rs
+++ b/examples/mirror_fs/fs/create_impl.rs
@@ -108,6 +108,9 @@ impl create::Create for MirrorFS {
             }
         };
 
+        self.invalidate_attr_cache_path(&child_path).await;
+        self.invalidate_attr_cache_path(&dir_path).await;
+
         Ok(create::Success {
             file: Some(handle),
             attr: Some(attr),

--- a/examples/mirror_fs/fs/fs_info_impl.rs
+++ b/examples/mirror_fs/fs/fs_info_impl.rs
@@ -1,11 +1,8 @@
-use async_trait::async_trait;
-
 use nfs_mamont::vfs::file;
 use nfs_mamont::vfs::fs_info;
 
 use super::{MirrorFS, READ_DIR_PREF, READ_WRITE_MAX};
 
-#[async_trait]
 impl fs_info::FsInfo for MirrorFS {
     async fn fs_info(&self, args: fs_info::Args) -> Result<fs_info::Success, fs_info::Fail> {
         let path = match self.path_for_handle(&args.root).await {

--- a/examples/mirror_fs/fs/fs_stat_impl.rs
+++ b/examples/mirror_fs/fs/fs_stat_impl.rs
@@ -1,10 +1,7 @@
-use async_trait::async_trait;
-
 use nfs_mamont::vfs::fs_stat;
 
 use super::MirrorFS;
 
-#[async_trait]
 impl fs_stat::FsStat for MirrorFS {
     async fn fs_stat(&self, args: fs_stat::Args) -> Result<fs_stat::Success, fs_stat::Fail> {
         let path = match self.path_for_handle(&args.root).await {

--- a/examples/mirror_fs/fs/get_attr_impl.rs
+++ b/examples/mirror_fs/fs/get_attr_impl.rs
@@ -10,8 +10,8 @@ impl get_attr::GetAttr for MirrorFS {
                 return Err(get_attr::Fail { error });
             }
         };
-        match Self::metadata(&path) {
-            Ok(meta) => Ok(get_attr::Success { object: Self::attr_from_metadata(&meta) }),
+        match self.attr_for_path(&path).await {
+            Ok(attr) => Ok(get_attr::Success { object: attr }),
             Err(error) => Err(get_attr::Fail { error }),
         }
     }

--- a/examples/mirror_fs/fs/get_attr_impl.rs
+++ b/examples/mirror_fs/fs/get_attr_impl.rs
@@ -1,10 +1,7 @@
-use async_trait::async_trait;
-
 use nfs_mamont::vfs::get_attr;
 
 use super::MirrorFS;
 
-#[async_trait]
 impl get_attr::GetAttr for MirrorFS {
     async fn get_attr(&self, args: get_attr::Args) -> Result<get_attr::Success, get_attr::Fail> {
         let path = match self.path_for_handle(&args.file).await {

--- a/examples/mirror_fs/fs/link_impl.rs
+++ b/examples/mirror_fs/fs/link_impl.rs
@@ -57,6 +57,10 @@ impl link::Link for MirrorFS {
         }
         let _ = self.ensure_handle_for_path(&target_path).await;
 
+        self.invalidate_attr_cache_path(&file_path).await;
+        self.invalidate_attr_cache_path(&target_path).await;
+        self.invalidate_attr_cache_path(&dir_path).await;
+
         Ok(link::Success {
             file_attr: Self::file_attr(&file_path),
             dir_wcc: Self::wcc_data(&dir_path, before),

--- a/examples/mirror_fs/fs/link_impl.rs
+++ b/examples/mirror_fs/fs/link_impl.rs
@@ -1,11 +1,9 @@
-use async_trait::async_trait;
 use tokio::fs;
 
 use nfs_mamont::vfs::{self, file, link};
 
 use super::MirrorFS;
 
-#[async_trait]
 impl link::Link for MirrorFS {
     async fn link(&self, args: link::Args) -> Result<link::Success, link::Fail> {
         if let Err(error) = Self::ensure_name_allowed(&args.link.name) {

--- a/examples/mirror_fs/fs/lookup_impl.rs
+++ b/examples/mirror_fs/fs/lookup_impl.rs
@@ -12,13 +12,12 @@ impl lookup::Lookup for MirrorFS {
                 return Err(lookup::Fail { error, dir_attr: None });
             }
         };
-        let parent_meta = match Self::metadata(&parent_path) {
-            Ok(meta) => meta,
+        let parent_attr = match self.attr_for_path(&parent_path).await {
+            Ok(attr) => attr,
             Err(error) => {
                 return Err(lookup::Fail { error, dir_attr: None });
             }
         };
-        let parent_attr = Self::attr_from_metadata(&parent_meta);
         if let Err(error) = Self::validate_directory(&parent_attr) {
             return Err(lookup::Fail { error, dir_attr: Some(parent_attr) });
         }
@@ -45,8 +44,8 @@ impl lookup::Lookup for MirrorFS {
                 child_path
             }
         };
-        let child_meta = match Self::metadata(&child_path) {
-            Ok(meta) => meta,
+        let child_attr = match self.attr_for_path(&child_path).await {
+            Ok(attr) => attr,
             Err(error) => {
                 return Err(lookup::Fail { error, dir_attr: Some(parent_attr) });
             }
@@ -61,7 +60,7 @@ impl lookup::Lookup for MirrorFS {
 
         Ok(lookup::Success {
             file: child_handle,
-            file_attr: Some(Self::attr_from_metadata(&child_meta)),
+            file_attr: Some(child_attr),
             dir_attr: Some(parent_attr),
         })
     }

--- a/examples/mirror_fs/fs/lookup_impl.rs
+++ b/examples/mirror_fs/fs/lookup_impl.rs
@@ -1,12 +1,9 @@
 use std::path::PathBuf;
 
-use async_trait::async_trait;
-
 use nfs_mamont::vfs::lookup;
 
 use super::MirrorFS;
 
-#[async_trait]
 impl lookup::Lookup for MirrorFS {
     async fn lookup(&self, args: lookup::Args) -> Result<lookup::Success, lookup::Fail> {
         let parent_path = match self.path_for_handle(&args.parent).await {

--- a/examples/mirror_fs/fs/mk_dir_impl.rs
+++ b/examples/mirror_fs/fs/mk_dir_impl.rs
@@ -1,11 +1,9 @@
-use async_trait::async_trait;
 use tokio::fs;
 
 use nfs_mamont::vfs::{self, mk_dir};
 
 use super::MirrorFS;
 
-#[async_trait]
 impl mk_dir::MkDir for MirrorFS {
     async fn mk_dir(&self, args: mk_dir::Args) -> Result<mk_dir::Success, mk_dir::Fail> {
         if let Err(error) = Self::ensure_name_allowed(&args.object.name) {

--- a/examples/mirror_fs/fs/mk_dir_impl.rs
+++ b/examples/mirror_fs/fs/mk_dir_impl.rs
@@ -48,6 +48,9 @@ impl mk_dir::MkDir for MirrorFS {
             }
         };
 
+        self.invalidate_attr_cache_path(&child_path).await;
+        self.invalidate_attr_cache_path(&dir_path).await;
+
         Ok(mk_dir::Success {
             file: Some(handle),
             attr: Some(attr),

--- a/examples/mirror_fs/fs/mk_node_impl.rs
+++ b/examples/mirror_fs/fs/mk_node_impl.rs
@@ -1,12 +1,9 @@
-use async_trait::async_trait;
-
 use nfs_mamont::vfs::{self, create, mk_dir, mk_node};
 
 use crate::fs::DEFAULT_SET_ATTR;
 
 use super::MirrorFS;
 
-#[async_trait]
 impl mk_node::MkNode for MirrorFS {
     async fn mk_node(&self, args: mk_node::Args) -> Result<mk_node::Success, mk_node::Fail> {
         match args.what {

--- a/examples/mirror_fs/fs/path_conf_impl.rs
+++ b/examples/mirror_fs/fs/path_conf_impl.rs
@@ -1,10 +1,7 @@
-use async_trait::async_trait;
-
 use nfs_mamont::vfs::{self, path_conf};
 
 use super::MirrorFS;
 
-#[async_trait]
 impl path_conf::PathConf for MirrorFS {
     async fn path_conf(
         &self,

--- a/examples/mirror_fs/fs/read_dir_impl.rs
+++ b/examples/mirror_fs/fs/read_dir_impl.rs
@@ -1,10 +1,7 @@
-use async_trait::async_trait;
-
 use nfs_mamont::vfs::{self, read_dir};
 
 use super::MirrorFS;
 
-#[async_trait]
 impl read_dir::ReadDir for MirrorFS {
     async fn read_dir(&self, args: read_dir::Args) -> Result<read_dir::Success, read_dir::Fail> {
         let dir_path = match self.path_for_handle(&args.dir).await {

--- a/examples/mirror_fs/fs/read_dir_impl.rs
+++ b/examples/mirror_fs/fs/read_dir_impl.rs
@@ -34,13 +34,14 @@ impl read_dir::ReadDir for MirrorFS {
         let start = args.cookie.raw() as usize;
         let mut used = 0u32;
         let mut result = Vec::new();
+        let mut selected_paths = Vec::new();
         for (index, (name, path, meta)) in entries.into_iter().enumerate().skip(start) {
             let estimated = (24 + name.as_str().len()) as u32;
             if !result.is_empty() && used.saturating_add(estimated) > args.count {
                 break;
             }
             let attr = Self::attr_from_metadata(&meta);
-            let _ = self.ensure_handle_for_path(&path).await;
+            selected_paths.push(path);
             result.push(read_dir::Entry {
                 file_id: attr.file_id,
                 file_name: name,
@@ -48,6 +49,9 @@ impl read_dir::ReadDir for MirrorFS {
             });
             used = used.saturating_add(estimated);
         }
+
+        self.cache_handles_for_paths(&selected_paths).await;
+
         let eof = start >= total_entries || start.saturating_add(result.len()) >= total_entries;
 
         Ok(read_dir::Success {

--- a/examples/mirror_fs/fs/read_dir_impl.rs
+++ b/examples/mirror_fs/fs/read_dir_impl.rs
@@ -21,7 +21,7 @@ impl read_dir::ReadDir for MirrorFS {
             return Err(read_dir::Fail { error: vfs::Error::BadCookie, dir_attr: Some(dir_attr) });
         }
 
-        let entries = match self.list_directory_entries(&dir_path).await {
+        let entries = match self.directory_entries_for(&dir_path, verifier).await {
             Ok(entries) => entries,
             Err(error) => return Err(read_dir::Fail { error, dir_attr: Some(dir_attr) }),
         };
@@ -31,15 +31,15 @@ impl read_dir::ReadDir for MirrorFS {
         let mut used = 0u32;
         let mut result = Vec::new();
         let mut selected_paths = Vec::new();
-        for (index, (name, path, meta)) in entries.into_iter().enumerate().skip(start) {
+        for (index, entry) in entries.iter().enumerate().skip(start) {
+            let name = entry.name.clone();
             let estimated = (24 + name.as_str().len()) as u32;
             if !result.is_empty() && used.saturating_add(estimated) > args.count {
                 break;
             }
-            let attr = Self::attr_from_metadata(&meta);
-            selected_paths.push(path);
+            selected_paths.push(entry.path.clone());
             result.push(read_dir::Entry {
-                file_id: attr.file_id,
+                file_id: entry.file_id,
                 file_name: name,
                 cookie: read_dir::Cookie::new((index + 1) as u64),
             });

--- a/examples/mirror_fs/fs/read_dir_impl.rs
+++ b/examples/mirror_fs/fs/read_dir_impl.rs
@@ -8,11 +8,10 @@ impl read_dir::ReadDir for MirrorFS {
             Ok(path) => path,
             Err(error) => return Err(read_dir::Fail { error, dir_attr: None }),
         };
-        let dir_meta = match Self::metadata(&dir_path) {
-            Ok(meta) => meta,
+        let dir_attr = match self.attr_for_path(&dir_path).await {
+            Ok(attr) => attr,
             Err(error) => return Err(read_dir::Fail { error, dir_attr: None }),
         };
-        let dir_attr = Self::attr_from_metadata(&dir_meta);
         if let Err(error) = Self::validate_directory(&dir_attr) {
             return Err(read_dir::Fail { error, dir_attr: Some(dir_attr) });
         }
@@ -22,7 +21,7 @@ impl read_dir::ReadDir for MirrorFS {
             return Err(read_dir::Fail { error: vfs::Error::BadCookie, dir_attr: Some(dir_attr) });
         }
 
-        let entries = match self.list_directory_entries(&dir_path) {
+        let entries = match self.list_directory_entries(&dir_path).await {
             Ok(entries) => entries,
             Err(error) => return Err(read_dir::Fail { error, dir_attr: Some(dir_attr) }),
         };

--- a/examples/mirror_fs/fs/read_dir_plus_impl.rs
+++ b/examples/mirror_fs/fs/read_dir_plus_impl.rs
@@ -37,33 +37,49 @@ impl read_dir_plus::ReadDirPlus for MirrorFS {
             Err(error) => return Err(read_dir_plus::Fail { error, dir_attr: Some(dir_attr) }),
         };
 
+        let total_entries = entries.len();
         let start = args.cookie.raw() as usize;
         let mut used = 0u32;
-        let mut result = Vec::new();
-        for (index, (name, path, meta)) in entries.iter().cloned().enumerate().skip(start) {
+        let mut selected_paths = Vec::new();
+        let mut selected_entries = Vec::new();
+        for (index, (name, path, meta)) in entries.into_iter().enumerate().skip(start) {
             let estimated = (48 + name.as_str().len() + NFS3_WRITEVERFSIZE) as u32;
-            if !result.is_empty() && used.saturating_add(estimated) > args.max_count {
+            if !selected_entries.is_empty() && used.saturating_add(estimated) > args.max_count {
                 break;
             }
             let attr = Self::attr_from_metadata(&meta);
-            let handle = match self.ensure_handle_for_path(&path).await {
-                Ok(handle) => handle,
-                Err(error) => return Err(read_dir_plus::Fail { error, dir_attr: Some(dir_attr) }),
-            };
-            result.push(read_dir_plus::Entry {
-                file_id: attr.file_id,
-                file_name: name,
-                cookie: read_dir::Cookie::new((index + 1) as u64),
-                file_attr: Some(attr),
-                file_handle: Some(handle),
-            });
+            selected_entries.push((
+                attr.file_id,
+                name,
+                read_dir::Cookie::new((index + 1) as u64),
+                attr,
+            ));
+            selected_paths.push(path);
             used = used.saturating_add(estimated);
+        }
+
+        let handles = match self.ensure_handles_for_paths(&selected_paths).await {
+            Ok(handles) => handles,
+            Err(error) => return Err(read_dir_plus::Fail { error, dir_attr: Some(dir_attr) }),
+        };
+
+        let mut result = Vec::with_capacity(selected_entries.len());
+        for ((file_id, file_name, cookie, file_attr), file_handle) in
+            selected_entries.into_iter().zip(handles)
+        {
+            result.push(read_dir_plus::Entry {
+                file_id,
+                file_name,
+                cookie,
+                file_attr: Some(file_attr),
+                file_handle: Some(file_handle),
+            });
         }
 
         Ok(read_dir_plus::Success {
             dir_attr: Some(dir_attr),
             cookie_verifier: verifier,
-            eof: start >= entries.len() || start.saturating_add(result.len()) >= entries.len(),
+            eof: start >= total_entries || start.saturating_add(result.len()) >= total_entries,
             entries: result,
         })
     }

--- a/examples/mirror_fs/fs/read_dir_plus_impl.rs
+++ b/examples/mirror_fs/fs/read_dir_plus_impl.rs
@@ -28,7 +28,7 @@ impl read_dir_plus::ReadDirPlus for MirrorFS {
             });
         }
 
-        let entries = match self.list_directory_entries(&dir_path).await {
+        let entries = match self.directory_entries_for(&dir_path, verifier).await {
             Ok(entries) => entries,
             Err(error) => return Err(read_dir_plus::Fail { error, dir_attr: Some(dir_attr) }),
         };
@@ -38,20 +38,26 @@ impl read_dir_plus::ReadDirPlus for MirrorFS {
         let mut used = 0u32;
         let mut selected_paths = Vec::new();
         let mut selected_entries = Vec::new();
-        for (index, (name, path, meta)) in entries.into_iter().enumerate().skip(start) {
+        for (index, entry) in entries.iter().enumerate().skip(start) {
+            let name = entry.name.clone();
             let estimated = (48 + name.as_str().len() + NFS3_WRITEVERFSIZE) as u32;
             if !selected_entries.is_empty() && used.saturating_add(estimated) > args.max_count {
                 break;
             }
-            let attr = Self::attr_from_metadata(&meta);
-            selected_entries.push((
-                attr.file_id,
-                name,
-                read_dir::Cookie::new((index + 1) as u64),
-                attr,
-            ));
-            selected_paths.push(path);
+            selected_entries.push((entry.file_id, name, read_dir::Cookie::new((index + 1) as u64)));
+            selected_paths.push(entry.path.clone());
             used = used.saturating_add(estimated);
+        }
+
+        let mut selected_attrs = Vec::with_capacity(selected_paths.len());
+        for path in &selected_paths {
+            let attr = match self.attr_for_path(path).await {
+                Ok(attr) => attr,
+                Err(error) => {
+                    return Err(read_dir_plus::Fail { error, dir_attr: Some(dir_attr) });
+                }
+            };
+            selected_attrs.push(attr);
         }
 
         let handles = match self.ensure_handles_for_paths(&selected_paths).await {
@@ -60,8 +66,8 @@ impl read_dir_plus::ReadDirPlus for MirrorFS {
         };
 
         let mut result = Vec::with_capacity(selected_entries.len());
-        for ((file_id, file_name, cookie, file_attr), file_handle) in
-            selected_entries.into_iter().zip(handles)
+        for (((file_id, file_name, cookie), file_attr), file_handle) in
+            selected_entries.into_iter().zip(selected_attrs).zip(handles)
         {
             result.push(read_dir_plus::Entry {
                 file_id,

--- a/examples/mirror_fs/fs/read_dir_plus_impl.rs
+++ b/examples/mirror_fs/fs/read_dir_plus_impl.rs
@@ -49,16 +49,12 @@ impl read_dir_plus::ReadDirPlus for MirrorFS {
             used = used.saturating_add(estimated);
         }
 
-        let mut selected_attrs = Vec::with_capacity(selected_paths.len());
-        for path in &selected_paths {
-            let attr = match self.attr_for_path(path).await {
-                Ok(attr) => attr,
-                Err(error) => {
-                    return Err(read_dir_plus::Fail { error, dir_attr: Some(dir_attr) });
-                }
-            };
-            selected_attrs.push(attr);
-        }
+        let selected_attrs = match self.attrs_for_paths_parallel(&selected_paths).await {
+            Ok(attrs) => attrs,
+            Err(error) => {
+                return Err(read_dir_plus::Fail { error, dir_attr: Some(dir_attr) });
+            }
+        };
 
         let handles = match self.ensure_handles_for_paths(&selected_paths).await {
             Ok(handles) => handles,

--- a/examples/mirror_fs/fs/read_dir_plus_impl.rs
+++ b/examples/mirror_fs/fs/read_dir_plus_impl.rs
@@ -12,11 +12,10 @@ impl read_dir_plus::ReadDirPlus for MirrorFS {
             Ok(path) => path,
             Err(error) => return Err(read_dir_plus::Fail { error, dir_attr: None }),
         };
-        let dir_meta = match Self::metadata(&dir_path) {
-            Ok(meta) => meta,
+        let dir_attr = match self.attr_for_path(&dir_path).await {
+            Ok(attr) => attr,
             Err(error) => return Err(read_dir_plus::Fail { error, dir_attr: None }),
         };
-        let dir_attr = Self::attr_from_metadata(&dir_meta);
         if let Err(error) = Self::validate_directory(&dir_attr) {
             return Err(read_dir_plus::Fail { error, dir_attr: Some(dir_attr) });
         }
@@ -29,7 +28,7 @@ impl read_dir_plus::ReadDirPlus for MirrorFS {
             });
         }
 
-        let entries = match self.list_directory_entries(&dir_path) {
+        let entries = match self.list_directory_entries(&dir_path).await {
             Ok(entries) => entries,
             Err(error) => return Err(read_dir_plus::Fail { error, dir_attr: Some(dir_attr) }),
         };

--- a/examples/mirror_fs/fs/read_dir_plus_impl.rs
+++ b/examples/mirror_fs/fs/read_dir_plus_impl.rs
@@ -1,11 +1,8 @@
-use async_trait::async_trait;
-
 use nfs_mamont::consts::nfsv3::NFS3_WRITEVERFSIZE;
 use nfs_mamont::vfs::{self, read_dir, read_dir_plus};
 
 use super::MirrorFS;
 
-#[async_trait]
 impl read_dir_plus::ReadDirPlus for MirrorFS {
     async fn read_dir_plus(
         &self,

--- a/examples/mirror_fs/fs/read_impl.rs
+++ b/examples/mirror_fs/fs/read_impl.rs
@@ -1,6 +1,5 @@
-use std::io::SeekFrom;
-use tokio::fs::File;
-use tokio::io::{AsyncReadExt, AsyncSeekExt};
+use std::fs::File;
+use std::os::unix::fs::FileExt;
 
 use nfs_mamont::vfs::read;
 use nfs_mamont::Slice;
@@ -15,14 +14,14 @@ impl read::Read for MirrorFS {
                 return Err(read::Fail { error, file_attr: None });
             }
         };
-        let mut file = match File::open(&path).await {
+        let file = match File::open(&path) {
             Ok(file) => file,
             Err(error) => {
                 return Err(read::Fail { error: Self::io_error_to_vfs(&error), file_attr: None });
             }
         };
 
-        let meta = match file.metadata().await {
+        let meta = match file.metadata() {
             Ok(meta) => meta,
             Err(error) => {
                 return Err(read::Fail { error: Self::io_error_to_vfs(&error), file_attr: None });
@@ -37,46 +36,59 @@ impl read::Read for MirrorFS {
         let start = args.offset.min(file_len);
         let end = args.offset.saturating_add(args.count as u64).min(file_len);
         let requested = end.saturating_sub(start) as usize;
-        let mut remaining = requested;
         let mut read_count = 0usize;
-        if let Err(error) = file.seek(SeekFrom::Start(start)).await {
-            return Err(read::Fail { error: Self::io_error_to_vfs(&error), file_attr: Some(attr) });
-        }
 
-        if remaining > 0 {
-            for chunk in data.iter_mut() {
-                if remaining == 0 {
-                    break;
-                }
+        if requested > 0 {
+            let read_result = tokio::task::spawn_blocking(move || {
+                let mut remaining = requested;
+                let mut local_offset = start;
+                let mut local_read_count = 0usize;
 
-                let to_read = chunk.len().min(remaining);
-                let mut chunk_offset = 0usize;
-
-                while chunk_offset < to_read {
-                    match file.read(&mut chunk[chunk_offset..to_read]).await {
-                        Ok(0) => {
-                            remaining = 0;
-                            break;
-                        }
-                        Ok(bytes) => {
-                            chunk_offset += bytes;
-                            read_count += bytes;
-                        }
-                        Err(error) => {
-                            return Err(read::Fail {
-                                error: Self::io_error_to_vfs(&error),
-                                file_attr: Some(attr),
-                            });
-                        }
+                for chunk in data.iter_mut() {
+                    if remaining == 0 {
+                        break;
                     }
+
+                    let to_read = chunk.len().min(remaining);
+                    let mut chunk_offset = 0usize;
+
+                    while chunk_offset < to_read {
+                        let bytes = file.read_at(
+                            &mut chunk[chunk_offset..to_read],
+                            local_offset + chunk_offset as u64,
+                        )?;
+
+                        if bytes == 0 {
+                            return Ok((data, local_read_count));
+                        }
+
+                        chunk_offset += bytes;
+                        local_read_count += bytes;
+                    }
+
+                    local_offset = local_offset.saturating_add(to_read as u64);
+                    remaining -= to_read;
                 }
 
-                if chunk_offset < to_read {
-                    break;
-                }
+                Ok::<(Slice, usize), std::io::Error>((data, local_read_count))
+            })
+            .await;
 
-                remaining -= to_read;
-            }
+            let (filled_data, filled_count) = match read_result {
+                Ok(Ok(ok)) => ok,
+                Ok(Err(error)) => {
+                    return Err(read::Fail {
+                        error: Self::io_error_to_vfs(&error),
+                        file_attr: Some(attr),
+                    });
+                }
+                Err(_) => {
+                    return Err(read::Fail { error: nfs_mamont::vfs::Error::IO, file_attr: Some(attr) });
+                }
+            };
+
+            data = filled_data;
+            read_count = filled_count;
         }
 
         Ok(read::Success {

--- a/examples/mirror_fs/fs/read_impl.rs
+++ b/examples/mirror_fs/fs/read_impl.rs
@@ -17,26 +17,23 @@ impl read::Read for MirrorFS {
                 return Err(read::Fail { error, file_attr: None });
             }
         };
-        let meta = match Self::metadata(&path) {
+        let mut file = match File::open(&path).await {
+            Ok(file) => file,
+            Err(error) => {
+                return Err(read::Fail { error: Self::io_error_to_vfs(&error), file_attr: None });
+            }
+        };
+
+        let meta = match file.metadata().await {
             Ok(meta) => meta,
             Err(error) => {
-                return Err(read::Fail { error, file_attr: None });
+                return Err(read::Fail { error: Self::io_error_to_vfs(&error), file_attr: None });
             }
         };
         let attr = Self::attr_from_metadata(&meta);
         if let Err(error) = Self::validate_regular(&attr) {
             return Err(read::Fail { error, file_attr: Some(attr) });
         }
-
-        let mut file = match File::open(&path).await {
-            Ok(file) => file,
-            Err(error) => {
-                return Err(read::Fail {
-                    error: Self::io_error_to_vfs(&error),
-                    file_attr: Some(attr),
-                });
-            }
-        };
 
         let file_len = meta.len();
         let start = args.offset.min(file_len);

--- a/examples/mirror_fs/fs/read_impl.rs
+++ b/examples/mirror_fs/fs/read_impl.rs
@@ -8,6 +8,7 @@ use super::MirrorFS;
 impl read::Read for MirrorFS {
     async fn read(&self, args: read::Args, mut data: Slice) -> Result<read::Success, read::Fail> {
         const SENDFILE_MIN_BYTES: usize = 32 * 1024;
+        const READ_AHEAD_TRIGGER_BYTES: usize = 256 * 1024;
 
         let (path, attr) = match self.path_and_attr_for_handle(&args.file).await {
             Ok(path_and_attr) => path_and_attr,
@@ -34,6 +35,12 @@ impl read::Read for MirrorFS {
         let mut read_count = 0usize;
         let mut sendfile_source = None;
 
+        let sequential = self.update_read_sequence(&path, start, end).await;
+        let should_prefetch = requested >= READ_AHEAD_TRIGGER_BYTES || sequential;
+        if should_prefetch {
+            self.schedule_read_ahead_window(&path, file.clone(), end, file_len).await;
+        }
+
         if requested > 0 && sendfile_source.is_none() {
             if let Some(cached) = self.read_ahead_copy_hit(&path, start, requested, &mut data).await {
                 read_count = cached;
@@ -41,7 +48,7 @@ impl read::Read for MirrorFS {
         }
 
         #[cfg(target_os = "linux")]
-        if requested >= SENDFILE_MIN_BYTES && read_count == 0 {
+        if requested >= SENDFILE_MIN_BYTES && read_count == 0 && !should_prefetch {
             read_count = requested;
             sendfile_source = Some(read::SendfileSource { file: file.clone(), offset: start });
             data = Slice::empty();
@@ -102,15 +109,6 @@ impl read::Read for MirrorFS {
 
             data = filled_data;
             read_count = filled_count;
-        }
-
-        if read_count > 0 {
-            let next_offset = start.saturating_add(read_count as u64);
-            let sequential = self.update_read_sequence(&path, start, next_offset).await;
-            let should_prefetch = requested >= (SENDFILE_MIN_BYTES * 4) || sequential;
-            if should_prefetch {
-                self.schedule_read_ahead(&path, file, next_offset, file_len).await;
-            }
         }
 
         Ok(read::Success {

--- a/examples/mirror_fs/fs/read_impl.rs
+++ b/examples/mirror_fs/fs/read_impl.rs
@@ -7,6 +7,8 @@ use super::MirrorFS;
 
 impl read::Read for MirrorFS {
     async fn read(&self, args: read::Args, mut data: Slice) -> Result<read::Success, read::Fail> {
+        const SENDFILE_MIN_BYTES: usize = 32 * 1024;
+
         let path = match self.path_for_handle(&args.file).await {
             Ok(path) => path,
             Err(error) => {
@@ -36,8 +38,16 @@ impl read::Read for MirrorFS {
         let end = args.offset.saturating_add(args.count as u64).min(file_len);
         let requested = end.saturating_sub(start) as usize;
         let mut read_count = 0usize;
+        let mut sendfile_source = None;
 
-        if requested > 0 {
+        #[cfg(target_os = "linux")]
+        if requested >= SENDFILE_MIN_BYTES {
+            read_count = requested;
+            sendfile_source = Some(read::SendfileSource { file: file.clone(), offset: start });
+            data = Slice::empty();
+        }
+
+        if requested > 0 && sendfile_source.is_none() {
             let read_result = tokio::task::spawn_blocking(move || {
                 let mut remaining = requested;
                 let mut local_offset = start;
@@ -82,7 +92,10 @@ impl read::Read for MirrorFS {
                     });
                 }
                 Err(_) => {
-                    return Err(read::Fail { error: nfs_mamont::vfs::Error::IO, file_attr: Some(attr) });
+                    return Err(read::Fail {
+                        error: nfs_mamont::vfs::Error::IO,
+                        file_attr: Some(attr),
+                    });
                 }
             };
 
@@ -97,6 +110,7 @@ impl read::Read for MirrorFS {
                 eof: start.saturating_add(read_count as u64) >= file_len,
             },
             data,
+            sendfile_source,
         })
     }
 }

--- a/examples/mirror_fs/fs/read_impl.rs
+++ b/examples/mirror_fs/fs/read_impl.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use std::io::SeekFrom;
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
@@ -8,7 +7,6 @@ use nfs_mamont::Slice;
 
 use super::MirrorFS;
 
-#[async_trait]
 impl read::Read for MirrorFS {
     async fn read(&self, args: read::Args, mut data: Slice) -> Result<read::Success, read::Fail> {
         let path = match self.path_for_handle(&args.file).await {

--- a/examples/mirror_fs/fs/read_impl.rs
+++ b/examples/mirror_fs/fs/read_impl.rs
@@ -9,12 +9,17 @@ impl read::Read for MirrorFS {
     async fn read(&self, args: read::Args, mut data: Slice) -> Result<read::Success, read::Fail> {
         const SENDFILE_MIN_BYTES: usize = 32 * 1024;
 
-        let path = match self.path_for_handle(&args.file).await {
-            Ok(path) => path,
+        let (path, attr) = match self.path_and_attr_for_handle(&args.file).await {
+            Ok(path_and_attr) => path_and_attr,
             Err(error) => {
                 return Err(read::Fail { error, file_attr: None });
             }
         };
+
+        if let Err(error) = Self::validate_regular(&attr) {
+            return Err(read::Fail { error, file_attr: Some(attr) });
+        }
+
         let file = match self.get_cached_read_file(&path).await {
             Ok(file) => file,
             Err(error) => {
@@ -22,32 +27,28 @@ impl read::Read for MirrorFS {
             }
         };
 
-        let meta = match tokio::fs::metadata(&path).await {
-            Ok(meta) => meta,
-            Err(error) => {
-                return Err(read::Fail { error: Self::io_error_to_vfs(&error), file_attr: None });
-            }
-        };
-        let attr = Self::attr_from_metadata(&meta);
-        if let Err(error) = Self::validate_regular(&attr) {
-            return Err(read::Fail { error, file_attr: Some(attr) });
-        }
-
-        let file_len = meta.len();
+        let file_len = attr.size;
         let start = args.offset.min(file_len);
         let end = args.offset.saturating_add(args.count as u64).min(file_len);
         let requested = end.saturating_sub(start) as usize;
         let mut read_count = 0usize;
         let mut sendfile_source = None;
 
+        if requested > 0 && sendfile_source.is_none() {
+            if let Some(cached) = self.read_ahead_copy_hit(&path, start, requested, &mut data).await {
+                read_count = cached;
+            }
+        }
+
         #[cfg(target_os = "linux")]
-        if requested >= SENDFILE_MIN_BYTES {
+        if requested >= SENDFILE_MIN_BYTES && read_count == 0 {
             read_count = requested;
             sendfile_source = Some(read::SendfileSource { file: file.clone(), offset: start });
             data = Slice::empty();
         }
 
-        if requested > 0 && sendfile_source.is_none() {
+        if requested > 0 && sendfile_source.is_none() && read_count == 0 {
+            let read_file = file.clone();
             let read_result = tokio::task::spawn_blocking(move || {
                 let mut remaining = requested;
                 let mut local_offset = start;
@@ -62,7 +63,7 @@ impl read::Read for MirrorFS {
                     let mut chunk_offset = 0usize;
 
                     while chunk_offset < to_read {
-                        let bytes = file.read_at(
+                        let bytes = read_file.read_at(
                             &mut chunk[chunk_offset..to_read],
                             local_offset + chunk_offset as u64,
                         )?;
@@ -101,6 +102,15 @@ impl read::Read for MirrorFS {
 
             data = filled_data;
             read_count = filled_count;
+        }
+
+        if read_count > 0 {
+            let next_offset = start.saturating_add(read_count as u64);
+            let sequential = self.update_read_sequence(&path, start, next_offset).await;
+            let should_prefetch = requested >= (SENDFILE_MIN_BYTES * 4) || sequential;
+            if should_prefetch {
+                self.schedule_read_ahead(&path, file, next_offset, file_len).await;
+            }
         }
 
         Ok(read::Success {

--- a/examples/mirror_fs/fs/read_impl.rs
+++ b/examples/mirror_fs/fs/read_impl.rs
@@ -1,6 +1,4 @@
-use std::io::SeekFrom;
 use tokio::fs::File;
-use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
 use nfs_mamont::vfs::read;
 use nfs_mamont::Slice;
@@ -8,14 +6,14 @@ use nfs_mamont::Slice;
 use super::MirrorFS;
 
 impl read::Read for MirrorFS {
-    async fn read(&self, args: read::Args, mut data: Slice) -> Result<read::Success, read::Fail> {
+    async fn read(&self, args: read::Args, data: Slice) -> Result<read::Success, read::Fail> {
         let path = match self.path_for_handle(&args.file).await {
             Ok(path) => path,
             Err(error) => {
                 return Err(read::Fail { error, file_attr: None });
             }
         };
-        let mut file = match File::open(&path).await {
+        let file = match File::open(&path).await {
             Ok(file) => file,
             Err(error) => {
                 return Err(read::Fail { error: Self::io_error_to_vfs(&error), file_attr: None });
@@ -36,48 +34,16 @@ impl read::Read for MirrorFS {
         let file_len = meta.len();
         let start = args.offset.min(file_len);
         let end = args.offset.saturating_add(args.count as u64).min(file_len);
-        let requested = end.saturating_sub(start) as usize;
-        let mut remaining = requested;
-        let mut read_count = 0usize;
-        if let Err(error) = file.seek(SeekFrom::Start(start)).await {
-            return Err(read::Fail { error: Self::io_error_to_vfs(&error), file_attr: Some(attr) });
-        }
-
-        if remaining > 0 {
-            for chunk in data.iter_mut() {
-                if remaining == 0 {
-                    break;
-                }
-
-                let to_read = chunk.len().min(remaining);
-                let mut chunk_offset = 0usize;
-
-                while chunk_offset < to_read {
-                    match file.read(&mut chunk[chunk_offset..to_read]).await {
-                        Ok(0) => {
-                            remaining = 0;
-                            break;
-                        }
-                        Ok(bytes) => {
-                            chunk_offset += bytes;
-                            read_count += bytes;
-                        }
-                        Err(error) => {
-                            return Err(read::Fail {
-                                error: Self::io_error_to_vfs(&error),
-                                file_attr: Some(attr),
-                            });
-                        }
-                    }
-                }
-
-                if chunk_offset < to_read {
-                    break;
-                }
-
-                remaining -= to_read;
-            }
-        }
+        let read_count = end.saturating_sub(start) as usize;
+        let payload = if read_count == 0 {
+            read::Payload::Slice(data)
+        } else {
+            read::Payload::SendFile(read::SendFile {
+                file: file.into_std().await,
+                offset: start,
+                count: read_count,
+            })
+        };
 
         Ok(read::Success {
             head: read::SuccessPartial {
@@ -85,7 +51,11 @@ impl read::Read for MirrorFS {
                 count: read_count as u32,
                 eof: start.saturating_add(read_count as u64) >= file_len,
             },
-            data,
+            data: payload,
         })
+    }
+
+    fn supports_sendfile(&self) -> bool {
+        true
     }
 }

--- a/examples/mirror_fs/fs/read_impl.rs
+++ b/examples/mirror_fs/fs/read_impl.rs
@@ -1,4 +1,3 @@
-use std::fs::File;
 use std::os::unix::fs::FileExt;
 
 use nfs_mamont::vfs::read;
@@ -14,14 +13,14 @@ impl read::Read for MirrorFS {
                 return Err(read::Fail { error, file_attr: None });
             }
         };
-        let file = match File::open(&path) {
+        let file = match self.get_cached_read_file(&path).await {
             Ok(file) => file,
             Err(error) => {
-                return Err(read::Fail { error: Self::io_error_to_vfs(&error), file_attr: None });
+                return Err(read::Fail { error, file_attr: None });
             }
         };
 
-        let meta = match file.metadata() {
+        let meta = match tokio::fs::metadata(&path).await {
             Ok(meta) => meta,
             Err(error) => {
                 return Err(read::Fail { error: Self::io_error_to_vfs(&error), file_attr: None });

--- a/examples/mirror_fs/fs/read_impl.rs
+++ b/examples/mirror_fs/fs/read_impl.rs
@@ -1,4 +1,6 @@
+use std::io::SeekFrom;
 use tokio::fs::File;
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
 use nfs_mamont::vfs::read;
 use nfs_mamont::Slice;
@@ -6,14 +8,14 @@ use nfs_mamont::Slice;
 use super::MirrorFS;
 
 impl read::Read for MirrorFS {
-    async fn read(&self, args: read::Args, data: Slice) -> Result<read::Success, read::Fail> {
+    async fn read(&self, args: read::Args, mut data: Slice) -> Result<read::Success, read::Fail> {
         let path = match self.path_for_handle(&args.file).await {
             Ok(path) => path,
             Err(error) => {
                 return Err(read::Fail { error, file_attr: None });
             }
         };
-        let file = match File::open(&path).await {
+        let mut file = match File::open(&path).await {
             Ok(file) => file,
             Err(error) => {
                 return Err(read::Fail { error: Self::io_error_to_vfs(&error), file_attr: None });
@@ -34,16 +36,48 @@ impl read::Read for MirrorFS {
         let file_len = meta.len();
         let start = args.offset.min(file_len);
         let end = args.offset.saturating_add(args.count as u64).min(file_len);
-        let read_count = end.saturating_sub(start) as usize;
-        let payload = if read_count == 0 {
-            read::Payload::Slice(data)
-        } else {
-            read::Payload::SendFile(read::SendFile {
-                file: file.into_std().await,
-                offset: start,
-                count: read_count,
-            })
-        };
+        let requested = end.saturating_sub(start) as usize;
+        let mut remaining = requested;
+        let mut read_count = 0usize;
+        if let Err(error) = file.seek(SeekFrom::Start(start)).await {
+            return Err(read::Fail { error: Self::io_error_to_vfs(&error), file_attr: Some(attr) });
+        }
+
+        if remaining > 0 {
+            for chunk in data.iter_mut() {
+                if remaining == 0 {
+                    break;
+                }
+
+                let to_read = chunk.len().min(remaining);
+                let mut chunk_offset = 0usize;
+
+                while chunk_offset < to_read {
+                    match file.read(&mut chunk[chunk_offset..to_read]).await {
+                        Ok(0) => {
+                            remaining = 0;
+                            break;
+                        }
+                        Ok(bytes) => {
+                            chunk_offset += bytes;
+                            read_count += bytes;
+                        }
+                        Err(error) => {
+                            return Err(read::Fail {
+                                error: Self::io_error_to_vfs(&error),
+                                file_attr: Some(attr),
+                            });
+                        }
+                    }
+                }
+
+                if chunk_offset < to_read {
+                    break;
+                }
+
+                remaining -= to_read;
+            }
+        }
 
         Ok(read::Success {
             head: read::SuccessPartial {
@@ -51,11 +85,7 @@ impl read::Read for MirrorFS {
                 count: read_count as u32,
                 eof: start.saturating_add(read_count as u64) >= file_len,
             },
-            data: payload,
+            data,
         })
-    }
-
-    fn supports_sendfile(&self) -> bool {
-        true
     }
 }

--- a/examples/mirror_fs/fs/read_impl.rs
+++ b/examples/mirror_fs/fs/read_impl.rs
@@ -34,11 +34,13 @@ impl read::Read for MirrorFS {
         let requested = end.saturating_sub(start) as usize;
         let mut read_count = 0usize;
         let mut sendfile_source = None;
+        let block_size = super::READ_AHEAD_BLOCK_SIZE as u64;
 
         let sequential = self.update_read_sequence(&path, start, end).await;
         let should_prefetch = requested >= READ_AHEAD_TRIGGER_BYTES || sequential;
         if should_prefetch {
-            self.schedule_read_ahead_window(&path, file.clone(), end, file_len).await;
+            let start_block_index = end / block_size;
+            self.schedule_read_ahead_window(&path, file.clone(), start_block_index, file_len).await;
         }
 
         if requested > 0 && sendfile_source.is_none() {
@@ -54,24 +56,34 @@ impl read::Read for MirrorFS {
             data = Slice::empty();
         }
 
-        if requested > 0 && sendfile_source.is_none() && read_count == 0 {
+        if requested > 0 && sendfile_source.is_none() && read_count < requested {
             let read_file = file.clone();
+            let read_start = start.saturating_add(read_count as u64);
+            let read_remaining = requested - read_count;
+            let data_offset = read_count;
             let read_result = tokio::task::spawn_blocking(move || {
-                let mut remaining = requested;
-                let mut local_offset = start;
+                let mut remaining = read_remaining;
+                let mut local_offset = read_start;
                 let mut local_read_count = 0usize;
+                let mut slice_offset = data_offset;
 
                 for chunk in data.iter_mut() {
+                    if slice_offset >= chunk.len() {
+                        slice_offset -= chunk.len();
+                        continue;
+                    }
+
                     if remaining == 0 {
                         break;
                     }
 
-                    let to_read = chunk.len().min(remaining);
+                    let writable = chunk.len() - slice_offset;
+                    let to_read = writable.min(remaining);
                     let mut chunk_offset = 0usize;
 
                     while chunk_offset < to_read {
                         let bytes = read_file.read_at(
-                            &mut chunk[chunk_offset..to_read],
+                            &mut chunk[slice_offset + chunk_offset..slice_offset + to_read],
                             local_offset + chunk_offset as u64,
                         )?;
 
@@ -85,6 +97,7 @@ impl read::Read for MirrorFS {
 
                     local_offset = local_offset.saturating_add(to_read as u64);
                     remaining -= to_read;
+                    slice_offset = 0;
                 }
 
                 Ok::<(Slice, usize), std::io::Error>((data, local_read_count))
@@ -108,7 +121,7 @@ impl read::Read for MirrorFS {
             };
 
             data = filled_data;
-            read_count = filled_count;
+            read_count += filled_count;
         }
 
         Ok(read::Success {

--- a/examples/mirror_fs/fs/read_link_impl.rs
+++ b/examples/mirror_fs/fs/read_link_impl.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use tokio::fs;
 
 use nfs_mamont::vfs::{self, file, read_link};
 
@@ -29,7 +30,7 @@ impl read_link::ReadLink for MirrorFS {
                 symlink_attr: Some(attr),
             });
         }
-        let target = match std::fs::read_link(&path) {
+        let target = match fs::read_link(&path).await {
             Ok(target) => target,
             Err(error) => {
                 return Err(read_link::Fail {

--- a/examples/mirror_fs/fs/read_link_impl.rs
+++ b/examples/mirror_fs/fs/read_link_impl.rs
@@ -1,11 +1,9 @@
-use async_trait::async_trait;
 use tokio::fs;
 
 use nfs_mamont::vfs::{self, file, read_link};
 
 use super::MirrorFS;
 
-#[async_trait]
 impl read_link::ReadLink for MirrorFS {
     async fn read_link(
         &self,

--- a/examples/mirror_fs/fs/remove_impl.rs
+++ b/examples/mirror_fs/fs/remove_impl.rs
@@ -1,11 +1,9 @@
-use async_trait::async_trait;
 use tokio::fs;
 
 use nfs_mamont::vfs::{self, remove};
 
 use super::MirrorFS;
 
-#[async_trait]
 impl remove::Remove for MirrorFS {
     async fn remove(&self, args: remove::Args) -> Result<remove::Success, remove::Fail> {
         if let Err(error) = Self::ensure_name_allowed(&args.object.name) {

--- a/examples/mirror_fs/fs/remove_impl.rs
+++ b/examples/mirror_fs/fs/remove_impl.rs
@@ -51,6 +51,7 @@ impl remove::Remove for MirrorFS {
             });
         }
         self.remove_cached_path(&child_path).await;
+        self.invalidate_attr_cache_path(&dir_path).await;
 
         Ok(remove::Success { wcc_data: Self::wcc_data(&dir_path, before) })
     }

--- a/examples/mirror_fs/fs/rename_impl.rs
+++ b/examples/mirror_fs/fs/rename_impl.rs
@@ -1,11 +1,9 @@
-use async_trait::async_trait;
 use tokio::fs;
 
 use nfs_mamont::vfs::{self, rename};
 
 use super::MirrorFS;
 
-#[async_trait]
 impl rename::Rename for MirrorFS {
     async fn rename(&self, args: rename::Args) -> Result<rename::Success, rename::Fail> {
         if matches!(args.from.name.as_str(), "." | "..")

--- a/examples/mirror_fs/fs/rename_impl.rs
+++ b/examples/mirror_fs/fs/rename_impl.rs
@@ -133,6 +133,9 @@ impl rename::Rename for MirrorFS {
             });
         }
 
+        self.invalidate_attr_cache_path(&from_dir_path).await;
+        self.invalidate_attr_cache_path(&to_dir_path).await;
+
         Ok(rename::Success {
             from_dir_wcc: Self::wcc_data(&from_dir_path, from_before),
             to_dir_wcc: Self::wcc_data(&to_dir_path, to_before),

--- a/examples/mirror_fs/fs/rename_impl.rs
+++ b/examples/mirror_fs/fs/rename_impl.rs
@@ -78,10 +78,35 @@ impl rename::Rename for MirrorFS {
                 });
             }
             if target_meta.is_dir() {
-                if let Ok(mut iter) = std::fs::read_dir(&to_path) {
-                    if iter.next().is_some() {
+                let mut iter = match fs::read_dir(&to_path).await {
+                    Ok(iter) => iter,
+                    Err(error) => {
+                        return Err(rename::Fail {
+                            error: Self::io_error_to_vfs(&error),
+                            from_dir_wcc: vfs::WccData {
+                                before: from_before,
+                                after: from_before_after,
+                            },
+                            to_dir_wcc: vfs::WccData { before: to_before, after: to_before_after },
+                        });
+                    }
+                };
+
+                match iter.next_entry().await {
+                    Ok(Some(_)) => {
                         return Err(rename::Fail {
                             error: vfs::Error::Exist,
+                            from_dir_wcc: vfs::WccData {
+                                before: from_before,
+                                after: from_before_after,
+                            },
+                            to_dir_wcc: vfs::WccData { before: to_before, after: to_before_after },
+                        });
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        return Err(rename::Fail {
+                            error: Self::io_error_to_vfs(&error),
                             from_dir_wcc: vfs::WccData {
                                 before: from_before,
                                 after: from_before_after,

--- a/examples/mirror_fs/fs/rm_dir_impl.rs
+++ b/examples/mirror_fs/fs/rm_dir_impl.rs
@@ -1,11 +1,9 @@
-use async_trait::async_trait;
 use tokio::fs;
 
 use nfs_mamont::vfs::{self, rm_dir};
 
 use super::MirrorFS;
 
-#[async_trait]
 impl rm_dir::RmDir for MirrorFS {
     async fn rm_dir(&self, args: rm_dir::Args) -> Result<rm_dir::Success, rm_dir::Fail> {
         if args.object.name.as_str() == "." {

--- a/examples/mirror_fs/fs/rm_dir_impl.rs
+++ b/examples/mirror_fs/fs/rm_dir_impl.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use tokio::fs;
 
 use nfs_mamont::vfs::{self, rm_dir};
 
@@ -51,7 +52,7 @@ impl rm_dir::RmDir for MirrorFS {
             });
         }
 
-        match std::fs::remove_dir(&child_path) {
+        match fs::remove_dir(&child_path).await {
             Ok(()) => {
                 self.remove_cached_path(&child_path).await;
                 Ok(rm_dir::Success { wcc_data: Self::wcc_data(&dir_path, before) })

--- a/examples/mirror_fs/fs/rm_dir_impl.rs
+++ b/examples/mirror_fs/fs/rm_dir_impl.rs
@@ -53,6 +53,7 @@ impl rm_dir::RmDir for MirrorFS {
         match fs::remove_dir(&child_path).await {
             Ok(()) => {
                 self.remove_cached_path(&child_path).await;
+                self.invalidate_attr_cache_path(&dir_path).await;
                 Ok(rm_dir::Success { wcc_data: Self::wcc_data(&dir_path, before) })
             }
             Err(error) => Err(rm_dir::Fail {

--- a/examples/mirror_fs/fs/set_attr_impl.rs
+++ b/examples/mirror_fs/fs/set_attr_impl.rs
@@ -1,10 +1,7 @@
-use async_trait::async_trait;
-
 use nfs_mamont::vfs::{self, set_attr};
 
 use super::MirrorFS;
 
-#[async_trait]
 impl set_attr::SetAttr for MirrorFS {
     async fn set_attr(&self, args: set_attr::Args) -> Result<set_attr::Success, set_attr::Fail> {
         let path = match self.path_for_handle(&args.file).await {

--- a/examples/mirror_fs/fs/set_attr_impl.rs
+++ b/examples/mirror_fs/fs/set_attr_impl.rs
@@ -38,6 +38,7 @@ impl set_attr::SetAttr for MirrorFS {
             return Err(set_attr::Fail { error, wcc_data: Self::wcc_data(&path, before) });
         }
 
+        self.invalidate_read_ahead_path(&path).await;
         self.invalidate_attr_cache_path(&path).await;
 
         Ok(set_attr::Success { wcc_data: Self::wcc_data(&path, before) })

--- a/examples/mirror_fs/fs/set_attr_impl.rs
+++ b/examples/mirror_fs/fs/set_attr_impl.rs
@@ -38,6 +38,8 @@ impl set_attr::SetAttr for MirrorFS {
             return Err(set_attr::Fail { error, wcc_data: Self::wcc_data(&path, before) });
         }
 
+        self.invalidate_attr_cache_path(&path).await;
+
         Ok(set_attr::Success { wcc_data: Self::wcc_data(&path, before) })
     }
 }

--- a/examples/mirror_fs/fs/symlink_impl.rs
+++ b/examples/mirror_fs/fs/symlink_impl.rs
@@ -49,6 +49,9 @@ impl symlink::Symlink for MirrorFS {
             }
         };
 
+        self.invalidate_attr_cache_path(&link_path).await;
+        self.invalidate_attr_cache_path(&dir_path).await;
+
         Ok(symlink::Success {
             file: Some(handle),
             attr: Some(attr),

--- a/examples/mirror_fs/fs/symlink_impl.rs
+++ b/examples/mirror_fs/fs/symlink_impl.rs
@@ -1,10 +1,7 @@
-use async_trait::async_trait;
-
 use nfs_mamont::vfs::{self, symlink};
 
 use super::MirrorFS;
 
-#[async_trait]
 impl symlink::Symlink for MirrorFS {
     async fn symlink(&self, args: symlink::Args) -> Result<symlink::Success, symlink::Fail> {
         if let Err(error) = Self::ensure_name_allowed(&args.object.name) {

--- a/examples/mirror_fs/fs/write_impl.rs
+++ b/examples/mirror_fs/fs/write_impl.rs
@@ -81,6 +81,7 @@ impl write::Write for MirrorFS {
             });
         }
 
+        self.invalidate_read_ahead_path(&path).await;
         self.invalidate_attr_cache_path(&path).await;
 
         Ok(write::Success {

--- a/examples/mirror_fs/fs/write_impl.rs
+++ b/examples/mirror_fs/fs/write_impl.rs
@@ -38,19 +38,32 @@ impl write::Write for MirrorFS {
             }
         };
 
-        let data = Self::collect_slice_bytes(&args.data, args.size);
         if let Err(error) = file.seek(SeekFrom::Start(args.offset)).await {
             return Err(write::Fail {
                 error: Self::io_error_to_vfs(&error),
                 wcc_data: Self::wcc_data(&path, before),
             });
         }
-        if let Err(error) = file.write_all(&data).await {
-            return Err(write::Fail {
-                error: Self::io_error_to_vfs(&error),
-                wcc_data: Self::wcc_data(&path, before),
-            });
+
+        let mut remaining = args.size as usize;
+        let mut written: u32 = 0;
+        for part in &args.data {
+            if remaining == 0 {
+                break;
+            }
+
+            let chunk_len = part.len().min(remaining);
+            if let Err(error) = file.write_all(&part[..chunk_len]).await {
+                return Err(write::Fail {
+                    error: Self::io_error_to_vfs(&error),
+                    wcc_data: Self::wcc_data(&path, before),
+                });
+            }
+
+            remaining -= chunk_len;
+            written += chunk_len as u32;
         }
+
         let sync_result = match args.stable {
             write::StableHow::Unstable => Ok(()),
             write::StableHow::DataSync => file.sync_data().await,
@@ -65,7 +78,7 @@ impl write::Write for MirrorFS {
 
         Ok(write::Success {
             file_wcc: Self::wcc_data(&path, before),
-            count: data.len() as u32,
+            count: written,
             commited: args.stable,
             verifier: self.write_verifier(),
         })

--- a/examples/mirror_fs/fs/write_impl.rs
+++ b/examples/mirror_fs/fs/write_impl.rs
@@ -81,6 +81,8 @@ impl write::Write for MirrorFS {
             });
         }
 
+        self.invalidate_attr_cache_path(&path).await;
+
         Ok(write::Success {
             file_wcc: Self::wcc_data(&path, before),
             count: written,

--- a/examples/mirror_fs/fs/write_impl.rs
+++ b/examples/mirror_fs/fs/write_impl.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use std::io::SeekFrom;
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
@@ -7,7 +6,6 @@ use nfs_mamont::vfs::{self, write};
 
 use super::MirrorFS;
 
-#[async_trait]
 impl write::Write for MirrorFS {
     async fn write(&self, args: write::Args) -> Result<write::Success, write::Fail> {
         let path = match self.path_for_handle(&args.file).await {

--- a/examples/mirror_fs/fs/write_impl.rs
+++ b/examples/mirror_fs/fs/write_impl.rs
@@ -8,6 +8,18 @@ use super::MirrorFS;
 
 impl write::Write for MirrorFS {
     async fn write(&self, args: write::Args) -> Result<write::Success, write::Fail> {
+        let mut payload = Vec::with_capacity(args.size as usize);
+        let mut remaining_payload = args.size as usize;
+        for part in &args.data {
+            if remaining_payload == 0 {
+                break;
+            }
+
+            let take = part.len().min(remaining_payload);
+            payload.extend_from_slice(&part[..take]);
+            remaining_payload -= take;
+        }
+
         let path = match self.path_for_handle(&args.file).await {
             Ok(path) => path,
             Err(error) => {
@@ -50,23 +62,14 @@ impl write::Write for MirrorFS {
             });
         }
 
-        let mut remaining = args.size as usize;
-        let mut written: u32 = 0;
-        for part in &args.data {
-            if remaining == 0 {
-                break;
-            }
-
-            let chunk_len = part.len().min(remaining);
-            if let Err(error) = file.write_all(&part[..chunk_len]).await {
+        let written = payload.len() as u32;
+        if !payload.is_empty() {
+            if let Err(error) = file.write_all(&payload).await {
                 return Err(write::Fail {
                     error: Self::io_error_to_vfs(&error),
                     wcc_data: Self::wcc_data(&path, before),
                 });
             }
-
-            remaining -= chunk_len;
-            written += chunk_len as u32;
         }
 
         match args.stable {

--- a/examples/mirror_fs/fs/write_impl.rs
+++ b/examples/mirror_fs/fs/write_impl.rs
@@ -69,16 +69,28 @@ impl write::Write for MirrorFS {
             written += chunk_len as u32;
         }
 
-        let sync_result = match args.stable {
-            write::StableHow::Unstable => Ok(()),
-            write::StableHow::DataSync => file.sync_data().await,
-            write::StableHow::FileSync => file.sync_all().await,
-        };
-        if let Err(error) = sync_result {
-            return Err(write::Fail {
-                error: Self::io_error_to_vfs(&error),
-                wcc_data: Self::wcc_data(&path, before),
-            });
+        match args.stable {
+            write::StableHow::Unstable => {
+                self.mark_pending_unstable_write(&path).await;
+            }
+            write::StableHow::DataSync => {
+                if let Err(error) = file.sync_data().await {
+                    return Err(write::Fail {
+                        error: Self::io_error_to_vfs(&error),
+                        wcc_data: Self::wcc_data(&path, before),
+                    });
+                }
+                self.clear_pending_unstable_write(&path).await;
+            }
+            write::StableHow::FileSync => {
+                if let Err(error) = file.sync_all().await {
+                    return Err(write::Fail {
+                        error: Self::io_error_to_vfs(&error),
+                        wcc_data: Self::wcc_data(&path, before),
+                    });
+                }
+                self.clear_pending_unstable_write(&path).await;
+            }
         }
 
         self.invalidate_read_ahead_path(&path).await;

--- a/examples/mirror_fs/fs/write_impl.rs
+++ b/examples/mirror_fs/fs/write_impl.rs
@@ -20,23 +20,30 @@ impl write::Write for MirrorFS {
             }
         };
 
-        let before_meta = std::fs::symlink_metadata(&path).ok();
-        let before = before_meta.as_ref().map(Self::wcc_attr_from_metadata);
-        if let Some(attr) = before_meta.as_ref().map(Self::attr_from_metadata) {
-            if let Err(error) = Self::validate_regular(&attr) {
-                return Err(write::Fail { error, wcc_data: Self::wcc_data(&path, before) });
-            }
-        }
-
         let mut file = match OpenOptions::new().write(true).truncate(false).open(&path).await {
             Ok(file) => file,
             Err(error) => {
                 return Err(write::Fail {
                     error: Self::io_error_to_vfs(&error),
-                    wcc_data: Self::wcc_data(&path, before),
+                    wcc_data: vfs::WccData { before: None, after: None },
                 });
             }
         };
+
+        let before_meta = match file.metadata().await {
+            Ok(meta) => meta,
+            Err(error) => {
+                return Err(write::Fail {
+                    error: Self::io_error_to_vfs(&error),
+                    wcc_data: vfs::WccData { before: None, after: None },
+                });
+            }
+        };
+        let before = Some(Self::wcc_attr_from_metadata(&before_meta));
+        let attr = Self::attr_from_metadata(&before_meta);
+        if let Err(error) = Self::validate_regular(&attr) {
+            return Err(write::Fail { error, wcc_data: Self::wcc_data(&path, before) });
+        }
 
         if let Err(error) = file.seek(SeekFrom::Start(args.offset)).await {
             return Err(write::Fail {

--- a/examples/mirror_fs/fs_map.rs
+++ b/examples/mirror_fs/fs_map.rs
@@ -1,22 +1,24 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
-use dashmap::mapref::entry::Entry;
-use dashmap::DashMap;
+use tokio::sync::{Mutex, RwLock};
+use whirlwind::ShardMap;
 
 use nfs_mamont::vfs;
 use nfs_mamont::vfs::file;
 
 /// Maps mirror paths to opaque VFS handles.
-#[derive(Debug)]
 pub struct FsMap {
     root: PathBuf,
     next_id: AtomicU64,
-    id_to_key: DashMap<u64, ObjectKey>,
-    key_to_id: DashMap<ObjectKey, u64>,
-    key_to_paths: DashMap<ObjectKey, BTreeSet<PathBuf>>,
-    relative_to_key: DashMap<PathBuf, ObjectKey>,
+    id_to_key: ShardMap<u64, ObjectKey>,
+    key_to_id: ShardMap<ObjectKey, u64>,
+    key_to_paths: ShardMap<ObjectKey, Arc<RwLock<BTreeSet<PathBuf>>>>,
+    relative_to_key: ShardMap<PathBuf, ObjectKey>,
+    relative_index: RwLock<BTreeSet<PathBuf>>,
+    mutation_lock: Mutex<()>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -30,10 +32,12 @@ impl FsMap {
         Self {
             root,
             next_id: AtomicU64::new(2),
-            id_to_key: DashMap::new(),
-            key_to_id: DashMap::new(),
-            key_to_paths: DashMap::new(),
-            relative_to_key: DashMap::new(),
+            id_to_key: ShardMap::new(),
+            key_to_id: ShardMap::new(),
+            key_to_paths: ShardMap::new(),
+            relative_to_key: ShardMap::new(),
+            relative_index: RwLock::new(BTreeSet::new()),
+            mutation_lock: Mutex::new(()),
         }
     }
 
@@ -41,7 +45,7 @@ impl FsMap {
         Self::encode_handle(1)
     }
 
-    pub fn path_candidates_for_handle(
+    pub async fn path_candidates_for_handle(
         &self,
         handle: &file::Handle,
     ) -> Result<Vec<PathBuf>, vfs::Error> {
@@ -50,13 +54,22 @@ impl FsMap {
             return Ok(vec![self.root.clone()]);
         }
 
-        let key = *self.id_to_key.get(&id).ok_or(vfs::Error::StaleFile)?;
-        let paths = self.key_to_paths.get(&key).ok_or(vfs::Error::StaleFile)?;
+        let key = {
+            let key_ref = self.id_to_key.get(&id).await.ok_or(vfs::Error::StaleFile)?;
+            *key_ref.value()
+        };
+
+        let paths_lock = {
+            let paths_ref = self.key_to_paths.get(&key).await.ok_or(vfs::Error::StaleFile)?;
+            Arc::clone(paths_ref.value())
+        };
+
+        let paths = paths_lock.read().await;
         let full_paths = paths.iter().map(|relative| self.to_full_path(relative)).collect();
         Ok(full_paths)
     }
 
-    pub fn ensure_handle_for_attr(
+    pub async fn ensure_handle_for_attr(
         &self,
         path: &Path,
         attr: &file::Attr,
@@ -68,103 +81,144 @@ impl FsMap {
             return Ok(self.root_handle());
         }
 
+        let _guard = self.mutation_lock.lock().await;
+
         let key = ObjectKey { dev: attr.fs_id, ino: attr.file_id };
-        if let Some(id) = self.key_to_id.get(&key).map(|entry| *entry.value()) {
-            self.key_to_paths.entry(key).or_insert_with(BTreeSet::new).insert(relative.clone());
-            self.relative_to_key.insert(relative, key);
+        if let Some(id) = {
+            self.key_to_id.get(&key).await.map(|id_ref| *id_ref.value())
+        } {
+            self.insert_relative_alias(relative, key).await;
             return Ok(Self::encode_handle(id));
         }
 
         let reserved = Self::reserve_next_id(&self.next_id);
-        let id = match self.key_to_id.entry(key) {
-            Entry::Occupied(existing) => *existing.get(),
-            Entry::Vacant(vacant) => {
-                vacant.insert(reserved);
-                self.id_to_key.insert(reserved, key);
-                reserved
-            }
-        };
+        self.key_to_id.insert(key, reserved).await;
+        self.id_to_key.insert(reserved, key).await;
+        self.key_to_paths.insert(key, Arc::new(RwLock::new(BTreeSet::new()))).await;
+        self.insert_relative_alias(relative, key).await;
 
-        self.key_to_paths.entry(key).or_insert_with(BTreeSet::new).insert(relative.clone());
-        self.relative_to_key.insert(relative, key);
-
-        if id != reserved {
-            self.id_to_key.remove(&reserved);
-        }
-
-        Ok(Self::encode_handle(id))
+        Ok(Self::encode_handle(reserved))
     }
 
-    pub fn remove_path(&self, path: &Path) {
+    pub async fn remove_path(&self, path: &Path) {
         let Ok(relative) = path.strip_prefix(&self.root) else {
             return;
         };
         let relative = relative.to_path_buf();
 
-        let to_remove = self
-            .relative_to_key
-            .iter()
-            .filter(|entry| {
-                entry.key() == &relative || entry.key().starts_with(&relative)
-            })
-            .map(|entry| entry.key().clone())
-            .collect::<Vec<_>>();
+        let _guard = self.mutation_lock.lock().await;
+
+        let to_remove = {
+            let index = self.relative_index.read().await;
+            index
+                .iter()
+                .filter(|known_relative| {
+                    *known_relative == &relative || known_relative.starts_with(&relative)
+                })
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+
+        if to_remove.is_empty() {
+            return;
+        }
 
         for known_relative in to_remove {
-            let Some(key) = self.relative_to_key.remove(&known_relative) else {
+            let Some(key) = self.relative_to_key.remove(&known_relative).await else {
                 continue;
             };
-            let key = key.1;
-            if let Some(mut paths) = self.key_to_paths.get_mut(&key) {
-                paths.value_mut().remove(&known_relative);
-                if paths.value().is_empty() {
-                    drop(paths);
-                    self.key_to_paths.remove(&key);
-                    if let Some(id) = self.key_to_id.remove(&key).map(|(_, id)| id) {
-                        self.id_to_key.remove(&id);
+            self.relative_index.write().await.remove(&known_relative);
+
+            if let Some(paths_lock) = self.paths_lock_for_key(&key).await {
+
+                let mut paths = paths_lock.write().await;
+                paths.remove(&known_relative);
+                let empty = paths.is_empty();
+                drop(paths);
+
+                if empty {
+                    self.key_to_paths.remove(&key).await;
+                    if let Some(id) = self.key_to_id.remove(&key).await {
+                        self.id_to_key.remove(&id).await;
                     }
                 }
             }
         }
     }
 
-    pub fn rename_path(&self, from: &Path, to: &Path) -> Result<(), vfs::Error> {
+    pub async fn rename_path(&self, from: &Path, to: &Path) -> Result<(), vfs::Error> {
         let from_relative =
             from.strip_prefix(&self.root).map_err(|_| vfs::Error::BadFileHandle)?.to_path_buf();
         let to_relative =
             to.strip_prefix(&self.root).map_err(|_| vfs::Error::BadFileHandle)?.to_path_buf();
 
-        let updates = self
-            .relative_to_key
-            .iter()
-            .filter_map(|entry| {
-                let known_relative = entry.key();
-                let key = *entry.value();
-                if known_relative == &from_relative || known_relative.starts_with(&from_relative) {
-                    let suffix = known_relative.strip_prefix(&from_relative).ok()?.to_path_buf();
-                    let mut replacement = to_relative.clone();
-                    if !suffix.as_os_str().is_empty() {
-                        replacement.push(suffix);
-                    }
-                    Some((known_relative.clone(), key, replacement))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
+        let _guard = self.mutation_lock.lock().await;
 
-        for (old_relative, key, new_relative) in updates {
-            self.relative_to_key.remove(&old_relative);
-            self.relative_to_key.insert(new_relative.clone(), key);
+        let to_rename = {
+            let index = self.relative_index.read().await;
+            index
+                .iter()
+                .filter(|known_relative| {
+                    *known_relative == &from_relative || known_relative.starts_with(&from_relative)
+                })
+                .cloned()
+                .collect::<Vec<_>>()
+        };
 
-            if let Some(mut paths) = self.key_to_paths.get_mut(&key) {
-                let values = paths.value_mut();
-                values.remove(&old_relative);
-                values.insert(new_relative);
+        if to_rename.is_empty() {
+            return Ok(());
+        }
+
+        for old_relative in to_rename {
+            let Some(key) = ({
+                self.relative_to_key
+                    .get(&old_relative)
+                    .await
+                    .map(|key_ref| *key_ref.value())
+            }) else {
+                continue;
+            };
+
+            let suffix = old_relative
+                .strip_prefix(&from_relative)
+                .map_err(|_| vfs::Error::InvalidArgument)?
+                .to_path_buf();
+            let mut new_relative = to_relative.clone();
+            if !suffix.as_os_str().is_empty() {
+                new_relative.push(suffix);
+            }
+
+            self.relative_to_key.remove(&old_relative).await;
+            self.relative_to_key.insert(new_relative.clone(), key).await;
+
+            {
+                let mut index = self.relative_index.write().await;
+                index.remove(&old_relative);
+                index.insert(new_relative.clone());
+            }
+
+            if let Some(paths_lock) = self.paths_lock_for_key(&key).await {
+
+                let mut paths = paths_lock.write().await;
+                paths.remove(&old_relative);
+                paths.insert(new_relative);
             }
         }
 
         Ok(())
+    }
+
+    async fn insert_relative_alias(&self, relative: PathBuf, key: ObjectKey) {
+        self.relative_to_key.insert(relative.clone(), key).await;
+        self.relative_index.write().await.insert(relative.clone());
+
+        if let Some(paths_lock) = self.paths_lock_for_key(&key).await {
+            paths_lock.write().await.insert(relative);
+        }
+    }
+
+    async fn paths_lock_for_key(&self, key: &ObjectKey) -> Option<Arc<RwLock<BTreeSet<PathBuf>>>> {
+        self.key_to_paths.get(key).await.map(|paths_ref| Arc::clone(paths_ref.value()))
     }
 
     fn to_full_path(&self, relative: &Path) -> PathBuf {

--- a/examples/mirror_fs/fs_map.rs
+++ b/examples/mirror_fs/fs_map.rs
@@ -1,6 +1,9 @@
-use std::collections::{BTreeSet, HashMap};
-use std::os::unix::fs::MetadataExt;
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
 
 use nfs_mamont::vfs;
 use nfs_mamont::vfs::file;
@@ -9,11 +12,11 @@ use nfs_mamont::vfs::file;
 #[derive(Debug)]
 pub struct FsMap {
     root: PathBuf,
-    next_id: u64,
-    id_to_key: HashMap<u64, ObjectKey>,
-    key_to_id: HashMap<ObjectKey, u64>,
-    key_to_paths: HashMap<ObjectKey, BTreeSet<PathBuf>>,
-    relative_to_key: HashMap<PathBuf, ObjectKey>,
+    next_id: AtomicU64,
+    id_to_key: DashMap<u64, ObjectKey>,
+    key_to_id: DashMap<ObjectKey, u64>,
+    key_to_paths: DashMap<ObjectKey, BTreeSet<PathBuf>>,
+    relative_to_key: DashMap<PathBuf, ObjectKey>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -26,11 +29,11 @@ impl FsMap {
     pub fn new(root: PathBuf) -> Self {
         Self {
             root,
-            next_id: 2,
-            id_to_key: HashMap::new(),
-            key_to_id: HashMap::new(),
-            key_to_paths: HashMap::new(),
-            relative_to_key: HashMap::new(),
+            next_id: AtomicU64::new(2),
+            id_to_key: DashMap::new(),
+            key_to_id: DashMap::new(),
+            key_to_paths: DashMap::new(),
+            relative_to_key: DashMap::new(),
         }
     }
 
@@ -38,29 +41,26 @@ impl FsMap {
         Self::encode_handle(1)
     }
 
-    pub fn path_for_handle(&self, handle: &file::Handle) -> Result<PathBuf, vfs::Error> {
+    pub fn path_candidates_for_handle(
+        &self,
+        handle: &file::Handle,
+    ) -> Result<Vec<PathBuf>, vfs::Error> {
         let id = Self::decode_handle(handle)?;
         if id == 1 {
-            return Ok(self.root.clone());
+            return Ok(vec![self.root.clone()]);
         }
 
-        let key = self.id_to_key.get(&id).ok_or(vfs::Error::StaleFile)?;
-        let paths = self.key_to_paths.get(key).ok_or(vfs::Error::StaleFile)?;
-
-        // Prefer a live path, but do not mutate mappings here.
-        // During in-flight rename/unlink operations another task may still update
-        // aliases; eager pruning here can invalidate a valid handle and cause EIO.
-        for relative in paths {
-            let full = self.to_full_path(relative);
-            if std::fs::symlink_metadata(&full).is_ok() {
-                return Ok(full);
-            }
-        }
-
-        Err(vfs::Error::StaleFile)
+        let key = *self.id_to_key.get(&id).ok_or(vfs::Error::StaleFile)?;
+        let paths = self.key_to_paths.get(&key).ok_or(vfs::Error::StaleFile)?;
+        let full_paths = paths.iter().map(|relative| self.to_full_path(relative)).collect();
+        Ok(full_paths)
     }
 
-    pub fn ensure_handle_for_path(&mut self, path: &Path) -> Result<file::Handle, vfs::Error> {
+    pub fn ensure_handle_for_attr(
+        &self,
+        path: &Path,
+        attr: &file::Attr,
+    ) -> Result<file::Handle, vfs::Error> {
         let relative =
             path.strip_prefix(&self.root).map_err(|_| vfs::Error::BadFileHandle)?.to_path_buf();
 
@@ -68,29 +68,34 @@ impl FsMap {
             return Ok(self.root_handle());
         }
 
-        let key = Self::object_key_for_path(path)?;
-        if let Some(id) = self.key_to_id.get(&key).copied() {
-            self.key_to_paths.entry(key).or_default().insert(relative.clone());
+        let key = ObjectKey { dev: attr.fs_id, ino: attr.file_id };
+        if let Some(id) = self.key_to_id.get(&key).map(|entry| *entry.value()) {
+            self.key_to_paths.entry(key).or_insert_with(BTreeSet::new).insert(relative.clone());
             self.relative_to_key.insert(relative, key);
             return Ok(Self::encode_handle(id));
         }
 
-        let id = self.next_id;
-        self.next_id = self.next_id.wrapping_add(1);
-        if self.next_id <= 1 {
-            self.next_id = 2;
-        }
-        let mut paths = BTreeSet::new();
-        paths.insert(relative.clone());
+        let reserved = Self::reserve_next_id(&self.next_id);
+        let id = match self.key_to_id.entry(key) {
+            Entry::Occupied(existing) => *existing.get(),
+            Entry::Vacant(vacant) => {
+                vacant.insert(reserved);
+                self.id_to_key.insert(reserved, key);
+                reserved
+            }
+        };
 
-        self.id_to_key.insert(id, key);
-        self.key_to_id.insert(key, id);
-        self.key_to_paths.insert(key, paths);
+        self.key_to_paths.entry(key).or_insert_with(BTreeSet::new).insert(relative.clone());
         self.relative_to_key.insert(relative, key);
+
+        if id != reserved {
+            self.id_to_key.remove(&reserved);
+        }
+
         Ok(Self::encode_handle(id))
     }
 
-    pub fn remove_path(&mut self, path: &Path) {
+    pub fn remove_path(&self, path: &Path) {
         let Ok(relative) = path.strip_prefix(&self.root) else {
             return;
         };
@@ -98,22 +103,24 @@ impl FsMap {
 
         let to_remove = self
             .relative_to_key
-            .keys()
-            .filter(|known_relative| {
-                *known_relative == &relative || known_relative.starts_with(&relative)
+            .iter()
+            .filter(|entry| {
+                entry.key() == &relative || entry.key().starts_with(&relative)
             })
-            .cloned()
+            .map(|entry| entry.key().clone())
             .collect::<Vec<_>>();
 
         for known_relative in to_remove {
             let Some(key) = self.relative_to_key.remove(&known_relative) else {
                 continue;
             };
-            if let Some(paths) = self.key_to_paths.get_mut(&key) {
-                paths.remove(&known_relative);
-                if paths.is_empty() {
+            let key = key.1;
+            if let Some(mut paths) = self.key_to_paths.get_mut(&key) {
+                paths.value_mut().remove(&known_relative);
+                if paths.value().is_empty() {
+                    drop(paths);
                     self.key_to_paths.remove(&key);
-                    if let Some(id) = self.key_to_id.remove(&key) {
+                    if let Some(id) = self.key_to_id.remove(&key).map(|(_, id)| id) {
                         self.id_to_key.remove(&id);
                     }
                 }
@@ -121,7 +128,7 @@ impl FsMap {
         }
     }
 
-    pub fn rename_path(&mut self, from: &Path, to: &Path) -> Result<(), vfs::Error> {
+    pub fn rename_path(&self, from: &Path, to: &Path) -> Result<(), vfs::Error> {
         let from_relative =
             from.strip_prefix(&self.root).map_err(|_| vfs::Error::BadFileHandle)?.to_path_buf();
         let to_relative =
@@ -130,14 +137,16 @@ impl FsMap {
         let updates = self
             .relative_to_key
             .iter()
-            .filter_map(|(known_relative, key)| {
+            .filter_map(|entry| {
+                let known_relative = entry.key();
+                let key = *entry.value();
                 if known_relative == &from_relative || known_relative.starts_with(&from_relative) {
                     let suffix = known_relative.strip_prefix(&from_relative).ok()?.to_path_buf();
                     let mut replacement = to_relative.clone();
                     if !suffix.as_os_str().is_empty() {
                         replacement.push(suffix);
                     }
-                    Some((known_relative.clone(), *key, replacement))
+                    Some((known_relative.clone(), key, replacement))
                 } else {
                     None
                 }
@@ -148,9 +157,10 @@ impl FsMap {
             self.relative_to_key.remove(&old_relative);
             self.relative_to_key.insert(new_relative.clone(), key);
 
-            if let Some(paths) = self.key_to_paths.get_mut(&key) {
-                paths.remove(&old_relative);
-                paths.insert(new_relative);
+            if let Some(mut paths) = self.key_to_paths.get_mut(&key) {
+                let values = paths.value_mut();
+                values.remove(&old_relative);
+                values.insert(new_relative);
             }
         }
 
@@ -169,11 +179,6 @@ impl FsMap {
         file::Handle(id.to_be_bytes())
     }
 
-    fn object_key_for_path(path: &Path) -> Result<ObjectKey, vfs::Error> {
-        let metadata = std::fs::symlink_metadata(path).map_err(Self::map_io_error)?;
-        Ok(ObjectKey { dev: metadata.dev(), ino: metadata.ino() })
-    }
-
     fn decode_handle(handle: &file::Handle) -> Result<u64, vfs::Error> {
         let id = u64::from_be_bytes(handle.0);
         if id == 0 {
@@ -183,14 +188,18 @@ impl FsMap {
         }
     }
 
-    fn map_io_error(error: std::io::Error) -> vfs::Error {
-        match error.kind() {
-            std::io::ErrorKind::NotFound => vfs::Error::NoEntry,
-            std::io::ErrorKind::PermissionDenied => vfs::Error::Access,
-            std::io::ErrorKind::InvalidInput | std::io::ErrorKind::InvalidData => {
-                vfs::Error::InvalidArgument
+    fn reserve_next_id(next_id: &AtomicU64) -> u64 {
+        loop {
+            let current = next_id.load(Ordering::Relaxed);
+            let candidate = if current <= 1 { 2 } else { current };
+            let next = candidate.wrapping_add(1).max(2);
+            if next_id
+                .compare_exchange(current, next, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+            {
+                return candidate;
             }
-            _ => vfs::Error::IO,
         }
     }
+
 }

--- a/examples/mirror_fs/fs_map.rs
+++ b/examples/mirror_fs/fs_map.rs
@@ -1,4 +1,6 @@
 use std::collections::BTreeSet;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -9,6 +11,8 @@ use whirlwind::ShardMap;
 use nfs_mamont::vfs;
 use nfs_mamont::vfs::file;
 
+const FS_MAP_MUTATION_SHARDS: usize = 64;
+
 /// Maps mirror paths to opaque VFS handles.
 pub struct FsMap {
     root: PathBuf,
@@ -18,7 +22,7 @@ pub struct FsMap {
     key_to_paths: ShardMap<ObjectKey, Arc<RwLock<BTreeSet<PathBuf>>>>,
     relative_to_key: ShardMap<PathBuf, ObjectKey>,
     relative_index: RwLock<BTreeSet<PathBuf>>,
-    mutation_lock: Mutex<()>,
+    mutation_locks: Vec<Mutex<()>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -37,7 +41,7 @@ impl FsMap {
             key_to_paths: ShardMap::new(),
             relative_to_key: ShardMap::new(),
             relative_index: RwLock::new(BTreeSet::new()),
-            mutation_lock: Mutex::new(()),
+            mutation_locks: (0..FS_MAP_MUTATION_SHARDS).map(|_| Mutex::new(())).collect(),
         }
     }
 
@@ -81,7 +85,8 @@ impl FsMap {
             return Ok(self.root_handle());
         }
 
-        let _guard = self.mutation_lock.lock().await;
+        let shard = Self::mutation_shard_for_relative(&relative);
+        let _guard = self.mutation_locks[shard].lock().await;
 
         let key = ObjectKey { dev: attr.fs_id, ino: attr.file_id };
         if let Some(id) = { self.key_to_id.get(&key).await.map(|id_ref| *id_ref.value()) } {
@@ -104,7 +109,8 @@ impl FsMap {
         };
         let relative = relative.to_path_buf();
 
-        let _guard = self.mutation_lock.lock().await;
+        let shard = Self::mutation_shard_for_relative(&relative);
+        let _guard = self.mutation_locks[shard].lock().await;
 
         let to_remove = {
             let index = self.relative_index.read().await;
@@ -149,7 +155,20 @@ impl FsMap {
         let to_relative =
             to.strip_prefix(&self.root).map_err(|_| vfs::Error::BadFileHandle)?.to_path_buf();
 
-        let _guard = self.mutation_lock.lock().await;
+        let from_shard = Self::mutation_shard_for_relative(&from_relative);
+        let to_shard = Self::mutation_shard_for_relative(&to_relative);
+        let (first, second) = if from_shard <= to_shard {
+            (from_shard, to_shard)
+        } else {
+            (to_shard, from_shard)
+        };
+
+        let _first_guard = self.mutation_locks[first].lock().await;
+        let _second_guard = if second != first {
+            Some(self.mutation_locks[second].lock().await)
+        } else {
+            None
+        };
 
         let to_rename = {
             let index = self.relative_index.read().await;
@@ -245,5 +264,11 @@ impl FsMap {
                 return candidate;
             }
         }
+    }
+
+    fn mutation_shard_for_relative(relative: &Path) -> usize {
+        let mut hasher = DefaultHasher::new();
+        relative.hash(&mut hasher);
+        (hasher.finish() as usize) % FS_MAP_MUTATION_SHARDS
     }
 }

--- a/examples/mirror_fs/fs_map.rs
+++ b/examples/mirror_fs/fs_map.rs
@@ -84,9 +84,7 @@ impl FsMap {
         let _guard = self.mutation_lock.lock().await;
 
         let key = ObjectKey { dev: attr.fs_id, ino: attr.file_id };
-        if let Some(id) = {
-            self.key_to_id.get(&key).await.map(|id_ref| *id_ref.value())
-        } {
+        if let Some(id) = { self.key_to_id.get(&key).await.map(|id_ref| *id_ref.value()) } {
             self.insert_relative_alias(relative, key).await;
             return Ok(Self::encode_handle(id));
         }
@@ -130,7 +128,6 @@ impl FsMap {
             self.relative_index.write().await.remove(&known_relative);
 
             if let Some(paths_lock) = self.paths_lock_for_key(&key).await {
-
                 let mut paths = paths_lock.write().await;
                 paths.remove(&known_relative);
                 let empty = paths.is_empty();
@@ -170,12 +167,9 @@ impl FsMap {
         }
 
         for old_relative in to_rename {
-            let Some(key) = ({
-                self.relative_to_key
-                    .get(&old_relative)
-                    .await
-                    .map(|key_ref| *key_ref.value())
-            }) else {
+            let Some(key) =
+                ({ self.relative_to_key.get(&old_relative).await.map(|key_ref| *key_ref.value()) })
+            else {
                 continue;
             };
 
@@ -198,7 +192,6 @@ impl FsMap {
             }
 
             if let Some(paths_lock) = self.paths_lock_for_key(&key).await {
-
                 let mut paths = paths_lock.write().await;
                 paths.remove(&old_relative);
                 paths.insert(new_relative);
@@ -247,13 +240,10 @@ impl FsMap {
             let current = next_id.load(Ordering::Relaxed);
             let candidate = if current <= 1 { 2 } else { current };
             let next = candidate.wrapping_add(1).max(2);
-            if next_id
-                .compare_exchange(current, next, Ordering::AcqRel, Ordering::Relaxed)
-                .is_ok()
+            if next_id.compare_exchange(current, next, Ordering::AcqRel, Ordering::Relaxed).is_ok()
             {
                 return candidate;
             }
         }
     }
-
 }

--- a/examples/mirror_fs/main.rs
+++ b/examples/mirror_fs/main.rs
@@ -33,10 +33,10 @@ async fn main() -> std::io::Result<()> {
     let root_handle = fs.root_handle().await;
     let context = ServerContext::new(
         fs.clone(),
-        NonZeroUsize::new(64 * 1024).unwrap(),
-        NonZeroUsize::new(8).unwrap(),
-        NonZeroUsize::new(64 * 1024).unwrap(),
-        NonZeroUsize::new(8).unwrap(),
+        NonZeroUsize::new(512 * 1024).unwrap(),
+        NonZeroUsize::new(2048).unwrap(),
+        NonZeroUsize::new(512 * 1024).unwrap(),
+        NonZeroUsize::new(2048).unwrap(),
     );
 
     #[cfg(debug_assertions)]

--- a/examples/mirror_fs/main.rs
+++ b/examples/mirror_fs/main.rs
@@ -34,9 +34,9 @@ async fn main() -> std::io::Result<()> {
     let context = ServerContext::new(
         fs.clone(),
         NonZeroUsize::new(512 * 1024).unwrap(),
-        NonZeroUsize::new(2048).unwrap(),
+        NonZeroUsize::new(2048 * 2).unwrap(),
         NonZeroUsize::new(512 * 1024).unwrap(),
-        NonZeroUsize::new(2048).unwrap(),
+        NonZeroUsize::new(2048 * 2).unwrap(),
     );
 
     #[cfg(debug_assertions)]

--- a/examples/mirror_fs/main.rs
+++ b/examples/mirror_fs/main.rs
@@ -10,6 +10,8 @@ use nfs_mamont::{handle_forever_with_exports, MountExport, ServerContext};
 #[cfg(debug_assertions)]
 use nfs_mamont::init_tracing;
 
+use crate::fs::READ_WRITE_MAX;
+
 pub mod fs;
 pub mod fs_map;
 
@@ -33,10 +35,10 @@ async fn main() -> std::io::Result<()> {
     let root_handle = fs.root_handle().await;
     let context = ServerContext::new(
         fs.clone(),
-        NonZeroUsize::new(512 * 1024).unwrap(),
-        NonZeroUsize::new(2048 * 2).unwrap(),
-        NonZeroUsize::new(512 * 1024).unwrap(),
-        NonZeroUsize::new(2048 * 2).unwrap(),
+        NonZeroUsize::new(READ_WRITE_MAX as usize).unwrap(),
+        NonZeroUsize::new(2048).unwrap(),
+        NonZeroUsize::new(READ_WRITE_MAX as usize).unwrap(),
+        NonZeroUsize::new(2048).unwrap(),
     );
 
     #[cfg(debug_assertions)]

--- a/examples/mirror_fs/tests/create_ops.rs
+++ b/examples/mirror_fs/tests/create_ops.rs
@@ -345,6 +345,38 @@ async fn write_writes_data_with_offset_and_commit_matches_verifier() {
 }
 
 #[tokio::test]
+async fn unstable_write_reports_unstable_and_commit_succeeds() {
+    let ctx = TestContext::new();
+    write_file(ctx.root_path(), "file.txt", b"");
+    let root = ctx.root_handle().await;
+    let handle = ctx.lookup_handle(root, "file.txt").await;
+
+    let write_result = expect_ok(
+        write::Write::write(
+            &ctx.fs,
+            write::Args {
+                file: handle.clone(),
+                offset: 0,
+                size: 4,
+                stable: write::StableHow::Unstable,
+                data: slice_from_bytes(b"data").await,
+            },
+        )
+        .await,
+        "unstable write should succeed",
+    );
+    assert_eq!(write_result.count, 4);
+    assert_eq!(write_result.commited, write::StableHow::Unstable);
+
+    let commit_result = expect_ok(
+        commit::Commit::commit(&ctx.fs, commit::Args { file: handle, offset: 0, count: 0 }).await,
+        "commit after unstable write should succeed",
+    );
+    assert_eq!(commit_result.verifier.0, write_result.verifier.0);
+    assert_eq!(stdfs::read(ctx.root_path().join("file.txt")).unwrap(), b"data");
+}
+
+#[tokio::test]
 async fn file_lifecycle_create_edit_read_and_remove() {
     let ctx = TestContext::new();
     let root = ctx.root_handle().await;

--- a/examples/mirror_fs/tests/info_ops.rs
+++ b/examples/mirror_fs/tests/info_ops.rs
@@ -15,6 +15,8 @@ use nfs_mamont::vfs::read_dir;
 use nfs_mamont::vfs::read_dir_plus;
 use nfs_mamont::vfs::read_link;
 
+use crate::fs::READ_WRITE_MAX;
+
 use super::helpers::{
     alloc_slice, create_dir, create_symlink, expect_err, expect_ok, slice_to_vec, write_file,
     TestContext,
@@ -108,8 +110,8 @@ async fn fs_info_returns_server_limits() {
     let properties = result.properties.bits();
 
     assert!(result.root_attr.is_some());
-    assert_eq!(result.read_max, 64 * 1024);
-    assert_eq!(result.write_max, 64 * 1024);
+    assert_eq!(result.read_max, READ_WRITE_MAX);
+    assert_eq!(result.write_max, READ_WRITE_MAX);
     assert_eq!(result.read_dir_pref, 8 * 1024);
     assert!(properties & fs_info::Properties::LINK != 0);
     assert!(properties & fs_info::Properties::SYMLINK != 0);

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -69,15 +69,16 @@ impl Allocator for Impl {
             return None;
         }
 
-        let mut remain_size = size.get();
-        let mut buffers = Vec::with_capacity(remain_size.div_ceil(self.buffer_size.get()));
+        let remain_size = size.get();
+        let count_needed = remain_size.div_ceil(self.buffer_size.get());
+        let mut buffers = Vec::with_capacity(count_needed);
 
-        while remain_size > 0 {
-            let buffer = self.receiver.recv().await?;
-            assert_eq!(buffer.len(), self.buffer_size.get());
-
-            remain_size = remain_size.saturating_sub(buffer.len());
-            buffers.push(buffer);
+        while buffers.len() < count_needed {
+            let limit = count_needed - buffers.len();
+            let count_read = self.receiver.recv_many(&mut buffers, limit).await;
+            if count_read == 0 {
+                return None;
+            }
         }
 
         Some(Slice::new(buffers, 0..size.get(), self.sender.clone()))

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -8,14 +8,21 @@ mod tests;
 
 use std::future::Future;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 
-use tokio::sync::mpsc;
+use crossbeam_queue::ArrayQueue;
+use tokio::sync::Semaphore;
 
 pub use slice::Slice;
 
-type Sender<T> = mpsc::UnboundedSender<T>;
-type Receiver<T> = mpsc::UnboundedReceiver<T>;
 type Buffer = Box<[u8]>;
+
+/// Shared state of the allocator to allow return of buffers and permit restoration.
+#[derive(Debug)]
+pub struct AllocatorState {
+    pub pool: ArrayQueue<Buffer>,
+    pub semaphore: Semaphore,
+}
 
 /// Allocates [`Slice`]'s.
 pub trait Allocator {
@@ -28,13 +35,11 @@ pub trait Allocator {
     /// # Panic
     ///
     /// This method panics if size is greater then allocator capacity.
-    fn allocate(&mut self, size: NonZeroUsize)
-        -> impl Future<Output = Option<slice::Slice>> + Send;
+    fn allocate(&self, size: NonZeroUsize) -> impl Future<Output = Option<slice::Slice>> + Send;
 }
 
 pub struct Impl {
-    receiver: Receiver<Buffer>,
-    sender: Sender<Buffer>,
+    state: Arc<AllocatorState>,
     buffer_size: NonZeroUsize,
     buffer_count: NonZeroUsize,
 }
@@ -47,15 +52,18 @@ impl Impl {
     /// - `size` --- size of each buffer to allocate
     /// - `count` --- number of buffers to allocate
     pub fn new(size: NonZeroUsize, count: NonZeroUsize) -> Self {
-        let (sender, receiver) = mpsc::unbounded_channel::<Buffer>();
+        let pool = ArrayQueue::new(count.get());
+        let semaphore = Semaphore::new(count.get());
 
         for _ in 0..count.get() {
-            sender
-                .send(vec![0; size.get()].into_boxed_slice())
-                .expect("can't initialize allocator");
+            pool.push(vec![0; size.get()].into_boxed_slice()).expect("can't initialize allocator");
         }
 
-        Self { sender, receiver, buffer_size: size, buffer_count: count }
+        Self {
+            state: Arc::new(AllocatorState { pool, semaphore }),
+            buffer_size: size,
+            buffer_count: count,
+        }
     }
 
     fn capacity(&self) -> usize {
@@ -64,23 +72,30 @@ impl Impl {
 }
 
 impl Allocator for Impl {
-    async fn allocate(&mut self, size: NonZeroUsize) -> Option<slice::Slice> {
+    async fn allocate(&self, size: NonZeroUsize) -> Option<slice::Slice> {
         if size.get() > self.capacity() {
             return None;
         }
 
         let remain_size = size.get();
         let count_needed = remain_size.div_ceil(self.buffer_size.get());
-        let mut buffers = Vec::with_capacity(count_needed);
 
-        while buffers.len() < count_needed {
-            let limit = count_needed - buffers.len();
-            let count_read = self.receiver.recv_many(&mut buffers, limit).await;
-            if count_read == 0 {
-                return None;
+        let permit = match self.state.semaphore.acquire_many(count_needed as u32).await {
+            Ok(p) => p,
+            Err(_) => return None,
+        };
+
+        let mut buffers = Vec::with_capacity(count_needed);
+        for _ in 0..count_needed {
+            if let Some(buf) = self.state.pool.pop() {
+                buffers.push(buf);
+            } else {
+                unreachable!("Semaphore permitted allocation but pool was empty");
             }
         }
 
-        Some(Slice::new(buffers, 0..size.get(), self.sender.clone()))
+        permit.forget();
+
+        Some(Slice::new(buffers, 0..size.get(), Some(Arc::clone(&self.state))))
     }
 }

--- a/src/allocator/slice.rs
+++ b/src/allocator/slice.rs
@@ -1,11 +1,13 @@
 //! Defines [`Slice`] --- list of buffers bounded by custome byte range.
 
+use std::sync::Arc;
+
 /// Represents bounded by custome range list of buffers.
 #[cfg_attr(test, derive(Debug))]
 pub struct Slice {
     buffers: Vec<Box<[u8]>>,
     range: std::ops::Range<usize>,
-    sender: Option<super::Sender<Box<[u8]>>>,
+    state: Option<Arc<super::AllocatorState>>,
 }
 
 impl Slice {
@@ -15,7 +17,7 @@ impl Slice {
     ///
     /// - `buffers` --- vec of buffers.
     /// - `range` --- range to which slice will allow access.
-    /// - `sender` --- sender to deallocated buffers in drop.
+    /// - `state` --- allocator state to return buffers and restore permits.
     ///
     /// # Panics
     ///
@@ -23,7 +25,7 @@ impl Slice {
     pub fn new(
         buffers: Vec<Box<[u8]>>,
         range: std::ops::Range<usize>,
-        sender: super::Sender<Box<[u8]>>,
+        state: Option<Arc<super::AllocatorState>>,
     ) -> Self {
         assert!(range.start <= range.end, "start should not be greater then end");
 
@@ -38,12 +40,12 @@ impl Slice {
         assert!(range.start <= len, "cannot index list as slice from start");
         assert!(range.end <= len, "cannot index list as slice to end");
 
-        Self { buffers, range, sender: Some(sender) }
+        Self { buffers, range, state }
     }
 
     // /// Returns an empty slice that owns no buffers.
     pub fn empty() -> Self {
-        Self { buffers: Vec::new(), range: 0..0, sender: None }
+        Self { buffers: Vec::new(), range: 0..0, state: None }
     }
 
     pub fn iter_mut(&mut self) -> IterMut<'_> {
@@ -56,10 +58,14 @@ impl Slice {
 
     /// Deallocates all buffers i.e. send them via specified in the [`Self::new`] `sender`.
     fn deallocate(&mut self) {
-        if let Some(sender) = &self.sender {
+        if let Some(state) = &self.state {
+            let count = self.buffers.len();
             for buffer in self.buffers.drain(..) {
                 // Ignore allocator drop
-                let _ = sender.send(buffer);
+                let _ = state.pool.push(buffer);
+            }
+            if count > 0 {
+                state.semaphore.add_permits(count);
             }
         }
     }

--- a/src/allocator/slice.rs
+++ b/src/allocator/slice.rs
@@ -1,13 +1,11 @@
 //! Defines [`Slice`] --- list of buffers bounded by custome byte range.
 
-use tokio::sync::mpsc;
-
 /// Represents bounded by custome range list of buffers.
 #[cfg_attr(test, derive(Debug))]
 pub struct Slice {
     buffers: Vec<Box<[u8]>>,
     range: std::ops::Range<usize>,
-    sender: super::Sender<Box<[u8]>>,
+    sender: Option<super::Sender<Box<[u8]>>>,
 }
 
 impl Slice {
@@ -40,13 +38,12 @@ impl Slice {
         assert!(range.start <= len, "cannot index list as slice from start");
         assert!(range.end <= len, "cannot index list as slice to end");
 
-        Self { buffers, range, sender }
+        Self { buffers, range, sender: Some(sender) }
     }
 
     // /// Returns an empty slice that owns no buffers.
     pub fn empty() -> Self {
-        let (sender, _receiver) = mpsc::unbounded_channel::<Box<[u8]>>();
-        Self { buffers: Vec::new(), range: 0..0, sender }
+        Self { buffers: Vec::new(), range: 0..0, sender: None }
     }
 
     pub fn iter_mut(&mut self) -> IterMut<'_> {
@@ -59,11 +56,11 @@ impl Slice {
 
     /// Deallocates all buffers i.e. send them via specified in the [`Self::new`] `sender`.
     fn deallocate(&mut self) {
-        for mut buffer in self.buffers.drain(..) {
-            // No user data should exist after dealloc
-            buffer.fill(0u8);
-            // Ignore allocator drop
-            let _ = self.sender.send(buffer);
+        if let Some(sender) = &self.sender {
+            for buffer in self.buffers.drain(..) {
+                // Ignore allocator drop
+                let _ = sender.send(buffer);
+            }
         }
     }
 }

--- a/src/allocator/tests/allocator/allocate.rs
+++ b/src/allocator/tests/allocator/allocate.rs
@@ -8,7 +8,7 @@ use crate::allocator::Allocator as _;
 use crate::allocator::Impl;
 
 async fn check_allocate(buffer_size: NonZeroUsize, count: NonZeroUsize, alloc_size: NonZeroUsize) {
-    let mut allocator = Impl::new(buffer_size, count);
+    let allocator = Impl::new(buffer_size, count);
     let mut slice = allocator.allocate(alloc_size).await.unwrap();
 
     let verify: Vec<u8> = (0..alloc_size.get()).map(|u| (u + 1) as u8).collect();
@@ -89,7 +89,7 @@ async fn reclaiming() {
     const COUNT: NonZeroUsize = NonZeroUsize::new(15).unwrap();
     const ALLOC_SIZE: NonZeroUsize = NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap();
 
-    let mut allocator = Impl::new(SIZE, COUNT);
+    let allocator = Impl::new(SIZE, COUNT);
 
     for _ in 0..5 {
         let slice = allocator.allocate(ALLOC_SIZE).await.unwrap();
@@ -114,7 +114,7 @@ async fn allocate_more_than_capacity_returns_none() {
     const SIZE: NonZeroUsize = NonZeroUsize::new(13).unwrap();
     const COUNT: NonZeroUsize = NonZeroUsize::new(15).unwrap();
 
-    let mut allocator = Impl::new(SIZE, COUNT);
+    let allocator = Impl::new(SIZE, COUNT);
     let requested = NonZeroUsize::new(SIZE.get() * COUNT.get() + 1).unwrap();
 
     assert!(allocator.allocate(requested).await.is_none());

--- a/src/allocator/tests/allocator/allocate.rs
+++ b/src/allocator/tests/allocator/allocate.rs
@@ -42,7 +42,6 @@ async fn check_allocate(buffer_size: NonZeroUsize, count: NonZeroUsize, alloc_si
     let allocator_capacity = NonZeroUsize::new(buffer_size.get() * count.get()).unwrap();
     let slice = allocator.allocate(allocator_capacity).await.unwrap();
     assert_eq!(slice.iter().count(), count.get());
-    assert!(slice.iter().all(|buffer| buffer.iter().all(|&u| u == 0)));
 }
 
 #[tokio::test]
@@ -95,7 +94,6 @@ async fn reclaiming() {
     for _ in 0..5 {
         let slice = allocator.allocate(ALLOC_SIZE).await.unwrap();
         assert_eq!(slice.iter().count(), COUNT.get());
-        assert!(slice.iter().all(|buffer| buffer.iter().all(|&u| u == 0)));
 
         tokio::time::timeout(Duration::from_millis(120), async {
             allocator.allocate(NonZeroUsize::new(1).unwrap()).await.unwrap();
@@ -108,7 +106,6 @@ async fn reclaiming() {
 
         let slice = allocator.allocate(ALLOC_SIZE).await.unwrap();
         assert_eq!(slice.iter().count(), COUNT.get());
-        assert!(slice.iter().all(|buffer| buffer.iter().all(|&u| u == 0)));
     }
 }
 

--- a/src/allocator/tests/slice/iter.rs
+++ b/src/allocator/tests/slice/iter.rs
@@ -1,23 +1,16 @@
 //! Defines tests for [`crate::allocator::slice::Slice::iter`] interface.
 
-use tokio::sync::mpsc;
-
-use crate::allocator::Receiver;
 use crate::allocator::Slice;
 
 const FIRST_BUFFER: &[u8] = &[1, 2, 3, 4, 5];
 const SECOND_BUFFER: &[u8] = &[6, 7, 8];
 const THIRD_BUFFER: &[u8] = &[9, 10, 11];
 
-fn make_slice<Buffers>(
-    buffers: Buffers,
-    range: std::ops::Range<usize>,
-) -> (Slice, Receiver<Box<[u8]>>)
+fn make_slice<Buffers>(buffers: Buffers, range: std::ops::Range<usize>) -> Slice
 where
     Buffers: IntoIterator<IntoIter: ExactSizeIterator<Item = &'static [u8]>>,
 {
     let buffers = buffers.into_iter();
-    let (sender, receiver) = mpsc::unbounded_channel();
 
     let mut result = Vec::with_capacity(buffers.len());
     for slice in buffers {
@@ -27,9 +20,9 @@ where
         result.push(buf.into_boxed_slice())
     }
 
-    let slice = Slice::new(result, range, sender);
+    let slice = Slice::new(result, range, None);
 
-    (slice, receiver)
+    slice
 }
 
 fn check_iter_is_empty<'a>(iter: &'a mut impl Iterator<Item = &'a [u8]>) {
@@ -61,7 +54,7 @@ where
 
 #[test]
 fn zero_zero_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], 0..0);
+    let mut slice = make_slice([FIRST_BUFFER], 0..0);
 
     check_slice_is_empty(&mut slice);
     check_slice_is_empty(&mut slice);
@@ -69,7 +62,7 @@ fn zero_zero_one_buffer() {
 
 #[test]
 fn one_one_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], 1..1);
+    let mut slice = make_slice([FIRST_BUFFER], 1..1);
 
     check_slice_is_empty(&mut slice);
     check_slice_is_empty(&mut slice);
@@ -77,7 +70,7 @@ fn one_one_one_buffer() {
 
 #[test]
 fn end_end_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], FIRST_BUFFER.len()..FIRST_BUFFER.len());
+    let mut slice = make_slice([FIRST_BUFFER], FIRST_BUFFER.len()..FIRST_BUFFER.len());
 
     check_slice_is_empty(&mut slice);
     check_slice_is_empty(&mut slice);
@@ -85,7 +78,7 @@ fn end_end_one_buffer() {
 
 #[test]
 fn zero_one_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], 0..1);
+    let mut slice = make_slice([FIRST_BUFFER], 0..1);
 
     check_slice_content(&mut slice, [&[1]]);
     check_slice_content(&mut slice, [&[1]]);
@@ -93,7 +86,7 @@ fn zero_one_one_buffer() {
 
 #[test]
 fn one_two_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], 1..2);
+    let mut slice = make_slice([FIRST_BUFFER], 1..2);
 
     check_slice_content(&mut slice, [&[2]]);
     check_slice_content(&mut slice, [&[2]]);
@@ -101,7 +94,7 @@ fn one_two_one_buffer() {
 
 #[test]
 fn last_byte_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], FIRST_BUFFER.len() - 1..FIRST_BUFFER.len());
+    let mut slice = make_slice([FIRST_BUFFER], FIRST_BUFFER.len() - 1..FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [&[5]]);
     check_slice_content(&mut slice, [&[5]]);
@@ -109,7 +102,7 @@ fn last_byte_one_buffer() {
 
 #[test]
 fn zero_half_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], 0..FIRST_BUFFER.len() / 2);
+    let mut slice = make_slice([FIRST_BUFFER], 0..FIRST_BUFFER.len() / 2);
 
     check_slice_content(&mut slice, [&[1, 2]]);
     check_slice_content(&mut slice, [&[1, 2]]);
@@ -117,7 +110,7 @@ fn zero_half_one_buffer() {
 
 #[test]
 fn half_end_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], FIRST_BUFFER.len() / 2..FIRST_BUFFER.len());
+    let mut slice = make_slice([FIRST_BUFFER], FIRST_BUFFER.len() / 2..FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [&[3, 4, 5]]);
     check_slice_content(&mut slice, [&[3, 4, 5]]);
@@ -125,7 +118,7 @@ fn half_end_one_buffer() {
 
 #[test]
 fn zero_end_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], 0..FIRST_BUFFER.len());
+    let mut slice = make_slice([FIRST_BUFFER], 0..FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [&[1, 2, 3, 4, 5]]);
     check_slice_content(&mut slice, [&[1, 2, 3, 4, 5]]);
@@ -135,7 +128,7 @@ fn zero_end_one_buffer() {
 
 #[test]
 fn first_zero_zero_two_buffers() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..0);
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..0);
 
     check_slice_is_empty(&mut slice);
     check_slice_is_empty(&mut slice);
@@ -143,7 +136,7 @@ fn first_zero_zero_two_buffers() {
 
 #[test]
 fn first_one_one_two_buffers() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 1..1);
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 1..1);
 
     check_slice_is_empty(&mut slice);
     check_slice_is_empty(&mut slice);
@@ -151,7 +144,7 @@ fn first_one_one_two_buffers() {
 
 #[test]
 fn first_end_end_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len()..FIRST_BUFFER.len());
 
     check_slice_is_empty(&mut slice);
@@ -160,7 +153,7 @@ fn first_end_end_two_buffers() {
 
 #[test]
 fn first_zero_one_two_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..1);
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..1);
 
     check_slice_content(&mut slice, [&[1]]);
     check_slice_content(&mut slice, [&[1]]);
@@ -168,7 +161,7 @@ fn first_zero_one_two_buffer() {
 
 #[test]
 fn first_one_two_two_buffers() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 1..2);
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 1..2);
 
     check_slice_content(&mut slice, [&[2]]);
     check_slice_content(&mut slice, [&[2]]);
@@ -176,7 +169,7 @@ fn first_one_two_two_buffers() {
 
 #[test]
 fn first_last_byte_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len() - 1..FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [&[5]]);
@@ -185,7 +178,7 @@ fn first_last_byte_two_buffers() {
 
 #[test]
 fn first_zero_half_two_buffers() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..FIRST_BUFFER.len() / 2);
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..FIRST_BUFFER.len() / 2);
 
     check_slice_content(&mut slice, [&[1, 2]]);
     check_slice_content(&mut slice, [&[1, 2]]);
@@ -193,7 +186,7 @@ fn first_zero_half_two_buffers() {
 
 #[test]
 fn first_half_end_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len() / 2..FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [&[3, 4, 5]]);
@@ -202,7 +195,7 @@ fn first_half_end_two_buffers() {
 
 #[test]
 fn first_zero_end_two_buffers() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..FIRST_BUFFER.len());
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [&[1, 2, 3, 4, 5]]);
     check_slice_content(&mut slice, [&[1, 2, 3, 4, 5]]);
@@ -212,7 +205,7 @@ fn first_zero_end_two_buffers() {
 
 #[test]
 fn second_zero_zero_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len()..FIRST_BUFFER.len());
 
     check_slice_is_empty(&mut slice);
@@ -221,7 +214,7 @@ fn second_zero_zero_two_buffers() {
 
 #[test]
 fn second_one_one_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], 1 + FIRST_BUFFER.len()..1 + FIRST_BUFFER.len());
 
     check_slice_is_empty(&mut slice);
@@ -230,7 +223,7 @@ fn second_one_one_two_buffers() {
 
 #[test]
 fn second_end_end_two_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER],
         FIRST_BUFFER.len() + SECOND_BUFFER.len()..FIRST_BUFFER.len() + SECOND_BUFFER.len(),
     );
@@ -241,7 +234,7 @@ fn second_end_end_two_buffers() {
 
 #[test]
 fn second_zero_one_two_buffer() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len()..FIRST_BUFFER.len() + 1);
 
     check_slice_content(&mut slice, [&[6]]);
@@ -251,7 +244,7 @@ fn second_zero_one_two_buffer() {
 #[test]
 
 fn second_one_two_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len() + 1..FIRST_BUFFER.len() + 2);
 
     check_slice_content(&mut slice, [&[7]]);
@@ -260,7 +253,7 @@ fn second_one_two_two_buffers() {
 
 #[test]
 fn second_last_byte_two_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER],
         FIRST_BUFFER.len() + SECOND_BUFFER.len() - 1..FIRST_BUFFER.len() + SECOND_BUFFER.len(),
     );
@@ -271,7 +264,7 @@ fn second_last_byte_two_buffers() {
 
 #[test]
 fn second_zero_half_two_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER],
         FIRST_BUFFER.len()..FIRST_BUFFER.len() + SECOND_BUFFER.len() / 2,
     );
@@ -282,7 +275,7 @@ fn second_zero_half_two_buffers() {
 
 #[test]
 fn second_half_end_two_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER],
         FIRST_BUFFER.len() + SECOND_BUFFER.len() / 2..FIRST_BUFFER.len() + SECOND_BUFFER.len(),
     );
@@ -293,7 +286,7 @@ fn second_half_end_two_buffers() {
 
 #[test]
 fn second_zero_end_two_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER],
         FIRST_BUFFER.len()..FIRST_BUFFER.len() + SECOND_BUFFER.len(),
     );
@@ -306,7 +299,7 @@ fn second_zero_end_two_buffers() {
 
 #[test]
 fn last_from_first_first_from_second_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len() - 1..FIRST_BUFFER.len() + 1);
 
     check_slice_content(&mut slice, [&[5], &[6]]);
@@ -315,7 +308,7 @@ fn last_from_first_first_from_second_two_buffers() {
 
 #[test]
 fn all_from_first_first_from_second_two_buffers() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..1 + FIRST_BUFFER.len());
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..1 + FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [[1, 2, 3, 4, 5].as_slice(), [6].as_slice()]);
     check_slice_content(&mut slice, [[1, 2, 3, 4, 5].as_slice(), [6].as_slice()]);
@@ -323,7 +316,7 @@ fn all_from_first_first_from_second_two_buffers() {
 
 #[test]
 fn last_from_first_all_from_second_two_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER],
         FIRST_BUFFER.len() - 1..FIRST_BUFFER.len() + SECOND_BUFFER.len(),
     );
@@ -334,7 +327,7 @@ fn last_from_first_all_from_second_two_buffers() {
 
 #[test]
 fn all_from_first_all_from_second_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..FIRST_BUFFER.len() + SECOND_BUFFER.len());
 
     check_slice_content(&mut slice, [[1, 2, 3, 4, 5].as_slice(), [6, 7, 8].as_slice()]);
@@ -345,7 +338,7 @@ fn all_from_first_all_from_second_two_buffers() {
 
 #[test]
 fn last_from_first_first_from_second_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len() - 1..FIRST_BUFFER.len() + 1,
     );
@@ -356,7 +349,7 @@ fn last_from_first_first_from_second_three_buffers() {
 
 #[test]
 fn all_from_first_first_from_second_three_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER], 0..1 + FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [[1, 2, 3, 4, 5].as_slice(), [6].as_slice()]);
@@ -365,7 +358,7 @@ fn all_from_first_first_from_second_three_buffers() {
 
 #[test]
 fn last_from_first_all_from_second_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len() - 1..FIRST_BUFFER.len() + SECOND_BUFFER.len(),
     );
@@ -376,7 +369,7 @@ fn last_from_first_all_from_second_three_buffers() {
 
 #[test]
 fn all_from_first_all_from_second_three_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..FIRST_BUFFER.len() + SECOND_BUFFER.len());
 
     check_slice_content(&mut slice, [[1, 2, 3, 4, 5].as_slice(), [6, 7, 8].as_slice()]);
@@ -387,7 +380,7 @@ fn all_from_first_all_from_second_three_buffers() {
 
 #[test]
 fn last_from_second_first_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len() + SECOND_BUFFER.len() - 1..FIRST_BUFFER.len() + SECOND_BUFFER.len() + 1,
     );
@@ -398,7 +391,7 @@ fn last_from_second_first_from_third_three_buffers() {
 
 #[test]
 fn all_from_second_first_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len()..FIRST_BUFFER.len() + SECOND_BUFFER.len() + 1,
     );
@@ -409,7 +402,7 @@ fn all_from_second_first_from_third_three_buffers() {
 
 #[test]
 fn last_from_second_all_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len() + SECOND_BUFFER.len() - 1
             ..FIRST_BUFFER.len() + SECOND_BUFFER.len() + THIRD_BUFFER.len(),
@@ -421,7 +414,7 @@ fn last_from_second_all_from_third_three_buffers() {
 
 #[test]
 fn all_from_second_all_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len()..FIRST_BUFFER.len() + SECOND_BUFFER.len() + THIRD_BUFFER.len(),
     );
@@ -434,7 +427,7 @@ fn all_from_second_all_from_third_three_buffers() {
 
 #[test]
 fn last_from_first_all_from_second_first_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len() - 1..FIRST_BUFFER.len() + SECOND_BUFFER.len() + 1,
     );
@@ -445,7 +438,7 @@ fn last_from_first_all_from_second_first_from_third_three_buffers() {
 
 #[test]
 fn all_from_first_all_from_second_first_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         0..FIRST_BUFFER.len() + SECOND_BUFFER.len() + 1,
     );
@@ -462,7 +455,7 @@ fn all_from_first_all_from_second_first_from_third_three_buffers() {
 
 #[test]
 fn last_from_first_all_from_second_all_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len() - 1..FIRST_BUFFER.len() + SECOND_BUFFER.len() + THIRD_BUFFER.len(),
     );
@@ -473,7 +466,7 @@ fn last_from_first_all_from_second_all_from_third_three_buffers() {
 
 #[test]
 fn all_from_first_all_from_second_all_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         0..FIRST_BUFFER.len() + SECOND_BUFFER.len() + THIRD_BUFFER.len(),
     );

--- a/src/allocator/tests/slice/iter_mut.rs
+++ b/src/allocator/tests/slice/iter_mut.rs
@@ -1,23 +1,16 @@
 //! Defines tests for [`crate::allocator::slice::Slice::iter_mut`] interface.
 
-use tokio::sync::mpsc;
-
-use crate::allocator::Receiver;
 use crate::allocator::Slice;
 
 const FIRST_BUFFER: &[u8] = &[1, 2, 3, 4, 5];
 const SECOND_BUFFER: &[u8] = &[6, 7, 8];
 const THIRD_BUFFER: &[u8] = &[9, 10, 11];
 
-fn make_slice<Buffers>(
-    buffers: Buffers,
-    range: std::ops::Range<usize>,
-) -> (Slice, Receiver<Box<[u8]>>)
+fn make_slice<Buffers>(buffers: Buffers, range: std::ops::Range<usize>) -> Slice
 where
     Buffers: IntoIterator<IntoIter: ExactSizeIterator<Item = &'static [u8]>>,
 {
     let buffers = buffers.into_iter();
-    let (sender, receiver) = mpsc::unbounded_channel();
 
     let mut result = Vec::with_capacity(buffers.len());
     for slice in buffers {
@@ -27,9 +20,9 @@ where
         result.push(buf.into_boxed_slice())
     }
 
-    let slice = Slice::new(result, range, sender);
+    let slice = Slice::new(result, range, None);
 
-    (slice, receiver)
+    slice
 }
 
 fn check_iter_is_empty<'a>(iter: &'a mut impl Iterator<Item = &'a mut [u8]>) {
@@ -61,7 +54,7 @@ where
 
 #[test]
 fn zero_zero_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], 0..0);
+    let mut slice = make_slice([FIRST_BUFFER], 0..0);
 
     check_slice_is_empty(&mut slice);
     check_slice_is_empty(&mut slice);
@@ -69,7 +62,7 @@ fn zero_zero_one_buffer() {
 
 #[test]
 fn one_one_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], 1..1);
+    let mut slice = make_slice([FIRST_BUFFER], 1..1);
 
     check_slice_is_empty(&mut slice);
     check_slice_is_empty(&mut slice);
@@ -77,7 +70,7 @@ fn one_one_one_buffer() {
 
 #[test]
 fn end_end_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], FIRST_BUFFER.len()..FIRST_BUFFER.len());
+    let mut slice = make_slice([FIRST_BUFFER], FIRST_BUFFER.len()..FIRST_BUFFER.len());
 
     check_slice_is_empty(&mut slice);
     check_slice_is_empty(&mut slice);
@@ -85,7 +78,7 @@ fn end_end_one_buffer() {
 
 #[test]
 fn zero_one_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], 0..1);
+    let mut slice = make_slice([FIRST_BUFFER], 0..1);
 
     check_slice_content(&mut slice, [&[1]]);
     check_slice_content(&mut slice, [&[1]]);
@@ -93,7 +86,7 @@ fn zero_one_one_buffer() {
 
 #[test]
 fn one_two_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], 1..2);
+    let mut slice = make_slice([FIRST_BUFFER], 1..2);
 
     check_slice_content(&mut slice, [&[2]]);
     check_slice_content(&mut slice, [&[2]]);
@@ -101,7 +94,7 @@ fn one_two_one_buffer() {
 
 #[test]
 fn last_byte_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], FIRST_BUFFER.len() - 1..FIRST_BUFFER.len());
+    let mut slice = make_slice([FIRST_BUFFER], FIRST_BUFFER.len() - 1..FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [&[5]]);
     check_slice_content(&mut slice, [&[5]]);
@@ -109,7 +102,7 @@ fn last_byte_one_buffer() {
 
 #[test]
 fn zero_half_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], 0..FIRST_BUFFER.len() / 2);
+    let mut slice = make_slice([FIRST_BUFFER], 0..FIRST_BUFFER.len() / 2);
 
     check_slice_content(&mut slice, [&[1, 2]]);
     check_slice_content(&mut slice, [&[1, 2]]);
@@ -117,7 +110,7 @@ fn zero_half_one_buffer() {
 
 #[test]
 fn half_end_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], FIRST_BUFFER.len() / 2..FIRST_BUFFER.len());
+    let mut slice = make_slice([FIRST_BUFFER], FIRST_BUFFER.len() / 2..FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [&[3, 4, 5]]);
     check_slice_content(&mut slice, [&[3, 4, 5]]);
@@ -125,7 +118,7 @@ fn half_end_one_buffer() {
 
 #[test]
 fn zero_end_one_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER], 0..FIRST_BUFFER.len());
+    let mut slice = make_slice([FIRST_BUFFER], 0..FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [&[1, 2, 3, 4, 5]]);
     check_slice_content(&mut slice, [&[1, 2, 3, 4, 5]]);
@@ -135,7 +128,7 @@ fn zero_end_one_buffer() {
 
 #[test]
 fn first_zero_zero_two_buffers() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..0);
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..0);
 
     check_slice_is_empty(&mut slice);
     check_slice_is_empty(&mut slice);
@@ -143,7 +136,7 @@ fn first_zero_zero_two_buffers() {
 
 #[test]
 fn first_one_one_two_buffers() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 1..1);
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 1..1);
 
     check_slice_is_empty(&mut slice);
     check_slice_is_empty(&mut slice);
@@ -151,7 +144,7 @@ fn first_one_one_two_buffers() {
 
 #[test]
 fn first_end_end_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len()..FIRST_BUFFER.len());
 
     check_slice_is_empty(&mut slice);
@@ -160,7 +153,7 @@ fn first_end_end_two_buffers() {
 
 #[test]
 fn first_zero_one_two_buffer() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..1);
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..1);
 
     check_slice_content(&mut slice, [&[1]]);
     check_slice_content(&mut slice, [&[1]]);
@@ -168,7 +161,7 @@ fn first_zero_one_two_buffer() {
 
 #[test]
 fn first_one_two_two_buffers() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 1..2);
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 1..2);
 
     check_slice_content(&mut slice, [&[2]]);
     check_slice_content(&mut slice, [&[2]]);
@@ -176,7 +169,7 @@ fn first_one_two_two_buffers() {
 
 #[test]
 fn first_last_byte_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len() - 1..FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [&[5]]);
@@ -185,7 +178,7 @@ fn first_last_byte_two_buffers() {
 
 #[test]
 fn first_zero_half_two_buffers() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..FIRST_BUFFER.len() / 2);
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..FIRST_BUFFER.len() / 2);
 
     check_slice_content(&mut slice, [&[1, 2]]);
     check_slice_content(&mut slice, [&[1, 2]]);
@@ -193,7 +186,7 @@ fn first_zero_half_two_buffers() {
 
 #[test]
 fn first_half_end_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len() / 2..FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [&[3, 4, 5]]);
@@ -202,7 +195,7 @@ fn first_half_end_two_buffers() {
 
 #[test]
 fn first_zero_end_two_buffers() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..FIRST_BUFFER.len());
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [&[1, 2, 3, 4, 5]]);
     check_slice_content(&mut slice, [&[1, 2, 3, 4, 5]]);
@@ -212,7 +205,7 @@ fn first_zero_end_two_buffers() {
 
 #[test]
 fn second_zero_zero_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len()..FIRST_BUFFER.len());
 
     check_slice_is_empty(&mut slice);
@@ -221,7 +214,7 @@ fn second_zero_zero_two_buffers() {
 
 #[test]
 fn second_one_one_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], 1 + FIRST_BUFFER.len()..1 + FIRST_BUFFER.len());
 
     check_slice_is_empty(&mut slice);
@@ -230,7 +223,7 @@ fn second_one_one_two_buffers() {
 
 #[test]
 fn second_end_end_two_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER],
         FIRST_BUFFER.len() + SECOND_BUFFER.len()..FIRST_BUFFER.len() + SECOND_BUFFER.len(),
     );
@@ -241,7 +234,7 @@ fn second_end_end_two_buffers() {
 
 #[test]
 fn second_zero_one_two_buffer() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len()..FIRST_BUFFER.len() + 1);
 
     check_slice_content(&mut slice, [&[6]]);
@@ -251,7 +244,7 @@ fn second_zero_one_two_buffer() {
 #[test]
 
 fn second_one_two_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len() + 1..FIRST_BUFFER.len() + 2);
 
     check_slice_content(&mut slice, [&[7]]);
@@ -260,7 +253,7 @@ fn second_one_two_two_buffers() {
 
 #[test]
 fn second_last_byte_two_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER],
         FIRST_BUFFER.len() + SECOND_BUFFER.len() - 1..FIRST_BUFFER.len() + SECOND_BUFFER.len(),
     );
@@ -271,7 +264,7 @@ fn second_last_byte_two_buffers() {
 
 #[test]
 fn second_zero_half_two_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER],
         FIRST_BUFFER.len()..FIRST_BUFFER.len() + SECOND_BUFFER.len() / 2,
     );
@@ -282,7 +275,7 @@ fn second_zero_half_two_buffers() {
 
 #[test]
 fn second_half_end_two_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER],
         FIRST_BUFFER.len() + SECOND_BUFFER.len() / 2..FIRST_BUFFER.len() + SECOND_BUFFER.len(),
     );
@@ -293,7 +286,7 @@ fn second_half_end_two_buffers() {
 
 #[test]
 fn second_zero_end_two_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER],
         FIRST_BUFFER.len()..FIRST_BUFFER.len() + SECOND_BUFFER.len(),
     );
@@ -306,7 +299,7 @@ fn second_zero_end_two_buffers() {
 
 #[test]
 fn last_from_first_first_from_second_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], FIRST_BUFFER.len() - 1..FIRST_BUFFER.len() + 1);
 
     check_slice_content(&mut slice, [&[5], &[6]]);
@@ -315,7 +308,7 @@ fn last_from_first_first_from_second_two_buffers() {
 
 #[test]
 fn all_from_first_first_from_second_two_buffers() {
-    let (mut slice, _) = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..1 + FIRST_BUFFER.len());
+    let mut slice = make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..1 + FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [[1, 2, 3, 4, 5].as_slice(), [6].as_slice()]);
     check_slice_content(&mut slice, [[1, 2, 3, 4, 5].as_slice(), [6].as_slice()]);
@@ -323,7 +316,7 @@ fn all_from_first_first_from_second_two_buffers() {
 
 #[test]
 fn last_from_first_all_from_second_two_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER],
         FIRST_BUFFER.len() - 1..FIRST_BUFFER.len() + SECOND_BUFFER.len(),
     );
@@ -334,7 +327,7 @@ fn last_from_first_all_from_second_two_buffers() {
 
 #[test]
 fn all_from_first_all_from_second_two_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..FIRST_BUFFER.len() + SECOND_BUFFER.len());
 
     check_slice_content(&mut slice, [[1, 2, 3, 4, 5].as_slice(), [6, 7, 8].as_slice()]);
@@ -345,7 +338,7 @@ fn all_from_first_all_from_second_two_buffers() {
 
 #[test]
 fn last_from_first_first_from_second_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len() - 1..FIRST_BUFFER.len() + 1,
     );
@@ -356,7 +349,7 @@ fn last_from_first_first_from_second_three_buffers() {
 
 #[test]
 fn all_from_first_first_from_second_three_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER], 0..1 + FIRST_BUFFER.len());
 
     check_slice_content(&mut slice, [[1, 2, 3, 4, 5].as_slice(), [6].as_slice()]);
@@ -365,7 +358,7 @@ fn all_from_first_first_from_second_three_buffers() {
 
 #[test]
 fn last_from_first_all_from_second_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len() - 1..FIRST_BUFFER.len() + SECOND_BUFFER.len(),
     );
@@ -376,7 +369,7 @@ fn last_from_first_all_from_second_three_buffers() {
 
 #[test]
 fn all_from_first_all_from_second_three_buffers() {
-    let (mut slice, _) =
+    let mut slice =
         make_slice([FIRST_BUFFER, SECOND_BUFFER], 0..FIRST_BUFFER.len() + SECOND_BUFFER.len());
 
     check_slice_content(&mut slice, [[1, 2, 3, 4, 5].as_slice(), [6, 7, 8].as_slice()]);
@@ -387,7 +380,7 @@ fn all_from_first_all_from_second_three_buffers() {
 
 #[test]
 fn last_from_second_first_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len() + SECOND_BUFFER.len() - 1..FIRST_BUFFER.len() + SECOND_BUFFER.len() + 1,
     );
@@ -398,7 +391,7 @@ fn last_from_second_first_from_third_three_buffers() {
 
 #[test]
 fn all_from_second_first_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len()..FIRST_BUFFER.len() + SECOND_BUFFER.len() + 1,
     );
@@ -409,7 +402,7 @@ fn all_from_second_first_from_third_three_buffers() {
 
 #[test]
 fn last_from_second_all_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len() + SECOND_BUFFER.len() - 1
             ..FIRST_BUFFER.len() + SECOND_BUFFER.len() + THIRD_BUFFER.len(),
@@ -421,7 +414,7 @@ fn last_from_second_all_from_third_three_buffers() {
 
 #[test]
 fn all_from_second_all_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len()..FIRST_BUFFER.len() + SECOND_BUFFER.len() + THIRD_BUFFER.len(),
     );
@@ -434,7 +427,7 @@ fn all_from_second_all_from_third_three_buffers() {
 
 #[test]
 fn last_from_first_all_from_second_first_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len() - 1..FIRST_BUFFER.len() + SECOND_BUFFER.len() + 1,
     );
@@ -445,7 +438,7 @@ fn last_from_first_all_from_second_first_from_third_three_buffers() {
 
 #[test]
 fn all_from_first_all_from_second_first_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         0..FIRST_BUFFER.len() + SECOND_BUFFER.len() + 1,
     );
@@ -462,7 +455,7 @@ fn all_from_first_all_from_second_first_from_third_three_buffers() {
 
 #[test]
 fn last_from_first_all_from_second_all_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         FIRST_BUFFER.len() - 1..FIRST_BUFFER.len() + SECOND_BUFFER.len() + THIRD_BUFFER.len(),
     );
@@ -473,7 +466,7 @@ fn last_from_first_all_from_second_all_from_third_three_buffers() {
 
 #[test]
 fn all_from_first_all_from_second_all_from_third_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         0..FIRST_BUFFER.len() + SECOND_BUFFER.len() + THIRD_BUFFER.len(),
     );
@@ -492,7 +485,7 @@ fn all_from_first_all_from_second_all_from_third_three_buffers() {
 
 #[test]
 fn write_all_three_buffers() {
-    let (mut slice, _) = make_slice(
+    let mut slice = make_slice(
         [FIRST_BUFFER, SECOND_BUFFER, THIRD_BUFFER],
         0..FIRST_BUFFER.len() + SECOND_BUFFER.len() + THIRD_BUFFER.len(),
     );

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,16 +5,22 @@ use std::sync::Arc;
 
 use crate::{allocator::Impl, vfs};
 
-pub struct ServerContext {
+pub struct ServerContext<V>
+where
+    V: vfs::Vfs + Send + Sync + 'static,
+{
     read_allocator: Arc<Impl>,
     write_allocator: Arc<Impl>,
-    backend: Arc<dyn vfs::Vfs + Send + Sync + 'static>,
+    backend: Arc<V>,
 }
 
-impl ServerContext {
+impl<V> ServerContext<V>
+where
+    V: vfs::Vfs + Send + Sync + 'static,
+{
     /// Builds context from allocator limits without exposing allocator implementation.
     pub fn new(
-        backend: Arc<dyn vfs::Vfs + Send + Sync + 'static>,
+        backend: Arc<V>,
         read_buffer_size: NonZeroUsize,
         read_buffer_count: NonZeroUsize,
         write_buffer_size: NonZeroUsize,
@@ -26,7 +32,7 @@ impl ServerContext {
         Self { read_allocator, write_allocator, backend }
     }
 
-    pub fn get_backend(&self) -> Arc<dyn vfs::Vfs + Send + Sync + 'static> {
+    pub fn get_backend(&self) -> Arc<V> {
         Arc::clone(&self.backend)
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,13 +3,11 @@
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
-use tokio::sync::Mutex;
-
 use crate::{allocator::Impl, vfs};
 
 pub struct ServerContext {
-    read_allocator: Arc<Mutex<Impl>>,
-    write_allocator: Arc<Mutex<Impl>>,
+    read_allocator: Arc<Impl>,
+    write_allocator: Arc<Impl>,
     backend: Arc<dyn vfs::Vfs + Send + Sync + 'static>,
 }
 
@@ -22,9 +20,8 @@ impl ServerContext {
         write_buffer_size: NonZeroUsize,
         write_buffer_count: NonZeroUsize,
     ) -> Self {
-        let read_allocator = Arc::new(Mutex::new(Impl::new(read_buffer_size, read_buffer_count)));
-        let write_allocator =
-            Arc::new(Mutex::new(Impl::new(write_buffer_size, write_buffer_count)));
+        let read_allocator = Arc::new(Impl::new(read_buffer_size, read_buffer_count));
+        let write_allocator = Arc::new(Impl::new(write_buffer_size, write_buffer_count));
 
         Self { read_allocator, write_allocator, backend }
     }
@@ -33,11 +30,11 @@ impl ServerContext {
         Arc::clone(&self.backend)
     }
 
-    pub fn get_read_allocator(&self) -> Arc<Mutex<Impl>> {
+    pub fn get_read_allocator(&self) -> Arc<Impl> {
         Arc::clone(&self.read_allocator)
     }
 
-    pub fn get_write_allocator(&self) -> Arc<Mutex<Impl>> {
+    pub fn get_write_allocator(&self) -> Arc<Impl> {
         Arc::clone(&self.write_allocator)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,8 +93,9 @@ where
     loop {
         let (socket, _) = listener.accept().await?;
 
-        socket.set_nodelay(true)?;
-        tune_socket_buffers(&socket)?;
+        // !!! SLOWS US
+        // socket.set_nodelay(true)?;
+        // tune_socket_buffers(&socket)?;
 
         connection::new(socket, mount_sender.clone(), &context).await;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,40 @@ where
         let (socket, _) = listener.accept().await?;
 
         socket.set_nodelay(true)?;
+        tune_socket_buffers(&socket)?;
 
         connection::new(socket, mount_sender.clone(), &context).await;
     }
+}
+
+#[cfg(target_os = "linux")]
+fn tune_socket_buffers(socket: &tokio::net::TcpStream) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    const SOCKET_BUFFER_SIZE: libc::c_int = 4 * 1024 * 1024;
+
+    let fd = socket.as_raw_fd();
+    let value_ptr = &SOCKET_BUFFER_SIZE as *const libc::c_int as *const libc::c_void;
+    let value_len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+
+    let snd_result = unsafe {
+        libc::setsockopt(fd, libc::SOL_SOCKET, libc::SO_SNDBUF, value_ptr, value_len)
+    };
+    if snd_result != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    let rcv_result = unsafe {
+        libc::setsockopt(fd, libc::SOL_SOCKET, libc::SO_RCVBUF, value_ptr, value_len)
+    };
+    if rcv_result != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn tune_socket_buffers(_socket: &tokio::net::TcpStream) -> std::io::Result<()> {
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,16 +54,25 @@ pub fn init_tracing() {
 }
 
 /// Starts the NFS server and processes client connections.
-pub async fn handle_forever(listener: TcpListener, context: ServerContext) -> std::io::Result<()> {
+pub async fn handle_forever<V>(
+    listener: TcpListener,
+    context: ServerContext<V>,
+) -> std::io::Result<()>
+where
+    V: vfs::Vfs + Send + Sync + 'static,
+{
     handle_forever_with_exports(listener, context, Vec::new()).await
 }
 
 /// Starts the NFS server and processes client connections with explicit MOUNT exports.
-pub async fn handle_forever_with_exports(
+pub async fn handle_forever_with_exports<V>(
     listener: TcpListener,
-    context: ServerContext,
+    context: ServerContext<V>,
     exports: Vec<MountExport>,
-) -> std::io::Result<()> {
+) -> std::io::Result<()>
+where
+    V: vfs::Vfs + Send + Sync + 'static,
+{
     let export_paths = exports
         .iter()
         .map(|entry| entry.export.directory.as_path().to_string_lossy().into_owned())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,40 +95,7 @@ where
 
         // !!! SLOWS US
         // socket.set_nodelay(true)?;
-        // tune_socket_buffers(&socket)?;
 
         connection::new(socket, mount_sender.clone(), &context).await;
     }
-}
-
-#[cfg(target_os = "linux")]
-fn tune_socket_buffers(socket: &tokio::net::TcpStream) -> std::io::Result<()> {
-    use std::os::fd::AsRawFd;
-
-    const SOCKET_BUFFER_SIZE: libc::c_int = 4 * 1024 * 1024;
-
-    let fd = socket.as_raw_fd();
-    let value_ptr = &SOCKET_BUFFER_SIZE as *const libc::c_int as *const libc::c_void;
-    let value_len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
-
-    let snd_result = unsafe {
-        libc::setsockopt(fd, libc::SOL_SOCKET, libc::SO_SNDBUF, value_ptr, value_len)
-    };
-    if snd_result != 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-
-    let rcv_result = unsafe {
-        libc::setsockopt(fd, libc::SOL_SOCKET, libc::SO_RCVBUF, value_ptr, value_len)
-    };
-    if rcv_result != 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-
-    Ok(())
-}
-
-#[cfg(not(target_os = "linux"))]
-fn tune_socket_buffers(_socket: &tokio::net::TcpStream) -> std::io::Result<()> {
-    Ok(())
 }

--- a/src/parser/parser_struct.rs
+++ b/src/parser/parser_struct.rs
@@ -18,7 +18,6 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use tokio::io::AsyncRead;
-use tokio::sync::Mutex;
 use tracing::{debug, error, warn};
 
 use crate::allocator::{Allocator, Slice};
@@ -81,7 +80,7 @@ pub const DEFAULT_SIZE: usize = 2500;
 /// # }
 /// ```
 pub struct RpcParser<A: Allocator, S: AsyncRead + Unpin> {
-    allocator: Arc<Mutex<A>>,
+    allocator: Arc<A>,
     buffer: CountBuffer<S>,
     last: bool,
     current_frame_size: usize,
@@ -99,7 +98,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     /// # Returns
     ///
     /// A new `RpcParser` instance ready to parse messages.
-    pub fn new(socket: S, allocator: Arc<Mutex<A>>) -> Self {
+    pub fn new(socket: S, allocator: Arc<A>) -> Self {
         Self {
             allocator,
             buffer: CountBuffer::new(DEFAULT_SIZE, socket),
@@ -119,7 +118,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     /// # Returns
     ///
     /// A new `RpcParser` instance ready to parse messages.
-    pub fn with_capacity(socket: S, allocator: Arc<Mutex<A>>, size: usize) -> Self {
+    pub fn with_capacity(socket: S, allocator: Arc<A>, size: usize) -> Self {
         Self {
             allocator,
             buffer: CountBuffer::new(size, socket),
@@ -266,9 +265,9 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
                 NfsArguments::ReadLink(self.buffer.parse_with_retry(read_link::args).await?)
             }
             READ => NfsArguments::Read(self.buffer.parse_with_retry(read::args).await?),
-            WRITE => {
-                NfsArguments::Write(adapter_for_write(&self.allocator, &mut self.buffer).await?)
-            }
+            WRITE => NfsArguments::Write(
+                adapter_for_write(self.allocator.as_ref(), &mut self.buffer).await?,
+            ),
             CREATE => NfsArguments::Create(self.buffer.parse_with_retry(create::args).await?),
             MKDIR => NfsArguments::MkDir(self.buffer.parse_with_retry(mk_dir::args).await?),
             SYMLINK => NfsArguments::SymLink(self.buffer.parse_with_retry(symlink::args).await?),
@@ -566,7 +565,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
 /// - Memory allocation fails
 /// - Reading the data fails
 async fn adapter_for_write<S: AsyncRead + Unpin>(
-    alloc: &Arc<Mutex<impl Allocator>>,
+    alloc: &impl Allocator,
     buffer: &mut CountBuffer<S>,
 ) -> Result<vfs::write::Args> {
     // Parse arguments for WRITE procedure.
@@ -575,7 +574,7 @@ async fn adapter_for_write<S: AsyncRead + Unpin>(
 
     // Attempt allocation with the given size, or fallback to NonZeroUsize::MIN.
     let non_zero_size = NonZeroUsize::new(size).unwrap_or(NonZeroUsize::MIN);
-    let mut slice = alloc.lock().await.allocate(non_zero_size).await.ok_or_else(|| {
+    let mut slice = alloc.allocate(non_zero_size).await.ok_or_else(|| {
         Error::IO(io::Error::new(ErrorKind::OutOfMemory, "cannot allocate memory"))
     })?;
 

--- a/src/parser/tests/allocator.rs
+++ b/src/parser/tests/allocator.rs
@@ -15,10 +15,10 @@ impl MockAllocator {
 }
 
 impl Allocator for MockAllocator {
-    async fn allocate(&mut self, size: NonZeroUsize) -> Option<Slice> {
+    async fn allocate(&self, size: NonZeroUsize) -> Option<Slice> {
         if size.get() <= self.max_size {
-            let (sender, _) = mpsc::unbounded_channel::<Box<[u8]>>();
-            Some(Slice::new(vec![vec![0; size.get()].into_boxed_slice()], 0..size.get(), sender))
+            let (_, _) = mpsc::unbounded_channel::<Box<[u8]>>();
+            Some(Slice::new(vec![vec![0; size.get()].into_boxed_slice()], 0..size.get(), None))
         } else {
             None
         }

--- a/src/parser/tests/parser_struct.rs
+++ b/src/parser/tests/parser_struct.rs
@@ -1,6 +1,5 @@
 use num_traits::ToPrimitive;
 use std::sync::Arc;
-use tokio::sync::Mutex;
 
 use crate::consts::mount::{MOUNT_PROGRAM, MOUNT_VERSION};
 use crate::consts::nfsv3::{FSSTAT, NFS_PROGRAM, NFS_VERSION, WRITE};
@@ -226,7 +225,7 @@ async fn parse_mount_call() {
         push_opaque(buf, b"/mnt/vol");
     });
     let socket = MockSocket::new(frame.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
+    let alloc = Arc::new(MockAllocator::new(0));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x40);
 
     let result: ArgWrapper = parser.next_message().await.unwrap();
@@ -253,7 +252,7 @@ async fn parse_mount_after_error() {
     buf.extend_from_slice(&second);
 
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
+    let alloc = Arc::new(MockAllocator::new(0));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x60);
 
     let first_result = parser.next_message().await;
@@ -286,7 +285,7 @@ async fn parse_two_correct() {
     buf.extend_from_slice(&second);
 
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
+    let alloc = Arc::new(MockAllocator::new(0));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x35);
 
     let result = parser.next_message().await.unwrap();
@@ -322,7 +321,7 @@ async fn parse_after_error() {
     buf.extend_from_slice(&second);
 
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
+    let alloc = Arc::new(MockAllocator::new(0));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x50);
 
     let result = parser.next_message().await;
@@ -369,7 +368,7 @@ async fn parse_write() {
     buf.extend_from_slice(&second);
 
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0x24)));
+    let alloc = Arc::new(MockAllocator::new(0x24));
     let mut parser = RpcParser::with_capacity(socket, alloc, 72);
 
     let result = parser.next_message().await.unwrap();
@@ -415,7 +414,7 @@ async fn parse_write_after_error() {
     buf.extend_from_slice(&second);
 
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0x24)));
+    let alloc = Arc::new(MockAllocator::new(0x24));
     let mut parser = RpcParser::with_capacity(socket, alloc, 80);
 
     let result = parser.next_message().await;
@@ -438,7 +437,7 @@ async fn parse_error_when_consumed_exceeds_frame_size() {
         0x00, 0x00, 0x00, 0x05, // invalid rpc version (must be 2)
     ];
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
+    let alloc = Arc::new(MockAllocator::new(0));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x20);
 
     let result = parser.next_message().await;
@@ -457,7 +456,7 @@ async fn parse_error_with_too_small_frame_size_returns_error() {
     ];
 
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
+    let alloc = Arc::new(MockAllocator::new(0));
     let mut parser = RpcParser::with_capacity(socket, alloc, 32);
 
     let result = parser.next_message().await;
@@ -483,7 +482,7 @@ async fn parse_rejects_any_non_call_message_type() {
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
     ];
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
+    let alloc = Arc::new(MockAllocator::new(0));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x35);
 
     let result = parser.next_message().await;
@@ -501,7 +500,7 @@ async fn parse_rejects_frame_smaller_than_xid() {
         0x80, 0x00, 0x00, 0x03, // head with invalid frame size (less than 4)
     ];
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
+    let alloc = Arc::new(MockAllocator::new(0));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x10);
 
     let result = parser.next_message().await;
@@ -531,7 +530,7 @@ async fn parse_write_with_empty_payload() {
     let mut buf = Vec::new();
     buf.extend_from_slice(&first);
     let socket = MockSocket::new(buf.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(2)));
+    let alloc = Arc::new(MockAllocator::new(2));
     let mut parser = RpcParser::with_capacity(socket, alloc, 72);
     let result = parser.next_message().await.unwrap();
     assert_arg_wrapper(result, &header, |proc, arg| assert_write_proc_result(proc, arg), &write);
@@ -546,7 +545,7 @@ async fn parse_rejects_non_none_cred_auth() {
         buf.extend_from_slice(&fsstat_args([1, 2, 3, 4, 5, 6, 7, 8]));
     });
     let socket = MockSocket::new(frame.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
+    let alloc = Arc::new(MockAllocator::new(0));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x40);
 
     let result = parser.next_message().await;
@@ -565,7 +564,7 @@ async fn parse_rejects_non_none_verf_auth() {
         buf.extend_from_slice(&fsstat_args([1, 2, 3, 4, 5, 6, 7, 8]));
     });
     let socket = MockSocket::new(frame.as_slice());
-    let alloc = Arc::new(Mutex::new(MockAllocator::new(0)));
+    let alloc = Arc::new(MockAllocator::new(0));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x40);
 
     let result = parser.next_message().await;

--- a/src/serializer/server/serialize_struct.rs
+++ b/src/serializer/server/serialize_struct.rs
@@ -6,9 +6,11 @@
 //! RPC reply to an async writer.
 
 use std::io;
-use std::io::{ErrorKind, Write};
+use std::io::{ErrorKind, IoSlice, Write};
+use std::os::fd::AsRawFd;
 
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
+use tokio::net::tcp::OwnedWriteHalf;
 
 use crate::allocator::Slice;
 use crate::mount::MountRes;
@@ -60,23 +62,23 @@ macro_rules! nfs_result {
 }
 
 /// Async writer wrapper used to emit XDR-encoded RPC replies.
-pub struct Serializer<T: AsyncWrite + Unpin> {
-    buffer: WriteBuffer<T>,
+pub struct Serializer {
+    buffer: WriteBuffer,
 }
 
-impl<T: AsyncWrite + Unpin> Serializer<T> {
+impl Serializer {
     /// Creates a reply serializer writing XDR bytes to the provided async writer.
     pub async fn flush(&mut self) -> io::Result<()> {
         use tokio::io::AsyncWriteExt;
         self.buffer.socket.flush().await
     }
 
-    pub fn new(writer: T) -> Self {
+    pub fn new(writer: OwnedWriteHalf) -> Self {
         Self { buffer: WriteBuffer::new(writer, DEFAULT_SIZE) }
     }
 
     /// Creates a reply serializer with an explicit internal buffer capacity.
-    fn with_capacity(writer: T, capacity: usize) -> Self {
+    fn with_capacity(writer: OwnedWriteHalf, capacity: usize) -> Self {
         Self { buffer: WriteBuffer::new(writer, capacity) }
     }
 
@@ -113,7 +115,7 @@ impl<T: AsyncWrite + Unpin> Serializer<T> {
                     let count = ok.head.count as usize;
                     usize_as_u32(&mut self.buffer, STATUS_OK)?;
                     read::result_ok_part(&mut self.buffer, ok.head)?;
-                    self.buffer.send_inner_with_slice(ok.data, count).await
+                    self.buffer.send_inner_with_payload(ok.data, count).await
                 }
                 Err(err) => {
                     error(&mut self.buffer, err.error)?;
@@ -276,12 +278,12 @@ impl<T: AsyncWrite + Unpin> Serializer<T> {
 }
 
 /// Buffered async writer used by the high-level reply serializer.
-struct WriteBuffer<T: AsyncWrite + Unpin> {
-    socket: T,
+struct WriteBuffer {
+    socket: OwnedWriteHalf,
     buf: Vec<u8>,
 }
 
-impl<T: AsyncWrite + Unpin> Write for WriteBuffer<T> {
+impl Write for WriteBuffer {
     /// Writes raw bytes into the internal staging buffer (not directly to the socket).
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.buf.extend_from_slice(buf);
@@ -294,9 +296,9 @@ impl<T: AsyncWrite + Unpin> Write for WriteBuffer<T> {
     }
 }
 
-impl<T: AsyncWrite + Unpin> WriteBuffer<T> {
+impl WriteBuffer {
     /// Creates a new buffer around an async writer with a fixed preallocated capacity.
-    fn new(socket: T, capacity: usize) -> WriteBuffer<T> {
+    fn new(socket: OwnedWriteHalf, capacity: usize) -> WriteBuffer {
         let mut buffer = WriteBuffer { socket, buf: Vec::with_capacity(capacity) };
         buffer.clean();
         buffer
@@ -334,8 +336,12 @@ impl<T: AsyncWrite + Unpin> WriteBuffer<T> {
         Ok(())
     }
 
-    /// Flushes the staged XDR bytes followed by a streamed payload [`Slice`] (used for READ data).
-    async fn send_inner_with_slice(&mut self, slice: Slice, count: usize) -> io::Result<()> {
+    /// Flushes the staged XDR bytes followed by a streamed payload (used for READ data).
+    async fn send_inner_with_payload(
+        &mut self,
+        payload: crate::vfs::read::Payload,
+        count: usize,
+    ) -> io::Result<()> {
         // this place is a bit paradox
         // In READ procedure (https://datatracker.ietf.org/doc/html/rfc1813#autoid-25) opaque data
         // (which is represented with Slice in vfs::read::Success) from XDR
@@ -350,15 +356,125 @@ impl<T: AsyncWrite + Unpin> WriteBuffer<T> {
         self.append_fragment_size(self.buf.len().saturating_sub(HEADER_SIZE) + count + padding)?;
         self.socket.write_all(&self.buf).await?;
 
-        // later change to explicit cursor (when one implemented)
-        for buf in slice.iter() {
-            self.socket.write_all(buf).await?;
+        match payload {
+            crate::vfs::read::Payload::Slice(slice) => {
+                self.write_slice_payload(slice, count).await?;
+            }
+            crate::vfs::read::Payload::SendFile(sendfile_data) => {
+                self.write_sendfile_payload(sendfile_data).await?;
+            }
         }
 
         // write padding directly to socket
-        let slice = [0u8; ALIGNMENT];
-        self.socket.write_all(&slice[..padding]).await?;
+        if padding > 0 {
+            let padding_buf = [0u8; ALIGNMENT];
+            let pad = IoSlice::new(&padding_buf[..padding]);
+            let mut written = 0usize;
+            while written < padding {
+                let bytes = self.socket.write_vectored(&[pad]).await?;
+                if bytes == 0 {
+                    return Err(io::Error::new(
+                        ErrorKind::WriteZero,
+                        "failed to write XDR padding",
+                    ));
+                }
+                written += bytes;
+            }
+        }
+
         self.clean();
+        Ok(())
+    }
+
+    async fn write_slice_payload(&mut self, slice: Slice, count: usize) -> io::Result<()> {
+        let mut chunks = Vec::with_capacity(16);
+        let mut remaining = count;
+        for chunk in slice.iter() {
+            if remaining == 0 {
+                break;
+            }
+            if chunk.is_empty() {
+                continue;
+            }
+            let take = chunk.len().min(remaining);
+            chunks.push(&chunk[..take]);
+            remaining -= take;
+        }
+
+        if remaining != 0 {
+            return Err(io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "slice payload shorter than READ count",
+            ));
+        }
+
+        let mut chunk_idx = 0usize;
+        let mut chunk_offset = 0usize;
+        while chunk_idx < chunks.len() {
+            let mut iovecs = Vec::with_capacity(16);
+            for (i, chunk) in chunks.iter().enumerate().skip(chunk_idx).take(16) {
+                if i == chunk_idx {
+                    iovecs.push(IoSlice::new(&chunk[chunk_offset..]));
+                } else {
+                    iovecs.push(IoSlice::new(chunk));
+                }
+            }
+
+            let bytes = self.socket.write_vectored(&iovecs).await?;
+            if bytes == 0 {
+                return Err(io::Error::new(ErrorKind::WriteZero, "failed to write READ payload"));
+            }
+
+            let mut consumed = bytes;
+            while consumed > 0 && chunk_idx < chunks.len() {
+                let available = chunks[chunk_idx].len().saturating_sub(chunk_offset);
+                if consumed < available {
+                    chunk_offset += consumed;
+                    consumed = 0;
+                } else {
+                    consumed -= available;
+                    chunk_idx += 1;
+                    chunk_offset = 0;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn write_sendfile_payload(
+        &mut self,
+        sendfile_data: crate::vfs::read::SendFile,
+    ) -> io::Result<()> {
+        let socket_fd = self.socket.as_ref().as_raw_fd();
+        let file_fd = sendfile_data.file.as_raw_fd();
+        let mut offset = sendfile_data.offset as libc::off_t;
+        let mut remaining = sendfile_data.count;
+
+        while remaining > 0 {
+            let chunk = remaining.min(1 << 20);
+            let sent = unsafe {
+                libc::sendfile(socket_fd, file_fd, &mut offset as *mut libc::off_t, chunk)
+            };
+
+            if sent < 0 {
+                let err = io::Error::last_os_error();
+                if err.kind() == ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(err);
+            }
+
+            if sent == 0 {
+                return Err(io::Error::new(
+                    ErrorKind::UnexpectedEof,
+                    "sendfile reached EOF before READ count",
+                ));
+            }
+
+            remaining = remaining.saturating_sub(sent as usize);
+        }
+
         Ok(())
     }
 }

--- a/src/serializer/server/serialize_struct.rs
+++ b/src/serializer/server/serialize_struct.rs
@@ -8,7 +8,11 @@
 use std::io;
 use std::io::{ErrorKind, Write};
 
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
+use tokio::net::tcp::OwnedWriteHalf;
+
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
 
 use crate::allocator::Slice;
 use crate::mount::MountRes;
@@ -42,6 +46,7 @@ const HEADER_MASK: usize = 0x8000_0000;
 /// Size of RMS header
 /// (<https://datatracker.ietf.org/doc/html/rfc5531#autoid-19>)
 const HEADER_SIZE: usize = 4;
+const SENDFILE_MIN_BYTES: usize = 32 * 1024;
 
 macro_rules! nfs_result {
     ($self:expr, $res:expr, $ok_fn:path, $fail_fn:path) => {{
@@ -60,23 +65,23 @@ macro_rules! nfs_result {
 }
 
 /// Async writer wrapper used to emit XDR-encoded RPC replies.
-pub struct Serializer<T: AsyncWrite + Unpin> {
-    buffer: WriteBuffer<T>,
+pub struct Serializer {
+    buffer: WriteBuffer,
 }
 
-impl<T: AsyncWrite + Unpin> Serializer<T> {
+impl Serializer {
     /// Creates a reply serializer writing XDR bytes to the provided async writer.
     pub async fn flush(&mut self) -> io::Result<()> {
         use tokio::io::AsyncWriteExt;
         self.buffer.socket.flush().await
     }
 
-    pub fn new(writer: T) -> Self {
+    pub fn new(writer: OwnedWriteHalf) -> Self {
         Self { buffer: WriteBuffer::new(writer, DEFAULT_SIZE) }
     }
 
     /// Creates a reply serializer with an explicit internal buffer capacity.
-    fn with_capacity(writer: T, capacity: usize) -> Self {
+    fn with_capacity(writer: OwnedWriteHalf, capacity: usize) -> Self {
         Self { buffer: WriteBuffer::new(writer, capacity) }
     }
 
@@ -113,7 +118,7 @@ impl<T: AsyncWrite + Unpin> Serializer<T> {
                     let count = ok.head.count as usize;
                     usize_as_u32(&mut self.buffer, STATUS_OK)?;
                     read::result_ok_part(&mut self.buffer, ok.head)?;
-                    self.buffer.send_inner_with_slice(ok.data, count).await
+                    self.buffer.send_inner_with_slice(ok.data, ok.sendfile_source, count).await
                 }
                 Err(err) => {
                     error(&mut self.buffer, err.error)?;
@@ -276,12 +281,12 @@ impl<T: AsyncWrite + Unpin> Serializer<T> {
 }
 
 /// Buffered async writer used by the high-level reply serializer.
-struct WriteBuffer<T: AsyncWrite + Unpin> {
-    socket: T,
+struct WriteBuffer {
+    socket: OwnedWriteHalf,
     buf: Vec<u8>,
 }
 
-impl<T: AsyncWrite + Unpin> Write for WriteBuffer<T> {
+impl Write for WriteBuffer {
     /// Writes raw bytes into the internal staging buffer (not directly to the socket).
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.buf.extend_from_slice(buf);
@@ -294,9 +299,9 @@ impl<T: AsyncWrite + Unpin> Write for WriteBuffer<T> {
     }
 }
 
-impl<T: AsyncWrite + Unpin> WriteBuffer<T> {
+impl WriteBuffer {
     /// Creates a new buffer around an async writer with a fixed preallocated capacity.
-    fn new(socket: T, capacity: usize) -> WriteBuffer<T> {
+    fn new(socket: OwnedWriteHalf, capacity: usize) -> WriteBuffer {
         let mut buffer = WriteBuffer { socket, buf: Vec::with_capacity(capacity) };
         buffer.clean();
         buffer
@@ -335,7 +340,12 @@ impl<T: AsyncWrite + Unpin> WriteBuffer<T> {
     }
 
     /// Flushes the staged XDR bytes followed by a streamed payload [`Slice`] (used for READ data).
-    async fn send_inner_with_slice(&mut self, slice: Slice, count: usize) -> io::Result<()> {
+    async fn send_inner_with_slice(
+        &mut self,
+        slice: Slice,
+        sendfile_source: Option<crate::vfs::read::SendfileSource>,
+        count: usize,
+    ) -> io::Result<()> {
         // this place is a bit paradox
         // In READ procedure (https://datatracker.ietf.org/doc/html/rfc1813#autoid-25) opaque data
         // (which is represented with Slice in vfs::read::Success) from XDR
@@ -350,15 +360,65 @@ impl<T: AsyncWrite + Unpin> WriteBuffer<T> {
         self.append_fragment_size(self.buf.len().saturating_sub(HEADER_SIZE) + count + padding)?;
         self.socket.write_all(&self.buf).await?;
 
-        // later change to explicit cursor (when one implemented)
-        for buf in slice.iter() {
-            self.socket.write_all(buf).await?;
+        let mut sent_with_sendfile = false;
+
+        #[cfg(target_os = "linux")]
+        if let Some(source) = sendfile_source {
+            if count >= SENDFILE_MIN_BYTES {
+                self.send_file_data_linux(source, count).await?;
+                sent_with_sendfile = true;
+            }
+        }
+
+        if !sent_with_sendfile {
+            // later change to explicit cursor (when one implemented)
+            for buf in slice.iter() {
+                self.socket.write_all(buf).await?;
+            }
         }
 
         // write padding directly to socket
         let slice = [0u8; ALIGNMENT];
         self.socket.write_all(&slice[..padding]).await?;
         self.clean();
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn send_file_data_linux(
+        &self,
+        source: crate::vfs::read::SendfileSource,
+        count: usize,
+    ) -> io::Result<()> {
+        let in_fd = source.file.as_raw_fd();
+        let out_fd = self.socket.as_ref().as_raw_fd();
+
+        let mut offset: libc::off_t = source.offset.try_into().map_err(|_| {
+            io::Error::new(ErrorKind::InvalidInput, "READ offset does not fit off_t")
+        })?;
+        let mut remaining = count;
+
+        while remaining > 0 {
+            let sent = unsafe {
+                libc::sendfile(out_fd, in_fd, &mut offset, remaining.min(usize::MAX >> 1))
+            };
+
+            if sent > 0 {
+                remaining -= sent as usize;
+                continue;
+            }
+
+            let err = io::Error::last_os_error();
+            match err.raw_os_error() {
+                Some(libc::EINTR) => continue,
+                Some(libc::EAGAIN) => {
+                    self.socket.writable().await?;
+                    continue;
+                }
+                _ => return Err(err),
+            }
+        }
+
         Ok(())
     }
 }

--- a/src/serializer/server/serialize_struct.rs
+++ b/src/serializer/server/serialize_struct.rs
@@ -66,6 +66,11 @@ pub struct Serializer<T: AsyncWrite + Unpin> {
 
 impl<T: AsyncWrite + Unpin> Serializer<T> {
     /// Creates a reply serializer writing XDR bytes to the provided async writer.
+    pub async fn flush(&mut self) -> io::Result<()> {
+        use tokio::io::AsyncWriteExt;
+        self.buffer.socket.flush().await
+    }
+
     pub fn new(writer: T) -> Self {
         Self { buffer: WriteBuffer::new(writer, DEFAULT_SIZE) }
     }

--- a/src/serializer/server/serialize_struct.rs
+++ b/src/serializer/server/serialize_struct.rs
@@ -6,11 +6,9 @@
 //! RPC reply to an async writer.
 
 use std::io;
-use std::io::{ErrorKind, IoSlice, Write};
-use std::os::fd::AsRawFd;
+use std::io::{ErrorKind, Write};
 
-use tokio::io::AsyncWriteExt;
-use tokio::net::tcp::OwnedWriteHalf;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 use crate::allocator::Slice;
 use crate::mount::MountRes;
@@ -62,23 +60,23 @@ macro_rules! nfs_result {
 }
 
 /// Async writer wrapper used to emit XDR-encoded RPC replies.
-pub struct Serializer {
-    buffer: WriteBuffer,
+pub struct Serializer<T: AsyncWrite + Unpin> {
+    buffer: WriteBuffer<T>,
 }
 
-impl Serializer {
+impl<T: AsyncWrite + Unpin> Serializer<T> {
     /// Creates a reply serializer writing XDR bytes to the provided async writer.
     pub async fn flush(&mut self) -> io::Result<()> {
         use tokio::io::AsyncWriteExt;
         self.buffer.socket.flush().await
     }
 
-    pub fn new(writer: OwnedWriteHalf) -> Self {
+    pub fn new(writer: T) -> Self {
         Self { buffer: WriteBuffer::new(writer, DEFAULT_SIZE) }
     }
 
     /// Creates a reply serializer with an explicit internal buffer capacity.
-    fn with_capacity(writer: OwnedWriteHalf, capacity: usize) -> Self {
+    fn with_capacity(writer: T, capacity: usize) -> Self {
         Self { buffer: WriteBuffer::new(writer, capacity) }
     }
 
@@ -115,7 +113,7 @@ impl Serializer {
                     let count = ok.head.count as usize;
                     usize_as_u32(&mut self.buffer, STATUS_OK)?;
                     read::result_ok_part(&mut self.buffer, ok.head)?;
-                    self.buffer.send_inner_with_payload(ok.data, count).await
+                    self.buffer.send_inner_with_slice(ok.data, count).await
                 }
                 Err(err) => {
                     error(&mut self.buffer, err.error)?;
@@ -278,12 +276,12 @@ impl Serializer {
 }
 
 /// Buffered async writer used by the high-level reply serializer.
-struct WriteBuffer {
-    socket: OwnedWriteHalf,
+struct WriteBuffer<T: AsyncWrite + Unpin> {
+    socket: T,
     buf: Vec<u8>,
 }
 
-impl Write for WriteBuffer {
+impl<T: AsyncWrite + Unpin> Write for WriteBuffer<T> {
     /// Writes raw bytes into the internal staging buffer (not directly to the socket).
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.buf.extend_from_slice(buf);
@@ -296,9 +294,9 @@ impl Write for WriteBuffer {
     }
 }
 
-impl WriteBuffer {
+impl<T: AsyncWrite + Unpin> WriteBuffer<T> {
     /// Creates a new buffer around an async writer with a fixed preallocated capacity.
-    fn new(socket: OwnedWriteHalf, capacity: usize) -> WriteBuffer {
+    fn new(socket: T, capacity: usize) -> WriteBuffer<T> {
         let mut buffer = WriteBuffer { socket, buf: Vec::with_capacity(capacity) };
         buffer.clean();
         buffer
@@ -336,12 +334,8 @@ impl WriteBuffer {
         Ok(())
     }
 
-    /// Flushes the staged XDR bytes followed by a streamed payload (used for READ data).
-    async fn send_inner_with_payload(
-        &mut self,
-        payload: crate::vfs::read::Payload,
-        count: usize,
-    ) -> io::Result<()> {
+    /// Flushes the staged XDR bytes followed by a streamed payload [`Slice`] (used for READ data).
+    async fn send_inner_with_slice(&mut self, slice: Slice, count: usize) -> io::Result<()> {
         // this place is a bit paradox
         // In READ procedure (https://datatracker.ietf.org/doc/html/rfc1813#autoid-25) opaque data
         // (which is represented with Slice in vfs::read::Success) from XDR
@@ -356,125 +350,15 @@ impl WriteBuffer {
         self.append_fragment_size(self.buf.len().saturating_sub(HEADER_SIZE) + count + padding)?;
         self.socket.write_all(&self.buf).await?;
 
-        match payload {
-            crate::vfs::read::Payload::Slice(slice) => {
-                self.write_slice_payload(slice, count).await?;
-            }
-            crate::vfs::read::Payload::SendFile(sendfile_data) => {
-                self.write_sendfile_payload(sendfile_data).await?;
-            }
+        // later change to explicit cursor (when one implemented)
+        for buf in slice.iter() {
+            self.socket.write_all(buf).await?;
         }
 
         // write padding directly to socket
-        if padding > 0 {
-            let padding_buf = [0u8; ALIGNMENT];
-            let pad = IoSlice::new(&padding_buf[..padding]);
-            let mut written = 0usize;
-            while written < padding {
-                let bytes = self.socket.write_vectored(&[pad]).await?;
-                if bytes == 0 {
-                    return Err(io::Error::new(
-                        ErrorKind::WriteZero,
-                        "failed to write XDR padding",
-                    ));
-                }
-                written += bytes;
-            }
-        }
-
+        let slice = [0u8; ALIGNMENT];
+        self.socket.write_all(&slice[..padding]).await?;
         self.clean();
-        Ok(())
-    }
-
-    async fn write_slice_payload(&mut self, slice: Slice, count: usize) -> io::Result<()> {
-        let mut chunks = Vec::with_capacity(16);
-        let mut remaining = count;
-        for chunk in slice.iter() {
-            if remaining == 0 {
-                break;
-            }
-            if chunk.is_empty() {
-                continue;
-            }
-            let take = chunk.len().min(remaining);
-            chunks.push(&chunk[..take]);
-            remaining -= take;
-        }
-
-        if remaining != 0 {
-            return Err(io::Error::new(
-                ErrorKind::UnexpectedEof,
-                "slice payload shorter than READ count",
-            ));
-        }
-
-        let mut chunk_idx = 0usize;
-        let mut chunk_offset = 0usize;
-        while chunk_idx < chunks.len() {
-            let mut iovecs = Vec::with_capacity(16);
-            for (i, chunk) in chunks.iter().enumerate().skip(chunk_idx).take(16) {
-                if i == chunk_idx {
-                    iovecs.push(IoSlice::new(&chunk[chunk_offset..]));
-                } else {
-                    iovecs.push(IoSlice::new(chunk));
-                }
-            }
-
-            let bytes = self.socket.write_vectored(&iovecs).await?;
-            if bytes == 0 {
-                return Err(io::Error::new(ErrorKind::WriteZero, "failed to write READ payload"));
-            }
-
-            let mut consumed = bytes;
-            while consumed > 0 && chunk_idx < chunks.len() {
-                let available = chunks[chunk_idx].len().saturating_sub(chunk_offset);
-                if consumed < available {
-                    chunk_offset += consumed;
-                    consumed = 0;
-                } else {
-                    consumed -= available;
-                    chunk_idx += 1;
-                    chunk_offset = 0;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn write_sendfile_payload(
-        &mut self,
-        sendfile_data: crate::vfs::read::SendFile,
-    ) -> io::Result<()> {
-        let socket_fd = self.socket.as_ref().as_raw_fd();
-        let file_fd = sendfile_data.file.as_raw_fd();
-        let mut offset = sendfile_data.offset as libc::off_t;
-        let mut remaining = sendfile_data.count;
-
-        while remaining > 0 {
-            let chunk = remaining.min(1 << 20);
-            let sent = unsafe {
-                libc::sendfile(socket_fd, file_fd, &mut offset as *mut libc::off_t, chunk)
-            };
-
-            if sent < 0 {
-                let err = io::Error::last_os_error();
-                if err.kind() == ErrorKind::Interrupted {
-                    continue;
-                }
-                return Err(err);
-            }
-
-            if sent == 0 {
-                return Err(io::Error::new(
-                    ErrorKind::UnexpectedEof,
-                    "sendfile reached EOF before READ count",
-                ));
-            }
-
-            remaining = remaining.saturating_sub(sent as usize);
-        }
-
         Ok(())
     }
 }

--- a/src/task/connection/mod.rs
+++ b/src/task/connection/mod.rs
@@ -7,7 +7,8 @@
 //! - [`vfs::VfsTask`] - Processes commands and performs VFS operations
 //! - [`write::WriteTask`] - Writes operation results back to the network connection
 //!
-//! These tasks communicate via unbounded channels to form an asynchronous processing pipeline.
+//! These tasks communicate via bounded channels to form an asynchronous processing pipeline
+//! with built-in backpressure.
 
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
@@ -22,6 +23,9 @@ use crate::vfs::Vfs;
 mod read;
 mod vfs;
 mod write;
+
+const COMMAND_CHANNEL_CAPACITY: usize = 512;
+const RESULT_CHANNEL_CAPACITY: usize = 512;
 
 // Creates all connection tasks with their inner connections
 pub async fn new<V>(
@@ -40,9 +44,10 @@ pub async fn new<V>(
     };
     let (readhalf, writehalf) = socket.into_split();
     // channel for result
-    let (result_sender, result_receiver) = mpsc::unbounded_channel::<ProcReply>();
+    let (result_sender, result_receiver) = mpsc::channel::<ProcReply>(RESULT_CHANNEL_CAPACITY);
     // channel for request
-    let (command_sender, command_receiver) = mpsc::unbounded_channel::<NfsArgWrapper>();
+    let (command_sender, command_receiver) =
+        mpsc::channel::<NfsArgWrapper>(COMMAND_CHANNEL_CAPACITY);
 
     read::ReadTask::new(
         readhalf,

--- a/src/task/connection/mod.rs
+++ b/src/task/connection/mod.rs
@@ -17,17 +17,20 @@ use crate::context::ServerContext;
 use crate::parser::NfsArgWrapper;
 use crate::task::global::mount::MountCommand;
 use crate::task::ProcReply;
+use crate::vfs::Vfs;
 
 mod read;
 mod vfs;
 mod write;
 
 // Creates all connection tasks with their inner connections
-pub async fn new(
+pub async fn new<V>(
     socket: TcpStream,
     mount_sender: mpsc::UnboundedSender<MountCommand>,
-    context: &ServerContext,
-) {
+    context: &ServerContext<V>,
+) where
+    V: Vfs + Send + Sync + 'static,
+{
     let peer_addr = match socket.peer_addr() {
         Ok(addr) => addr,
         Err(err) => {

--- a/src/task/connection/read.rs
+++ b/src/task/connection/read.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tokio::net::tcp::OwnedReadHalf;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::Mutex;
-use tracing::{debug, error};
+use tracing::{error, info};
 
 use crate::allocator::Impl;
 use crate::mount::MountRes;
@@ -65,7 +65,7 @@ impl ReadTask {
                 Ok(ArgWrapper { proc: ProcArguments::Nfs3(proc), header })
                     if matches!(*proc, NfsArguments::Null) =>
                 {
-                    debug!(client=%self.client_addr, xid=header.xid, program="NFS", proc="NULL", "rpc dispatch");
+                    info!(client=%self.client_addr, xid=header.xid, program="NFS", proc="NULL", "rpc dispatch");
                     let result = ProcReply {
                         xid: header.xid,
                         proc_result: Ok(ProcResult::Nfs3(Box::new(NfsRes::Null))),
@@ -78,7 +78,7 @@ impl ReadTask {
 
                 Ok(ArgWrapper { proc: ProcArguments::Nfs3(proc), header }) => {
                     let xid = header.xid;
-                    debug!(client=%self.client_addr, xid, program="NFS", proc="NON_NULL", "rpc dispatch");
+                    info!(client=%self.client_addr, xid, program="NFS", proc="NON_NULL", "rpc dispatch");
                     let command = NfsArgWrapper { header, proc };
 
                     if let Err(err) = self.command_sender.send(command) {
@@ -90,7 +90,7 @@ impl ReadTask {
                     if matches!(*proc, MountArguments::Null) =>
                 {
                     let xid = header.xid;
-                    debug!(client=%self.client_addr, xid, program="MOUNT", proc="NULL", "rpc dispatch");
+                    info!(client=%self.client_addr, xid, program="MOUNT", proc="NULL", "rpc dispatch");
 
                     let result = ProcReply {
                         xid: header.xid,
@@ -104,7 +104,7 @@ impl ReadTask {
 
                 Ok(ArgWrapper { proc: ProcArguments::Mount(proc), header }) => {
                     let xid = header.xid;
-                    debug!(client=%self.client_addr, xid, program="MOUNT", proc="NON_NULL", "rpc dispatch");
+                    info!(client=%self.client_addr, xid, program="MOUNT", proc="NON_NULL", "rpc dispatch");
                     let command = MountCommand {
                         result_tx: self.result_sender.clone(),
                         args: MountArgWrapper { header, proc },

--- a/src/task/connection/read.rs
+++ b/src/task/connection/read.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use tokio::net::tcp::OwnedReadHalf;
 use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::Mutex;
 use tracing::{error, info};
 
 use crate::allocator::Impl;
@@ -32,7 +31,7 @@ pub struct ReadTask {
     // and
     // to bypass vfs with null procedure
     result_sender: UnboundedSender<ProcReply>,
-    allocator: Arc<Mutex<Impl>>,
+    allocator: Arc<Impl>,
 }
 
 impl ReadTask {
@@ -43,7 +42,7 @@ impl ReadTask {
         command_sender: UnboundedSender<NfsArgWrapper>,
         mount_sender: UnboundedSender<MountCommand>,
         result_sender: UnboundedSender<ProcReply>,
-        allocator: Arc<Mutex<Impl>>,
+        allocator: Arc<Impl>,
     ) -> Self {
         Self { readhalf, client_addr, command_sender, mount_sender, result_sender, allocator }
     }

--- a/src/task/connection/read.rs
+++ b/src/task/connection/read.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use tokio::net::tcp::OwnedReadHalf;
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::{Sender, UnboundedSender};
 use tracing::{error, info};
 
 use crate::allocator::Impl;
@@ -23,14 +23,14 @@ use crate::vfs::NfsRes;
 pub struct ReadTask {
     readhalf: OwnedReadHalf,
     client_addr: SocketAddr,
-    command_sender: UnboundedSender<NfsArgWrapper>,
+    command_sender: Sender<NfsArgWrapper>,
     // to send messages into mount task
     mount_sender: UnboundedSender<MountCommand>,
     // to pass into mount task as part of message,
     // so mount task can send result back to write task
     // and
     // to bypass vfs with null procedure
-    result_sender: UnboundedSender<ProcReply>,
+    result_sender: Sender<ProcReply>,
     allocator: Arc<Impl>,
 }
 
@@ -39,9 +39,9 @@ impl ReadTask {
     pub fn new(
         readhalf: OwnedReadHalf,
         client_addr: SocketAddr,
-        command_sender: UnboundedSender<NfsArgWrapper>,
+        command_sender: Sender<NfsArgWrapper>,
         mount_sender: UnboundedSender<MountCommand>,
-        result_sender: UnboundedSender<ProcReply>,
+        result_sender: Sender<ProcReply>,
         allocator: Arc<Impl>,
     ) -> Self {
         Self { readhalf, client_addr, command_sender, mount_sender, result_sender, allocator }
@@ -70,8 +70,8 @@ impl ReadTask {
                         proc_result: Ok(ProcResult::Nfs3(Box::new(NfsRes::Null))),
                     };
 
-                    if let Err(err) = self.result_sender.send(result) {
-                        return send_broken_pipe(&self.result_sender, header.xid, err);
+                    if let Err(err) = self.result_sender.send(result).await {
+                        return send_broken_pipe(&self.result_sender, header.xid, err).await;
                     }
                 }
 
@@ -80,8 +80,8 @@ impl ReadTask {
                     info!(client=%self.client_addr, xid, program="NFS", proc="NON_NULL", "rpc dispatch");
                     let command = NfsArgWrapper { header, proc };
 
-                    if let Err(err) = self.command_sender.send(command) {
-                        return send_broken_pipe(&self.result_sender, xid, err);
+                    if let Err(err) = self.command_sender.send(command).await {
+                        return send_broken_pipe(&self.result_sender, xid, err).await;
                     }
                 }
 
@@ -96,8 +96,8 @@ impl ReadTask {
                         proc_result: Ok(ProcResult::Mount(Box::new(MountRes::Null))),
                     };
 
-                    if let Err(err) = self.result_sender.send(result) {
-                        return send_broken_pipe(&self.result_sender, xid, err);
+                    if let Err(err) = self.result_sender.send(result).await {
+                        return send_broken_pipe(&self.result_sender, xid, err).await;
                     }
                 }
 
@@ -110,15 +110,15 @@ impl ReadTask {
                         client_addr: self.client_addr,
                     };
                     if let Err(err) = self.mount_sender.send(command) {
-                        return send_broken_pipe(&self.result_sender, xid, err);
+                        return send_broken_pipe(&self.result_sender, xid, err).await;
                     }
                 }
 
                 Err(ErrorWrapper { xid: Some(xid), error }) => {
                     error!(client=%self.client_addr, xid, error=?error, "rpc parse error");
                     let result = ProcReply { xid, proc_result: Err(error) };
-                    if let Err(err) = self.result_sender.send(result) {
-                        return send_broken_pipe(&self.result_sender, xid, err);
+                    if let Err(err) = self.result_sender.send(result).await {
+                        return send_broken_pipe(&self.result_sender, xid, err).await;
                     }
                 }
 
@@ -132,8 +132,8 @@ impl ReadTask {
     }
 }
 
-fn send_broken_pipe(
-    sender: &UnboundedSender<ProcReply>,
+async fn send_broken_pipe(
+    sender: &Sender<ProcReply>,
     xid: u32,
     err: impl std::fmt::Display,
 ) -> io::Result<()> {
@@ -142,5 +142,6 @@ fn send_broken_pipe(
             xid,
             proc_result: Err(Error::IO(io::Error::new(io::ErrorKind::BrokenPipe, err.to_string()))),
         })
+        .await
         .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))
 }

--- a/src/task/connection/vfs.rs
+++ b/src/task/connection/vfs.rs
@@ -10,17 +10,23 @@ use crate::task::{ProcReply, ProcResult};
 use crate::vfs::{self, NfsRes, Vfs};
 
 /// Process RPC commands, sends operation results to [`crate::task::connection::write::WriteTask`].
-pub struct VfsTask {
-    backend: Arc<dyn Vfs + Send + Sync + 'static>,
+pub struct VfsTask<V>
+where
+    V: Vfs + Send + Sync + 'static,
+{
+    backend: Arc<V>,
     allocator: Arc<Impl>,
     command_receiver: UnboundedReceiver<NfsArgWrapper>,
     result_sender: UnboundedSender<ProcReply>,
 }
 
-impl VfsTask {
+impl<V> VfsTask<V>
+where
+    V: Vfs + Send + Sync + 'static,
+{
     /// Creates new instance of [`VfsTask`].
     pub fn new(
-        context: &ServerContext,
+        context: &ServerContext<V>,
         command_receiver: UnboundedReceiver<NfsArgWrapper>,
         result_sender: UnboundedSender<ProcReply>,
     ) -> Self {

--- a/src/task/connection/vfs.rs
+++ b/src/task/connection/vfs.rs
@@ -1,7 +1,6 @@
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tokio::sync::Mutex;
 use tracing::{error, info};
 
 use crate::allocator::{Allocator, Impl, Slice};
@@ -13,7 +12,7 @@ use crate::vfs::{self, NfsRes, Vfs};
 /// Process RPC commands, sends operation results to [`crate::task::connection::write::WriteTask`].
 pub struct VfsTask {
     backend: Arc<dyn Vfs + Send + Sync + 'static>,
-    allocator: Arc<Mutex<Impl>>,
+    allocator: Arc<Impl>,
     command_receiver: UnboundedReceiver<NfsArgWrapper>,
     result_sender: UnboundedSender<ProcReply>,
 }
@@ -72,7 +71,7 @@ impl VfsTask {
                         } else {
                             let requested_size = NonZeroUsize::new(args.count as usize).unwrap();
 
-                            let mut allocator = allocator.lock().await;
+                            let allocator = allocator;
                             allocator.allocate(requested_size).await.ok_or(vfs::read::Fail {
                                 error: vfs::Error::TooSmall,
                                 file_attr: None,

--- a/src/task/connection/vfs.rs
+++ b/src/task/connection/vfs.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::Semaphore;
 use tracing::{error, info};
 
 use crate::allocator::{Allocator, Impl, Slice};
@@ -14,10 +15,11 @@ pub struct VfsTask<V>
 where
     V: Vfs + Send + Sync + 'static,
 {
+    inflight_limit: Arc<Semaphore>,
     backend: Arc<V>,
     allocator: Arc<Impl>,
-    command_receiver: UnboundedReceiver<NfsArgWrapper>,
-    result_sender: UnboundedSender<ProcReply>,
+    command_receiver: Receiver<NfsArgWrapper>,
+    result_sender: Sender<ProcReply>,
 }
 
 impl<V> VfsTask<V>
@@ -27,10 +29,13 @@ where
     /// Creates new instance of [`VfsTask`].
     pub fn new(
         context: &ServerContext<V>,
-        command_receiver: UnboundedReceiver<NfsArgWrapper>,
-        result_sender: UnboundedSender<ProcReply>,
+        command_receiver: Receiver<NfsArgWrapper>,
+        result_sender: Sender<ProcReply>,
     ) -> Self {
+        const MAX_INFLIGHT_OPS: usize = 128;
+
         Self {
+            inflight_limit: Arc::new(Semaphore::new(MAX_INFLIGHT_OPS)),
             backend: context.get_backend(),
             allocator: context.get_read_allocator(),
             command_receiver,
@@ -62,8 +67,15 @@ where
             let backend = self.backend.clone();
             let allocator = self.allocator.clone();
             let result_sender = self.result_sender.clone();
+            let inflight_limit = self.inflight_limit.clone();
+
+            let permit = match inflight_limit.acquire_owned().await {
+                Ok(permit) => permit,
+                Err(_) => break,
+            };
 
             tokio::spawn(async move {
+                let _permit = permit;
                 let response = match *proc {
                     NfsArguments::Null => NfsRes::Null,
                     NfsArguments::GetAttr(args) => NfsRes::GetAttr(backend.get_attr(args).await),
@@ -118,7 +130,7 @@ where
                 };
 
                 // Write task may already be closed; then this connection pipeline is done.
-                let _ = result_sender.send(reply);
+                let _ = result_sender.send(reply).await;
             });
         }
     }

--- a/src/task/connection/vfs.rs
+++ b/src/task/connection/vfs.rs
@@ -46,71 +46,75 @@ impl VfsTask {
         let mut command_receiver = self.command_receiver;
 
         while let Some(command) = command_receiver.recv().await {
+            if self.result_sender.is_closed() {
+                break;
+            }
+
             let NfsArgWrapper { header, proc } = command;
             let proc_name = Self::proc_name(&proc);
             info!(xid=header.xid, proc=%proc_name);
 
-            let response = match *proc {
-                NfsArguments::Null => NfsRes::Null,
-                NfsArguments::GetAttr(args) => NfsRes::GetAttr(self.backend.get_attr(args).await),
-                NfsArguments::SetAttr(args) => NfsRes::SetAttr(self.backend.set_attr(args).await),
-                NfsArguments::LookUp(args) => NfsRes::LookUp(self.backend.lookup(args).await),
-                NfsArguments::Access(args) => NfsRes::Access(self.backend.access(args).await),
-                NfsArguments::ReadLink(args) => {
-                    NfsRes::ReadLink(self.backend.read_link(args).await)
-                }
-                NfsArguments::Read(args) => {
-                    let data_result = if args.count == 0 {
-                        Ok(Slice::empty())
-                    } else {
-                        let requested_size = NonZeroUsize::new(args.count as usize).unwrap();
+            let backend = self.backend.clone();
+            let allocator = self.allocator.clone();
+            let result_sender = self.result_sender.clone();
 
-                        let mut allocator = self.allocator.lock().await;
-                        allocator
-                            .allocate(requested_size)
-                            .await
-                            .ok_or(vfs::read::Fail { error: vfs::Error::TooSmall, file_attr: None })
-                    };
+            tokio::spawn(async move {
+                let response = match *proc {
+                    NfsArguments::Null => NfsRes::Null,
+                    NfsArguments::GetAttr(args) => NfsRes::GetAttr(backend.get_attr(args).await),
+                    NfsArguments::SetAttr(args) => NfsRes::SetAttr(backend.set_attr(args).await),
+                    NfsArguments::LookUp(args) => NfsRes::LookUp(backend.lookup(args).await),
+                    NfsArguments::Access(args) => NfsRes::Access(backend.access(args).await),
+                    NfsArguments::ReadLink(args) => NfsRes::ReadLink(backend.read_link(args).await),
+                    NfsArguments::Read(args) => {
+                        let data_result = if args.count == 0 {
+                            Ok(Slice::empty())
+                        } else {
+                            let requested_size = NonZeroUsize::new(args.count as usize).unwrap();
 
-                    match data_result {
-                        Ok(data) => NfsRes::Read(self.backend.read(args, data).await),
-                        Err(err) => NfsRes::Read(Err(err)),
+                            let mut allocator = allocator.lock().await;
+                            allocator.allocate(requested_size).await.ok_or(vfs::read::Fail {
+                                error: vfs::Error::TooSmall,
+                                file_attr: None,
+                            })
+                        };
+
+                        match data_result {
+                            Ok(data) => NfsRes::Read(backend.read(args, data).await),
+                            Err(err) => NfsRes::Read(Err(err)),
+                        }
                     }
-                }
-                NfsArguments::Write(args) => NfsRes::Write(self.backend.write(args).await),
-                NfsArguments::Create(args) => NfsRes::Create(self.backend.create(args).await),
-                NfsArguments::MkDir(args) => NfsRes::MkDir(self.backend.mk_dir(args).await),
-                NfsArguments::SymLink(args) => NfsRes::SymLink(self.backend.symlink(args).await),
-                NfsArguments::MkNod(args) => NfsRes::MkNod(self.backend.mk_node(args).await),
-                NfsArguments::Remove(args) => NfsRes::Remove(self.backend.remove(args).await),
-                NfsArguments::RmDir(args) => NfsRes::RmDir(self.backend.rm_dir(args).await),
-                NfsArguments::Rename(args) => NfsRes::Rename(self.backend.rename(args).await),
-                NfsArguments::Link(args) => NfsRes::Link(self.backend.link(args).await),
-                NfsArguments::ReadDir(args) => NfsRes::ReadDir(self.backend.read_dir(args).await),
-                NfsArguments::ReadDirPlus(args) => {
-                    NfsRes::ReadDirPlus(self.backend.read_dir_plus(args).await)
-                }
-                NfsArguments::FsStat(args) => NfsRes::FsStat(self.backend.fs_stat(args).await),
-                NfsArguments::FsInfo(args) => NfsRes::FsInfo(self.backend.fs_info(args).await),
-                NfsArguments::PathConf(args) => {
-                    NfsRes::PathConf(self.backend.path_conf(args).await)
-                }
-                NfsArguments::Commit(args) => NfsRes::Commit(self.backend.commit(args).await),
-            };
+                    NfsArguments::Write(args) => NfsRes::Write(backend.write(args).await),
+                    NfsArguments::Create(args) => NfsRes::Create(backend.create(args).await),
+                    NfsArguments::MkDir(args) => NfsRes::MkDir(backend.mk_dir(args).await),
+                    NfsArguments::SymLink(args) => NfsRes::SymLink(backend.symlink(args).await),
+                    NfsArguments::MkNod(args) => NfsRes::MkNod(backend.mk_node(args).await),
+                    NfsArguments::Remove(args) => NfsRes::Remove(backend.remove(args).await),
+                    NfsArguments::RmDir(args) => NfsRes::RmDir(backend.rm_dir(args).await),
+                    NfsArguments::Rename(args) => NfsRes::Rename(backend.rename(args).await),
+                    NfsArguments::Link(args) => NfsRes::Link(backend.link(args).await),
+                    NfsArguments::ReadDir(args) => NfsRes::ReadDir(backend.read_dir(args).await),
+                    NfsArguments::ReadDirPlus(args) => {
+                        NfsRes::ReadDirPlus(backend.read_dir_plus(args).await)
+                    }
+                    NfsArguments::FsStat(args) => NfsRes::FsStat(backend.fs_stat(args).await),
+                    NfsArguments::FsInfo(args) => NfsRes::FsInfo(backend.fs_info(args).await),
+                    NfsArguments::PathConf(args) => NfsRes::PathConf(backend.path_conf(args).await),
+                    NfsArguments::Commit(args) => NfsRes::Commit(backend.commit(args).await),
+                };
 
-            if let Some(error) = Self::error_from_response(&response) {
-                error!(xid=header.xid, proc=%proc_name, error=?error, "nfs op failed");
-            }
+                if let Some(error) = Self::error_from_response(&response) {
+                    error!(xid=header.xid, proc=%proc_name, error=?error, "nfs op failed");
+                }
 
-            let reply = ProcReply {
-                xid: header.xid,
-                proc_result: Ok(ProcResult::Nfs3(Box::new(response))),
-            };
+                let reply = ProcReply {
+                    xid: header.xid,
+                    proc_result: Ok(ProcResult::Nfs3(Box::new(response))),
+                };
 
-            // Write task may already be closed; then this connection pipeline is done.
-            if self.result_sender.send(reply).is_err() {
-                return;
-            }
+                // Write task may already be closed; then this connection pipeline is done.
+                let _ = result_sender.send(reply);
+            });
         }
     }
 

--- a/src/task/connection/vfs.rs
+++ b/src/task/connection/vfs.rs
@@ -72,7 +72,7 @@ where
                     NfsArguments::Access(args) => NfsRes::Access(backend.access(args).await),
                     NfsArguments::ReadLink(args) => NfsRes::ReadLink(backend.read_link(args).await),
                     NfsArguments::Read(args) => {
-                        let data_result = if args.count == 0 || backend.supports_sendfile() {
+                        let data_result = if args.count == 0 {
                             Ok(Slice::empty())
                         } else {
                             let requested_size = NonZeroUsize::new(args.count as usize).unwrap();

--- a/src/task/connection/vfs.rs
+++ b/src/task/connection/vfs.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::Mutex;
-use tracing::error;
+use tracing::{error, info};
 
 use crate::allocator::{Allocator, Impl, Slice};
 use crate::context::ServerContext;
@@ -48,6 +48,7 @@ impl VfsTask {
         while let Some(command) = command_receiver.recv().await {
             let NfsArgWrapper { header, proc } = command;
             let proc_name = Self::proc_name(&proc);
+            info!(xid=header.xid, proc=%proc_name);
 
             let response = match *proc {
                 NfsArguments::Null => NfsRes::Null,

--- a/src/task/connection/vfs.rs
+++ b/src/task/connection/vfs.rs
@@ -72,7 +72,7 @@ where
                     NfsArguments::Access(args) => NfsRes::Access(backend.access(args).await),
                     NfsArguments::ReadLink(args) => NfsRes::ReadLink(backend.read_link(args).await),
                     NfsArguments::Read(args) => {
-                        let data_result = if args.count == 0 {
+                        let data_result = if args.count == 0 || backend.supports_sendfile() {
                             Ok(Slice::empty())
                         } else {
                             let requested_size = NonZeroUsize::new(args.count as usize).unwrap();

--- a/src/task/connection/write.rs
+++ b/src/task/connection/write.rs
@@ -1,5 +1,5 @@
 use tokio::net::tcp::OwnedWriteHalf;
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::Receiver;
 use tracing::{error, info};
 
 use crate::rpc::{AuthFlavor, OpaqueAuth};
@@ -9,12 +9,12 @@ use crate::task::ProcReply;
 /// Writes [`crate::task::connection::vfs::VfsTask`] responses to a network connection.
 pub struct WriteTask {
     writehalf: OwnedWriteHalf,
-    result_receiver: UnboundedReceiver<ProcReply>,
+    result_receiver: Receiver<ProcReply>,
 }
 
 impl WriteTask {
     /// Creates new instance of [`WriteTask`]
-    pub fn new(writehalf: OwnedWriteHalf, result_receiver: UnboundedReceiver<ProcReply>) -> Self {
+    pub fn new(writehalf: OwnedWriteHalf, result_receiver: Receiver<ProcReply>) -> Self {
         Self { writehalf, result_receiver }
     }
 
@@ -28,10 +28,13 @@ impl WriteTask {
     }
 
     async fn run(self) {
+        const MAX_BATCH_REPLIES: usize = 32;
+        const BATCH_WINDOW: std::time::Duration = std::time::Duration::from_millis(1);
+
         let mut result_receiver = self.result_receiver;
         let mut serializer = serializer::server::serialize_struct::Serializer::new(self.writehalf);
 
-        while let Some(reply) = result_receiver.recv().await {
+        'outer: while let Some(reply) = result_receiver.recv().await {
             // Process the first received reply
             let verifier = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
             info!(xid=%reply.xid, "write task: reply");
@@ -39,8 +42,13 @@ impl WriteTask {
                 error!(error=%e, "write task: failed to serialize/send reply");
             }
 
-            // Drain any additionally available replies from the channel synchronously
-            while let Ok(next_reply) = result_receiver.try_recv() {
+            // Batch a small time window to improve throughput on non-local networks.
+            for _ in 0..MAX_BATCH_REPLIES.saturating_sub(1) {
+                let next_reply = match tokio::time::timeout(BATCH_WINDOW, result_receiver.recv()).await {
+                    Ok(Some(next_reply)) => next_reply,
+                    Ok(None) => break 'outer,
+                    Err(_) => break,
+                };
                 let verifier = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
                 info!(xid=%next_reply.xid, "write task: reply (batched)");
                 if let Err(e) = serializer.form_reply(next_reply, verifier).await {

--- a/src/task/connection/write.rs
+++ b/src/task/connection/write.rs
@@ -29,24 +29,30 @@ impl WriteTask {
 
     async fn run(self) {
         let mut result_receiver = self.result_receiver;
-        let mut serializer = serializer::server::serialize_struct::Serializer::new(self.writehalf);
+        let buf_writer = tokio::io::BufWriter::with_capacity(128 * 1024, self.writehalf);
+        let mut serializer = serializer::server::serialize_struct::Serializer::new(buf_writer);
 
         while let Some(reply) = result_receiver.recv().await {
-            // TODO: <https://github.com/RMamonts/nfs-mamont/issues/143>
-            // Use proper authentication verifier instead of None
+            // Process the first received reply
             let verifier = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
-
             info!(xid=%reply.xid, "write task: reply");
-            match serializer.form_reply(reply, verifier).await {
-                Ok(_) => {
-                    // Reply successfully written to socket
-                }
-                Err(e) => {
+            if let Err(e) = serializer.form_reply(reply, verifier).await {
+                error!(error=%e, "write task: failed to serialize/send reply");
+            }
+
+            // Drain any additionally available replies from the channel synchronously
+            while let Ok(next_reply) = result_receiver.try_recv() {
+                let verifier = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
+                info!(xid=%next_reply.xid, "write task: reply (batched)");
+                if let Err(e) = serializer.form_reply(next_reply, verifier).await {
                     error!(error=%e, "write task: failed to serialize/send reply");
-                    // TODO: Consider closing connection or continuing based on error type
-                    // For now, continue processing other replies
                 }
-            };
+            }
+
+            // After draining all ready replies, flush the buffered writer to the socket.
+            if let Err(e) = serializer.flush().await {
+                error!(error=%e, "write task: failed to flush buffered replies");
+            }
         }
     }
 }

--- a/src/task/connection/write.rs
+++ b/src/task/connection/write.rs
@@ -29,8 +29,7 @@ impl WriteTask {
 
     async fn run(self) {
         let mut result_receiver = self.result_receiver;
-        let buf_writer = tokio::io::BufWriter::with_capacity(128 * 1024, self.writehalf);
-        let mut serializer = serializer::server::serialize_struct::Serializer::new(buf_writer);
+        let mut serializer = serializer::server::serialize_struct::Serializer::new(self.writehalf);
 
         while let Some(reply) = result_receiver.recv().await {
             // Process the first received reply

--- a/src/task/connection/write.rs
+++ b/src/task/connection/write.rs
@@ -29,7 +29,8 @@ impl WriteTask {
 
     async fn run(self) {
         let mut result_receiver = self.result_receiver;
-        let mut serializer = serializer::server::serialize_struct::Serializer::new(self.writehalf);
+        let buf_writer = tokio::io::BufWriter::with_capacity(128 * 1024, self.writehalf);
+        let mut serializer = serializer::server::serialize_struct::Serializer::new(buf_writer);
 
         while let Some(reply) = result_receiver.recv().await {
             // Process the first received reply

--- a/src/task/connection/write.rs
+++ b/src/task/connection/write.rs
@@ -1,6 +1,6 @@
 use tokio::net::tcp::OwnedWriteHalf;
 use tokio::sync::mpsc::UnboundedReceiver;
-use tracing::error;
+use tracing::{error, info};
 
 use crate::rpc::{AuthFlavor, OpaqueAuth};
 use crate::serializer;
@@ -36,6 +36,7 @@ impl WriteTask {
             // Use proper authentication verifier instead of None
             let verifier = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
 
+            info!(xid=%reply.xid, "write task: reply");
             match serializer.form_reply(reply, verifier).await {
                 Ok(_) => {
                     // Reply successfully written to socket

--- a/src/task/global/mount.rs
+++ b/src/task/global/mount.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{self, Sender, UnboundedReceiver, UnboundedSender};
 use tracing::debug;
 
 use crate::mount::dump::Dump;
@@ -16,7 +16,7 @@ use crate::task::{ProcReply, ProcResult};
 /// Command sent to [`MountTask`] from connection read tasks.
 pub struct MountCommand {
     /// Channel used to pass the result to write task.
-    pub result_tx: UnboundedSender<ProcReply>,
+    pub result_tx: Sender<ProcReply>,
     /// Client socket address from connection task.
     pub client_addr: SocketAddr,
     /// Placeholder for mount procedure args.
@@ -111,10 +111,12 @@ impl MountTask {
             // - some logs when occurred error
             // - or retry with fail
             // * but don't stop task
-            let _ = result_tx.send(ProcReply {
+            let _ = result_tx
+                .send(ProcReply {
                 xid: header.xid,
                 proc_result: Ok(ProcResult::Mount(Box::new(mount_result))),
-            });
+                })
+                .await;
             debug!(xid = header.xid, "mount task: reply queued");
         }
     }

--- a/src/vfs/access.rs
+++ b/src/vfs/access.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`Access`] interface.
 
-use async_trait::async_trait;
-
 use super::{file, Error};
 
 /// Success result.
@@ -53,7 +51,6 @@ pub struct Args {
     pub mask: Mask,
 }
 
-#[async_trait]
 pub trait Access {
     /// Determines the access rights that a user, as identified by the credentials
     /// in the request, has with respect to a file system object.
@@ -64,5 +61,6 @@ pub trait Access {
     /// such access will be allowed to the file system object in
     /// the future, as access rights can be revoked by the server
     /// at any time.
-    async fn access(&self, args: Args) -> Result<Success, Fail>;
+    fn access(&self, args: Args)
+        -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/commit.rs
+++ b/src/vfs/commit.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`Commit`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 use super::file;
@@ -35,8 +33,8 @@ pub struct Args {
     pub count: u32,
 }
 
-#[async_trait]
 pub trait Commit {
     /// Forces or flushes data to stable storage that was previously written.
-    async fn commit(&self, args: Args) -> Result<Success, Fail>;
+    fn commit(&self, args: Args)
+        -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/create.rs
+++ b/src/vfs/create.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`Create`] interface.
 
-use async_trait::async_trait;
-
 use crate::consts::nfsv3::NFS3_CREATEVERFSIZE;
 use crate::vfs;
 
@@ -64,8 +62,8 @@ pub struct Args {
     pub how: How,
 }
 
-#[async_trait]
 pub trait Create {
     /// Creates a [`file::Type::Regular`] file.
-    async fn create(&self, args: Args) -> Result<Success, Fail>;
+    fn create(&self, args: Args)
+        -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/fs_info.rs
+++ b/src/vfs/fs_info.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`FsInfo`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 use super::file;
@@ -79,8 +77,10 @@ pub struct Args {
     pub root: file::Handle,
 }
 
-#[async_trait]
 pub trait FsInfo {
     /// Retrieves nonvolatile file system state information and general information.
-    async fn fs_info(&self, args: Args) -> Result<Success, Fail>;
+    fn fs_info(
+        &self,
+        args: Args,
+    ) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/fs_stat.rs
+++ b/src/vfs/fs_stat.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`FsStat`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 use super::file;
@@ -51,8 +49,10 @@ pub struct Args {
     pub root: file::Handle,
 }
 
-#[async_trait]
 pub trait FsStat {
     /// Retrieves volatile file system state information.
-    async fn fs_stat(&self, args: Args) -> Result<Success, Fail>;
+    fn fs_stat(
+        &self,
+        args: Args,
+    ) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/get_attr.rs
+++ b/src/vfs/get_attr.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`GetAttr`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 use super::file;
@@ -23,8 +21,10 @@ pub struct Args {
     pub file: file::Handle,
 }
 
-#[async_trait]
 pub trait GetAttr {
     /// Retrieves the attributes for a specified file system object.
-    async fn get_attr(&self, args: Args) -> Result<Success, Fail>;
+    fn get_attr(
+        &self,
+        args: Args,
+    ) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/link.rs
+++ b/src/vfs/link.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`Link`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 use super::file;
@@ -32,7 +30,6 @@ pub struct Args {
     pub link: vfs::DirOpArgs,
 }
 
-#[async_trait]
 pub trait Link {
     /// Creates a hard link from [`Args::file`] to [`Args::link`], in the directory.
     ///
@@ -45,5 +42,5 @@ pub trait Link {
     /// On some servers, the filenames, "." and "..", are illegal for link names.
     /// In addition, the link name cannot be an alias for the target directory. These servers will
     /// return the error, [`vfs::Error::InvalidArgument`], in these cases.
-    async fn link(&self, args: Args) -> Result<Success, Fail>;
+    fn link(&self, args: Args) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/lookup.rs
+++ b/src/vfs/lookup.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`Lookup`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 use super::file;
@@ -29,11 +27,11 @@ pub struct Args {
     pub name: file::Name,
 }
 
-#[async_trait]
 pub trait Lookup {
     /// Searches a directory for a specific name and returns the file handle for the corresponding
     /// file system object.
     ///
     /// Note that this procedure does not follow symbolic links.
-    async fn lookup(&self, args: Args) -> Result<Success, Fail>;
+    fn lookup(&self, args: Args)
+        -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/mk_dir.rs
+++ b/src/vfs/mk_dir.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`MkDir`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 use super::file;
@@ -32,10 +30,10 @@ pub struct Args {
     pub attr: super::set_attr::NewAttr,
 }
 
-#[async_trait]
 pub trait MkDir {
     /// Creates a new subdirectory.
     ///
     /// Returns [`vfs::Error::Exist`] for "." or ".." `name`.
-    async fn mk_dir(&self, args: Args) -> Result<Success, Fail>;
+    fn mk_dir(&self, args: Args)
+        -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/mk_node.rs
+++ b/src/vfs/mk_node.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`MkNode`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 use super::file;
@@ -51,7 +49,6 @@ pub struct Args {
     pub what: What,
 }
 
-#[async_trait]
 pub trait MkNode {
     /// Creates a new special file of the type `what`.
     ///
@@ -60,5 +57,8 @@ pub trait MkNode {
     ///
     /// Otherwise, if the server does not support the target type the error,
     /// [`vfs::Error::BadType`], should be returned.
-    async fn mk_node(&self, args: Args) -> Result<Success, Fail>;
+    fn mk_node(
+        &self,
+        args: Args,
+    ) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/path_conf.rs
+++ b/src/vfs/path_conf.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`PathConf`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 use super::file;
@@ -48,8 +46,10 @@ pub struct Args {
     pub file: file::Handle,
 }
 
-#[async_trait]
 pub trait PathConf {
     /// Retrieves the pathconf information for a file or directory.
-    async fn path_conf(&self, args: Args) -> Result<Success, Fail>;
+    fn path_conf(
+        &self,
+        args: Args,
+    ) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/read.rs
+++ b/src/vfs/read.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`Read`] interface.
 
-use std::fs::File;
-
 use crate::allocator::Slice;
 use crate::vfs;
 
@@ -12,22 +10,7 @@ pub struct Success {
     /// The attributes of the file on completion of the read.
     pub head: SuccessPartial,
     /// The counted data read from the file.
-    pub data: Payload,
-}
-
-/// READ payload transported by the serializer.
-pub enum Payload {
-    /// Read data already materialized in memory.
-    Slice(Slice),
-    /// File-backed payload that can be streamed to socket with `sendfile`.
-    SendFile(SendFile),
-}
-
-/// File descriptor-backed payload for zero-copy socket transmission.
-pub struct SendFile {
-    pub file: File,
-    pub offset: u64,
-    pub count: usize,
+    pub data: Slice,
 }
 
 pub struct SuccessPartial {
@@ -74,9 +57,4 @@ pub trait Read {
         args: Args,
         data: Slice,
     ) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
-
-    /// Whether implementation can return [`Payload::SendFile`] and skip allocator buffers.
-    fn supports_sendfile(&self) -> bool {
-        false
-    }
 }

--- a/src/vfs/read.rs
+++ b/src/vfs/read.rs
@@ -1,5 +1,7 @@
 //! Defines NFSv3 [`Read`] interface.
 
+use std::sync::Arc;
+
 use crate::allocator::Slice;
 use crate::vfs;
 
@@ -11,6 +13,14 @@ pub struct Success {
     pub head: SuccessPartial,
     /// The counted data read from the file.
     pub data: Slice,
+    /// Optional zero-copy source for transferring payload directly to the socket.
+    pub sendfile_source: Option<SendfileSource>,
+}
+
+/// Backing file range that can be sent with `sendfile` for READ payload.
+pub struct SendfileSource {
+    pub file: Arc<std::fs::File>,
+    pub offset: u64,
 }
 
 pub struct SuccessPartial {

--- a/src/vfs/read.rs
+++ b/src/vfs/read.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`Read`] interface.
 
-use async_trait::async_trait;
-
 use crate::allocator::Slice;
 use crate::vfs;
 
@@ -49,11 +47,14 @@ pub struct Args {
     pub count: u32,
 }
 
-#[async_trait]
 pub trait Read {
     /// Reads data from a file into a server-provided buffer.
     ///
     /// The `data` buffer is allocated by NFS-Mamont allocator and must be
     /// filled by implementation. This keeps allocation policy under server control.
-    async fn read(&self, args: Args, data: Slice) -> Result<Success, Fail>;
+    fn read(
+        &self,
+        args: Args,
+        data: Slice,
+    ) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/read.rs
+++ b/src/vfs/read.rs
@@ -1,5 +1,7 @@
 //! Defines NFSv3 [`Read`] interface.
 
+use std::fs::File;
+
 use crate::allocator::Slice;
 use crate::vfs;
 
@@ -10,7 +12,22 @@ pub struct Success {
     /// The attributes of the file on completion of the read.
     pub head: SuccessPartial,
     /// The counted data read from the file.
-    pub data: Slice,
+    pub data: Payload,
+}
+
+/// READ payload transported by the serializer.
+pub enum Payload {
+    /// Read data already materialized in memory.
+    Slice(Slice),
+    /// File-backed payload that can be streamed to socket with `sendfile`.
+    SendFile(SendFile),
+}
+
+/// File descriptor-backed payload for zero-copy socket transmission.
+pub struct SendFile {
+    pub file: File,
+    pub offset: u64,
+    pub count: usize,
 }
 
 pub struct SuccessPartial {
@@ -57,4 +74,9 @@ pub trait Read {
         args: Args,
         data: Slice,
     ) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
+
+    /// Whether implementation can return [`Payload::SendFile`] and skip allocator buffers.
+    fn supports_sendfile(&self) -> bool {
+        false
+    }
 }

--- a/src/vfs/read_dir.rs
+++ b/src/vfs/read_dir.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`ReadDir`] interface.
 
-use async_trait::async_trait;
-
 use crate::consts::nfsv3::NFS3_COOKIEVERFSIZE;
 use crate::vfs;
 
@@ -124,7 +122,6 @@ pub struct Args {
     pub count: u32,
 }
 
-#[async_trait]
 pub trait ReadDir {
     /// Retrieves a variable number of entries, in sequence, from a directory.
     ///
@@ -135,5 +132,8 @@ pub trait ReadDir {
     /// The [`Args::count`] specified by the client in the request should be greater than or equal to
     /// the server's preferred [`ReadDir`] transfer size from
     /// [`super::fs_info::Success::read_dir_pref`].
-    async fn read_dir(&self, args: Args) -> Result<Success, Fail>;
+    fn read_dir(
+        &self,
+        args: Args,
+    ) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/read_dir_plus.rs
+++ b/src/vfs/read_dir_plus.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`ReadDirPlus`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 use crate::vfs::read_dir::Cookie;
 use crate::vfs::read_dir::CookieVerifier;
@@ -65,9 +63,11 @@ pub struct Args {
     pub max_count: u32,
 }
 
-#[async_trait]
 pub trait ReadDirPlus {
     /// Retrieves a variable number of entries from a file system directory and returns complete
     /// information about each.
-    async fn read_dir_plus(&self, args: Args) -> Result<Success, Fail>;
+    fn read_dir_plus(
+        &self,
+        args: Args,
+    ) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/read_link.rs
+++ b/src/vfs/read_link.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`ReadLink`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 use super::file;
@@ -28,12 +26,14 @@ pub struct Args {
     pub file: file::Handle,
 }
 
-#[async_trait]
 pub trait ReadLink {
     /// Reads the data associated with a symbolic link.
     ///
     /// The [`ReadLink::read_link`] operation is only allowed on
     /// objects of type [`file::Type::Symlink`]. The server should return the error,
     /// [`vfs::Error::InvalidArgument`], if the object is not of type, [`file::Type::Symlink`].
-    async fn read_link(&self, args: Args) -> Result<Success, Fail>;
+    fn read_link(
+        &self,
+        args: Args,
+    ) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/remove.rs
+++ b/src/vfs/remove.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`Remove`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 /// Success result.
@@ -24,8 +22,8 @@ pub struct Args {
     pub object: vfs::DirOpArgs,
 }
 
-#[async_trait]
 pub trait Remove {
     /// Removes (deletes) an entry from a directory.
-    async fn remove(&self, args: Args) -> Result<Success, Fail>;
+    fn remove(&self, args: Args)
+        -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/rename.rs
+++ b/src/vfs/rename.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`Rename`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 /// Success result.
@@ -32,7 +30,6 @@ pub struct Args {
     pub to: vfs::DirOpArgs,
 }
 
-#[async_trait]
 pub trait Rename {
     /// Renames the file in the directory.
     ///
@@ -62,5 +59,6 @@ pub trait Rename {
     ///
     /// If arguments pairs refer to the same file (they might be hard links of each other), then
     /// [`Rename::rename`] should perform no action and return [`Success`].
-    async fn rename(&self, args: Args) -> Result<Success, Fail>;
+    fn rename(&self, args: Args)
+        -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/rm_dir.rs
+++ b/src/vfs/rm_dir.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`RmDir`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 /// Success result.
@@ -25,7 +23,6 @@ pub struct Args {
     pub object: vfs::DirOpArgs,
 }
 
-#[async_trait]
 pub trait RmDir {
     /// Removes (deletes) a subdirectory from a directory.
     ///
@@ -34,5 +31,6 @@ pub trait RmDir {
     ///
     /// On some servers, the filename, "..", is illegal. These servers will return
     /// the error, [`vfs::Error::Exist`].
-    async fn rm_dir(&self, args: Args) -> Result<Success, Fail>;
+    fn rm_dir(&self, args: Args)
+        -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/set_attr.rs
+++ b/src/vfs/set_attr.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`SetAttr`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 use super::file;
@@ -52,7 +50,6 @@ pub struct Fail {
     pub wcc_data: vfs::WccData,
 }
 
-#[async_trait]
 pub trait SetAttr {
     /// Changes one or more of the attributes of a file system object on the server.
     ///
@@ -79,5 +76,8 @@ pub trait SetAttr {
     /// - if implementation can only support 32 bit offset and sizes,
     ///   and [`SetAttr::set_attr`] request to set the size of a file to larger than
     ///   can be represented in 32 bit.
-    async fn set_attr(&self, args: Args) -> Result<Success, Fail>;
+    fn set_attr(
+        &self,
+        args: Args,
+    ) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/symlink.rs
+++ b/src/vfs/symlink.rs
@@ -1,7 +1,5 @@
 //! Defines NFSv3 [`Symlink`] interface.
 
-use async_trait::async_trait;
-
 use crate::vfs;
 
 use super::file;
@@ -34,7 +32,6 @@ pub struct Args {
     pub path: file::Path,
 }
 
-#[async_trait]
 pub trait Symlink {
     /// Creates a new symbolic link.
     ///
@@ -44,5 +41,8 @@ pub trait Symlink {
     /// created in a single atomic operation. That is, once the symbolic link is visible,
     /// there must not be a window where a [`super::read_link::ReadLink::read_link`] would fail or
     /// return incorrect data.
-    async fn symlink(&self, args: Args) -> Result<Success, Fail>;
+    fn symlink(
+        &self,
+        args: Args,
+    ) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }

--- a/src/vfs/write.rs
+++ b/src/vfs/write.rs
@@ -1,6 +1,5 @@
 //! Defines NFSv3 [`Write`] interface.
 
-use async_trait::async_trait;
 use num_derive::{FromPrimitive, ToPrimitive};
 
 use crate::allocator::Slice;
@@ -88,7 +87,6 @@ pub struct ArgsPartial {
     pub stable: StableHow,
 }
 
-#[async_trait]
 pub trait Write {
     /// Writes data to a file.
     ///
@@ -97,5 +95,5 @@ pub trait Write {
     ///
     /// If the `file` system object type was not a [`file::Type::Regular`] file,
     /// [`vfs::Error::InvalidArgument`] is returned.
-    async fn write(&self, args: Args) -> Result<Success, Fail>;
+    fn write(&self, args: Args) -> impl std::future::Future<Output = Result<Success, Fail>> + Send;
 }


### PR DESCRIPTION
remove useless vector allocation in write proc of mirrorfs

futhermore used tokio::fs instead of std::fs in may cases

**this pr passed integration tests**