### PR TITLE
ci: fuzz workflow

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,18 +7,17 @@ on:
         description: "Set time for fuzz target in seconds"
         required: true
         type: number
+      target:
+        description: "Fuzz target name"
+        required: true
+        type: string
 
 jobs:
   fuzz:
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [ parser, round, serializer ]
-
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo install cargo-fuzz
-      - run: cargo +nightly fuzz run "${{ matrix.target }}" -- -ascii_only=1 -max_len=8192 -max_total_time=${{ inputs.time }}
+      - run: cargo +nightly fuzz run "${{ inputs.target }}" -- -ascii_only=1 -max_len=8192 -max_total_time=${{ inputs.time }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,24 @@
+name: Fuzzing
+
+on:
+  workflow_dispatch:
+    inputs:
+      time:
+        description: "Set time for fuzz target in seconds"
+        required: true
+        type: number
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [ parser, round, serializer ]
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo install cargo-fuzz
+      - run: cargo +nightly fuzz run "${{ matrix.target }}" -- -ascii_only=1 -max_len=8192 -max_total_time=${{ inputs.time }}


### PR DESCRIPTION
Add simple workflow that might be run manually on `fuzz` branch after changes in `parser` or `serializer` modules