### PR TITLE
feat: pass link of mount service instead of its value

### DIFF
--- a/examples/mirror_fs/main.rs
+++ b/examples/mirror_fs/main.rs
@@ -62,6 +62,6 @@ async fn main() -> std::io::Result<()> {
         });
     }
 
-    let mount_service = service::mount::MountService::with_exports(exports);
+    let mount_service = Arc::new(service::mount::MountService::with_exports(exports));
     handle_forever(listener, context, mount_service).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub mod service;
 mod task;
 pub mod vfs;
 
+use std::sync::Arc;
+
 use tokio::net::TcpListener;
 use tracing_subscriber::EnvFilter;
 
@@ -37,11 +39,11 @@ pub fn init_tracing() {
 pub async fn handle_forever<A, M>(
     listener: TcpListener,
     context: ServerContext<A>,
-    mount_service: M,
+    mount_service: Arc<M>,
 ) -> std::io::Result<()>
 where
     A: Allocator + Send + Sync + 'static,
-    M: Mount + Send + 'static,
+    M: Mount + Send + Sync + 'static,
 {
     let (mount_task, mount_sender) = MountTask::new(mount_service);
     mount_task.spawn();

--- a/src/mount/mnt.rs
+++ b/src/mount/mnt.rs
@@ -63,7 +63,7 @@ pub trait Mnt {
     /// This procedure also results in the server adding a new entry
     /// to its mount list recording that this client has mounted the directory.
     async fn mnt(
-        &mut self,
+        &self,
         args: Args,
         client_addr: SocketAddr,
         cred: OpaqueAuth,

--- a/src/mount/umnt.rs
+++ b/src/mount/umnt.rs
@@ -26,5 +26,5 @@ pub trait Umnt {
     ///
     /// AUTH_UNIX authentication or better is required.
     /// There are no MOUNT protocol errors which can be returned from this procedure.
-    async fn umnt(&mut self, args: Args, client_addr: SocketAddr);
+    async fn umnt(&self, args: Args, client_addr: SocketAddr);
 }

--- a/src/mount/umntall.rs
+++ b/src/mount/umntall.rs
@@ -14,5 +14,5 @@ pub trait Umntall {
     ///
     /// AUTH_UNIX authentication or better is required.
     /// There are no MOUNT protocol errors which can be returned from this procedure.
-    async fn umntall(&mut self, client_addr: SocketAddr);
+    async fn umntall(&self, client_addr: SocketAddr);
 }

--- a/src/service/mount/dump.rs
+++ b/src/service/mount/dump.rs
@@ -9,8 +9,14 @@ use super::MountService;
 #[async_trait]
 impl Dump for MountService {
     async fn dump(&self) -> Success {
-        let mount_list =
-            self.mounts.by_client.values().flat_map(|entries| entries.iter().cloned()).collect();
+        let mount_list = self
+            .mounts
+            .read()
+            .await
+            .by_client
+            .values()
+            .flat_map(|entries| entries.iter().cloned())
+            .collect();
         Success { mount_list }
     }
 }

--- a/src/service/mount/export.rs
+++ b/src/service/mount/export.rs
@@ -9,7 +9,7 @@ use super::MountService;
 #[async_trait]
 impl Export for MountService {
     async fn export(&self) -> Success {
-        let exports = self.exports.read().await.export_list();
+        let exports = self.exports.export_list();
         Success { exports }
     }
 }

--- a/src/service/mount/export.rs
+++ b/src/service/mount/export.rs
@@ -9,7 +9,7 @@ use super::MountService;
 #[async_trait]
 impl Export for MountService {
     async fn export(&self) -> Success {
-        let exports = self.exports.export_list();
+        let exports = self.exports.read().await.export_list();
         Success { exports }
     }
 }

--- a/src/service/mount/mnt.rs
+++ b/src/service/mount/mnt.rs
@@ -23,8 +23,6 @@ impl Mnt for MountService {
         let Some(export) = self.export_entry(&args.dirpath).await else {
             let configured = self
                 .exports
-                .read()
-                .await
                 .export_list()
                 .into_iter()
                 .map(|entry| entry.directory.as_path().to_string_lossy().into_owned())

--- a/src/service/mount/mnt.rs
+++ b/src/service/mount/mnt.rs
@@ -15,14 +15,16 @@ use super::AUTH;
 #[async_trait]
 impl Mnt for MountService {
     async fn mnt(
-        &mut self,
+        &self,
         args: Args,
         client_addr: SocketAddr,
         _cred: OpaqueAuth,
     ) -> Result<Success, Fail> {
-        let Some(export) = self.export_entry(&args.dirpath) else {
+        let Some(export) = self.export_entry(&args.dirpath).await else {
             let configured = self
                 .exports
+                .read()
+                .await
                 .export_list()
                 .into_iter()
                 .map(|entry| entry.directory.as_path().to_string_lossy().into_owned())
@@ -41,7 +43,7 @@ impl Mnt for MountService {
         let mount_entry =
             MountEntry { hostname: client_addr.ip().to_string(), directory: args.dirpath.clone() };
 
-        self.mounts.by_client.entry(client_addr).or_default().insert(mount_entry);
+        self.mounts.write().await.by_client.entry(client_addr).or_default().insert(mount_entry);
 
         Ok(Success { file_handle, auth_flavors: AUTH.to_vec() })
     }

--- a/src/service/mount/mod.rs
+++ b/src/service/mount/mod.rs
@@ -22,6 +22,8 @@
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 
+use tokio::sync::RwLock;
+
 use crate::mount::{ExportEntry, MountEntry};
 use crate::rpc::AuthFlavor;
 use crate::vfs::file;
@@ -80,17 +82,21 @@ struct MountRegistry {
 /// In-memory state backing the MOUNT v3 service implementation
 pub struct MountService {
     /// Exported directories that are available for mounting
-    exports: ExportRegistry,
+    exports: RwLock<ExportRegistry>,
     /// Active mounts keyed by client.
-    mounts: MountRegistry,
+    mounts: RwLock<MountRegistry>,
 }
 
 impl MountService {
     pub fn with_exports(entries: Vec<ExportEntryWrapper>) -> Self {
-        Self { exports: ExportRegistry::from_entries(entries), mounts: MountRegistry::default() }
+        Self {
+            exports: RwLock::new(ExportRegistry::from_entries(entries)),
+            mounts: RwLock::new(MountRegistry::default()),
+        }
     }
 
-    fn export_entry(&self, path: &file::Path) -> Option<&ExportEntryWrapper> {
-        self.exports.by_path(path)
+    async fn export_entry(&self, path: &file::Path) -> Option<ExportEntryWrapper> {
+        let guard = self.exports.read().await;
+        guard.by_path(path).cloned()
     }
 }

--- a/src/service/mount/mod.rs
+++ b/src/service/mount/mod.rs
@@ -21,6 +21,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use tokio::sync::RwLock;
 
@@ -82,7 +83,7 @@ struct MountRegistry {
 /// In-memory state backing the MOUNT v3 service implementation
 pub struct MountService {
     /// Exported directories that are available for mounting
-    exports: RwLock<ExportRegistry>,
+    exports: Arc<ExportRegistry>,
     /// Active mounts keyed by client.
     mounts: RwLock<MountRegistry>,
 }
@@ -90,13 +91,12 @@ pub struct MountService {
 impl MountService {
     pub fn with_exports(entries: Vec<ExportEntryWrapper>) -> Self {
         Self {
-            exports: RwLock::new(ExportRegistry::from_entries(entries)),
+            exports: Arc::new(ExportRegistry::from_entries(entries)),
             mounts: RwLock::new(MountRegistry::default()),
         }
     }
 
     async fn export_entry(&self, path: &file::Path) -> Option<ExportEntryWrapper> {
-        let guard = self.exports.read().await;
-        guard.by_path(path).cloned()
+        self.exports.by_path(path).cloned()
     }
 }

--- a/src/service/mount/mod.rs
+++ b/src/service/mount/mod.rs
@@ -96,7 +96,7 @@ impl MountService {
         }
     }
 
-    async fn export_entry(&self, path: &file::Path) -> Option<ExportEntryWrapper> {
-        self.exports.by_path(path).cloned()
+    async fn export_entry(&self, path: &file::Path) -> Option<&ExportEntryWrapper> {
+        self.exports.by_path(path)
     }
 }

--- a/src/service/mount/umnt.rs
+++ b/src/service/mount/umnt.rs
@@ -11,10 +11,12 @@ use super::MountService;
 #[async_trait]
 impl Umnt for MountService {
     async fn umnt(&self, args: Args, client_addr: SocketAddr) {
-        if let Some(entries) = self.mounts.write().await.by_client.get_mut(&client_addr) {
+        let mut mounts = self.mounts.write().await;
+
+        if let Some(entries) = mounts.by_client.get_mut(&client_addr) {
             entries.retain(|entry| entry.directory != args.dirpath);
             if entries.is_empty() {
-                self.mounts.write().await.by_client.remove(&client_addr);
+                mounts.by_client.remove(&client_addr);
             }
         }
     }

--- a/src/service/mount/umnt.rs
+++ b/src/service/mount/umnt.rs
@@ -10,11 +10,11 @@ use super::MountService;
 
 #[async_trait]
 impl Umnt for MountService {
-    async fn umnt(&mut self, args: Args, client_addr: SocketAddr) {
-        if let Some(entries) = self.mounts.by_client.get_mut(&client_addr) {
+    async fn umnt(&self, args: Args, client_addr: SocketAddr) {
+        if let Some(entries) = self.mounts.write().await.by_client.get_mut(&client_addr) {
             entries.retain(|entry| entry.directory != args.dirpath);
             if entries.is_empty() {
-                self.mounts.by_client.remove(&client_addr);
+                self.mounts.write().await.by_client.remove(&client_addr);
             }
         }
     }

--- a/src/service/mount/umntall.rs
+++ b/src/service/mount/umntall.rs
@@ -10,7 +10,7 @@ use super::MountService;
 
 #[async_trait]
 impl Umntall for MountService {
-    async fn umntall(&mut self, client_addr: SocketAddr) {
-        self.mounts.by_client.remove(&client_addr);
+    async fn umntall(&self, client_addr: SocketAddr) {
+        self.mounts.write().await.by_client.remove(&client_addr);
     }
 }

--- a/src/task/global/mount.rs
+++ b/src/task/global/mount.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tracing::debug;
@@ -19,19 +20,19 @@ pub struct MountCommand {
 
 pub struct MountTask<M>
 where
-    M: Mount + Send + 'static,
+    M: Mount + Send + Sync + 'static,
 {
-    mount_service: M,
+    mount_service: Arc<M>,
     // channel for commands from client connection tasks
     receiver: UnboundedReceiver<MountCommand>,
 }
 
 impl<M> MountTask<M>
 where
-    M: Mount + Send + 'static,
+    M: Mount + Send + Sync + 'static,
 {
     /// Creates new instance of [`MountTask`]
-    pub fn new(mount_service: M) -> (Self, UnboundedSender<MountCommand>) {
+    pub fn new(mount_service: Arc<M>) -> (Self, UnboundedSender<MountCommand>) {
         let (sender, receiver) = mpsc::unbounded_channel::<MountCommand>();
 
         let task = Self { mount_service, receiver };
@@ -51,7 +52,7 @@ where
     }
 
     async fn run(self) {
-        let mut mount_service = self.mount_service;
+        let mount_service = self.mount_service;
         let mut receiver = self.receiver;
 
         while let Some(command) = receiver.recv().await {


### PR DESCRIPTION
Now we pass link to MOUNT service, removed `&mut self` from Mount trait methods