### PR TITLE
refactor: nlm::OpaqueHandle

### DIFF
--- a/nfs-mamont/src/nlm/holder.rs
+++ b/nfs-mamont/src/nlm/holder.rs
@@ -51,7 +51,7 @@ mod tests {
     #[test]
     fn new_holder_succeeds() {
         let oh = [1; OPAQUE_HANDLE_SIZE].to_vec();
-        let oh_verf = oh.clone();
+        let oh_expected = oh.clone();
         let opaque_handle = OpaqueHandle::new(oh).unwrap();
         let system_id = 12345;
         let offset = 0;
@@ -59,7 +59,7 @@ mod tests {
 
         let lock = Nlm4Holder::new(true, system_id, opaque_handle, offset, length);
 
-        assert_eq!(lock.opaque_handle.as_bytes(), oh_verf.as_slice());
+        assert_eq!(lock.opaque_handle.as_bytes(), oh_expected.as_slice());
         assert_eq!(lock.system_identifier, system_id);
         assert_eq!(lock.lock_offset, offset);
         assert_eq!(lock.lock_length, length);

--- a/nfs-mamont/src/nlm/holder.rs
+++ b/nfs-mamont/src/nlm/holder.rs
@@ -50,15 +50,16 @@ mod tests {
 
     #[test]
     fn new_holder_succeeds() {
-        let oh = [1; OPAQUE_HANDLE_SIZE];
-        let opaque_handle = OpaqueHandle::new(oh);
+        let oh = [1; OPAQUE_HANDLE_SIZE].to_vec();
+        let oh_verf = oh.clone();
+        let opaque_handle = OpaqueHandle::new(oh).unwrap();
         let system_id = 12345;
         let offset = 0;
         let length = 0;
 
         let lock = Nlm4Holder::new(true, system_id, opaque_handle, offset, length);
 
-        assert_eq!(lock.opaque_handle.as_bytes(), &oh);
+        assert_eq!(lock.opaque_handle.as_bytes(), oh_verf.as_slice());
         assert_eq!(lock.system_identifier, system_id);
         assert_eq!(lock.lock_offset, offset);
         assert_eq!(lock.lock_length, length);

--- a/nfs-mamont/src/nlm/lock.rs
+++ b/nfs-mamont/src/nlm/lock.rs
@@ -93,8 +93,9 @@ mod tests {
         let caller_name = "host".to_string();
         let fh = [0; NFS3_FHSIZE];
         let file_handle = Handle(fh);
-        let oh = [1; OPAQUE_HANDLE_SIZE];
-        let opaque_handle = OpaqueHandle::new(oh);
+        let oh = [1; OPAQUE_HANDLE_SIZE].to_vec();
+        let oh_verf = oh.clone();
+        let opaque_handle = OpaqueHandle::new(oh).unwrap();
         let system_id = 12345;
         let offset = 0;
         let length = 0;
@@ -111,7 +112,7 @@ mod tests {
 
         assert_eq!(lock.caller_name, caller_name);
         assert_eq!(lock.file_handle.0, fh);
-        assert_eq!(lock.opaque_handle.as_bytes(), &oh);
+        assert_eq!(lock.opaque_handle.as_bytes(), oh_verf.as_slice());
         assert_eq!(lock.system_identifier, system_id);
         assert_eq!(lock.lock_offset, offset);
         assert_eq!(lock.lock_length, length);
@@ -122,7 +123,7 @@ mod tests {
         let result = Nlm4Lock::new(
             "".to_string(),
             Handle([0; NFS3_FHSIZE]),
-            OpaqueHandle::new([1; OPAQUE_HANDLE_SIZE]),
+            OpaqueHandle::new([1; OPAQUE_HANDLE_SIZE].to_vec()).unwrap(),
             12345,
             0,
             0,
@@ -135,7 +136,7 @@ mod tests {
         let result = Nlm4Lock::new(
             "a".repeat(nlm::LM_MAXSTRLEN + 1),
             Handle([0; NFS3_FHSIZE]),
-            OpaqueHandle::new([0; OPAQUE_HANDLE_SIZE]),
+            OpaqueHandle::new([0; OPAQUE_HANDLE_SIZE].to_vec()).unwrap(),
             12345,
             0,
             0,

--- a/nfs-mamont/src/nlm/lock.rs
+++ b/nfs-mamont/src/nlm/lock.rs
@@ -82,11 +82,11 @@ impl Nlm4Lock {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use crate::consts::nfsv3::NFS3_FHSIZE;
     use crate::consts::nlm::OPAQUE_HANDLE_SIZE;
     use crate::vfs::file::Handle;
+
+    use super::{nlm::LM_MAXSTRLEN, Nlm4Lock, OpaqueHandle};
 
     #[test]
     fn new_lock_succeeds() {
@@ -134,7 +134,7 @@ mod tests {
     #[test]
     fn new_lock_fails_on_too_long_caller_name() {
         let result = Nlm4Lock::new(
-            "a".repeat(nlm::LM_MAXSTRLEN + 1),
+            "a".repeat(LM_MAXSTRLEN + 1),
             Handle([0; NFS3_FHSIZE]),
             OpaqueHandle::new([0; OPAQUE_HANDLE_SIZE].to_vec()).unwrap(),
             12345,

--- a/nfs-mamont/src/nlm/mod.rs
+++ b/nfs-mamont/src/nlm/mod.rs
@@ -66,7 +66,7 @@ impl OpaqueHandle {
     #[inline]
     pub fn new(oh: Vec<u8>) -> io::Result<Self> {
         if oh.len() > OPAQUE_HANDLE_SIZE {
-            return Err(io::Error::new(io::ErrorKind::InvalidInput, "name too long"));
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "opaque handle too long"));
         }
         Ok(OpaqueHandle(oh))
     }

--- a/nfs-mamont/src/nlm/mod.rs
+++ b/nfs-mamont/src/nlm/mod.rs
@@ -8,12 +8,14 @@ pub mod lock;
 pub mod procedures;
 pub mod share;
 
+use std::io;
+
+use num_derive::{FromPrimitive, ToPrimitive};
+
 use crate::consts::nlm::OPAQUE_HANDLE_SIZE;
 use crate::nlm::procedures::{
     cancel::Nlm4CancelRes, lock::Nlm4LockRes, test::Nlm4TestRes, unlock::Nlm4UnlockRes,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use std::io;
 
 /// `Nlm4Stats` indicates the success or failure of a call.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ToPrimitive, FromPrimitive)]
@@ -109,7 +111,7 @@ impl<T> Nlm for T where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{OpaqueHandle, OPAQUE_HANDLE_SIZE};
 
     #[test]
     fn opaque_handle_bytes() {

--- a/nfs-mamont/src/nlm/mod.rs
+++ b/nfs-mamont/src/nlm/mod.rs
@@ -13,6 +13,7 @@ use crate::nlm::procedures::{
     cancel::Nlm4CancelRes, lock::Nlm4LockRes, test::Nlm4TestRes, unlock::Nlm4UnlockRes,
 };
 use num_derive::{FromPrimitive, ToPrimitive};
+use std::io;
 
 /// `Nlm4Stats` indicates the success or failure of a call.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ToPrimitive, FromPrimitive)]
@@ -57,13 +58,17 @@ pub enum NlmRes {
 }
 
 /// The unique identifier of the lock owner.
-pub struct OpaqueHandle([u8; OPAQUE_HANDLE_SIZE]);
+#[derive(Clone, PartialEq)]
+pub struct OpaqueHandle(Vec<u8>);
 
 impl OpaqueHandle {
     /// Creates a new opaque lock owner identifier.
     #[inline]
-    pub fn new(oh: [u8; OPAQUE_HANDLE_SIZE]) -> Self {
-        OpaqueHandle(oh)
+    pub fn new(oh: Vec<u8>) -> io::Result<Self> {
+        if oh.len() > OPAQUE_HANDLE_SIZE {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "name too long"));
+        }
+        Ok(OpaqueHandle(oh))
     }
 
     /// Returns the underlying bytes of the opaque handle.
@@ -79,8 +84,9 @@ mod tests {
 
     #[test]
     fn opaque_handle_bytes() {
-        let bytes = [0x01; OPAQUE_HANDLE_SIZE];
-        let oh = OpaqueHandle::new(bytes);
-        assert_eq!(oh.as_bytes(), bytes.as_slice());
+        let bytes = [0x01; OPAQUE_HANDLE_SIZE].to_vec();
+        let verifier = bytes.clone();
+        let oh = OpaqueHandle::new(bytes).unwrap();
+        assert_eq!(oh.as_bytes(), verifier.as_slice());
     }
 }

--- a/nfs-mamont/src/nlm/share.rs
+++ b/nfs-mamont/src/nlm/share.rs
@@ -101,11 +101,11 @@ impl Nlm4Share {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use crate::consts::nfsv3::NFS3_FHSIZE;
     use crate::consts::nlm::OPAQUE_HANDLE_SIZE;
     use crate::vfs::file::Handle;
+
+    use super::{FileSharingAccess, FileSharingMode, Nlm4Share, OpaqueHandle};
 
     #[test]
     fn new_share_succeeds() {

--- a/nfs-mamont/src/nlm/share.rs
+++ b/nfs-mamont/src/nlm/share.rs
@@ -112,8 +112,9 @@ mod tests {
         let caller_name = "host".to_string();
         let fh = [0; NFS3_FHSIZE];
         let file_handle = Handle(fh);
-        let oh = [1; OPAQUE_HANDLE_SIZE];
-        let opaque_handle = OpaqueHandle::new(oh);
+        let oh = [1; OPAQUE_HANDLE_SIZE].to_vec();
+        let oh_verf = oh.clone();
+        let opaque_handle = OpaqueHandle::new(oh).unwrap();
         let fsh4_mode = FileSharingMode::Read;
         let fsh4_access = FileSharingAccess::ReadWrite;
 
@@ -123,7 +124,7 @@ mod tests {
 
         assert_eq!(lock.caller_name, caller_name);
         assert_eq!(lock.file_handle.0, fh);
-        assert_eq!(lock.opaque_handle.as_bytes(), &oh);
+        assert_eq!(lock.opaque_handle.as_bytes(), oh_verf.as_slice());
         assert_eq!(lock.fsh4_access, fsh4_access);
         assert_eq!(lock.fsh4_mode, fsh4_mode);
     }

--- a/nfs-mamont/src/parser/nlm/mod.rs
+++ b/nfs-mamont/src/parser/nlm/mod.rs
@@ -16,13 +16,7 @@ pub mod unlock;
 /// Decodes the lock-owner identifier from an NLM request.
 /// The wire encoding is a variable-length opaque capped at [`OPAQUE_HANDLE_SIZE`](nlm::OPAQUE_HANDLE_SIZE).
 pub fn opaque_handle(src: &mut impl Read) -> Result<OpaqueHandle> {
-    let bytes = vector(src)?;
-    if bytes.len() > nlm::OPAQUE_HANDLE_SIZE {
-        return Err(Error::BadFileHandle);
-    }
-    let mut buf = [0u8; nlm::OPAQUE_HANDLE_SIZE];
-    buf[..bytes.len()].copy_from_slice(&bytes);
-    Ok(OpaqueHandle::new(buf))
+    OpaqueHandle::new(vector(src)?).map_err(|_| Error::BadFileHandle)
 }
 
 /// Decodes the lock-arguments block shared by every LOCK/UNLOCK/TEST/CANCEL request.

--- a/nfs-mamont/src/serializer/server/nlm/mod.rs
+++ b/nfs-mamont/src/serializer/server/nlm/mod.rs
@@ -170,7 +170,7 @@ mod tests {
                 holder: Some(Nlm4Holder::new(
                     true,
                     1,
-                    OpaqueHandle::new([0; OPAQUE_HANDLE_SIZE]),
+                    OpaqueHandle::new([0; OPAQUE_HANDLE_SIZE].to_vec()).unwrap(),
                     0,
                     0,
                 )),
@@ -189,11 +189,11 @@ mod tests {
     #[test]
     fn test_res_denied_serializes_full_holder() {
         let holder = Nlm4Holder::new(
-            true,                                          // exclusive
-            12345,                                         // system_identifier
-            OpaqueHandle::new([0xAB; OPAQUE_HANDLE_SIZE]), // opaque_handle
-            99,                                            // lock_offset
-            200,                                           // lock_length
+            true,                                                            // exclusive
+            12345,                                                           // system_identifier
+            OpaqueHandle::new([0xAB; OPAQUE_HANDLE_SIZE].to_vec()).unwrap(), // opaque_handle
+            99,                                                              // lock_offset
+            200,                                                             // lock_length
         );
         let res = Nlm4TestRes {
             cookie: cookie(0xDEADBEEF),
@@ -223,8 +223,13 @@ mod tests {
 
     #[test]
     fn test_res_denied_holder_has_correct_offset_in_buffer() {
-        let holder =
-            Nlm4Holder::new(false, 999, OpaqueHandle::new([0x01; OPAQUE_HANDLE_SIZE]), 0, 0);
+        let holder = Nlm4Holder::new(
+            false,
+            999,
+            OpaqueHandle::new([0x01; OPAQUE_HANDLE_SIZE].to_vec()).unwrap(),
+            0,
+            0,
+        );
         let res = Nlm4TestRes {
             cookie: cookie(0),
             test_stat: Nlm4TestReply { stat: Nlm4Stats::Denied, holder: Some(holder) },

--- a/nfs-mamont/src/serializer/server/nlm/mod.rs
+++ b/nfs-mamont/src/serializer/server/nlm/mod.rs
@@ -71,7 +71,6 @@ pub fn test_res(dest: &mut impl Write, res: Nlm4TestRes) -> io::Result<()> {
 mod tests {
     use std::io::Cursor;
 
-    use super::*;
     use crate::consts::nlm::OPAQUE_HANDLE_SIZE;
     use crate::nlm::cookie::Cookie;
     use crate::nlm::holder::Nlm4Holder;
@@ -82,6 +81,8 @@ mod tests {
         unlock::Nlm4UnlockRes,
     };
     use crate::nlm::{Nlm4Stats, OpaqueHandle};
+
+    use super::{cancel_res, lock_res, test_res, unlock_res};
 
     fn cookie(val: u64) -> Cookie {
         Cookie::new(val)

--- a/nfs-mamont/src/service/nlm/cancel.rs
+++ b/nfs-mamont/src/service/nlm/cancel.rs
@@ -1,6 +1,7 @@
-use super::{ActiveLock, NlmService, PendingLock};
 use crate::nlm::procedures::cancel::{Cancel, Nlm4CancelArgs, Nlm4CancelRes};
 use crate::nlm::Nlm4Stats;
+
+use super::{ActiveLock, NlmService, PendingLock};
 
 impl Cancel for NlmService {
     async fn cancel(&self, args: Nlm4CancelArgs) -> Nlm4CancelRes {

--- a/nfs-mamont/src/service/nlm/test.rs
+++ b/nfs-mamont/src/service/nlm/test.rs
@@ -1,6 +1,7 @@
-use super::{ActiveLock, NlmService};
 use crate::nlm::procedures::test::{Nlm4TestArgs, Nlm4TestReply, Nlm4TestRes, Test};
 use crate::nlm::Nlm4Stats;
+
+use super::{ActiveLock, NlmService};
 
 impl Test for NlmService {
     async fn test(&self, args: Nlm4TestArgs) -> Nlm4TestRes {

--- a/nfs-mamont/src/service/nlm/tests/mod.rs
+++ b/nfs-mamont/src/service/nlm/tests/mod.rs
@@ -21,7 +21,7 @@ pub fn fill_fh(value: u8) -> Handle {
 }
 
 pub fn fill_opaque(value: u8) -> OpaqueHandle {
-    OpaqueHandle::new([value; crate::consts::nlm::OPAQUE_HANDLE_SIZE])
+    OpaqueHandle::new([value; crate::consts::nlm::OPAQUE_HANDLE_SIZE].to_vec()).unwrap()
 }
 
 pub fn make_active_lock(

--- a/nfs-mamont/src/service/nlm/tests/mod.rs
+++ b/nfs-mamont/src/service/nlm/tests/mod.rs
@@ -1,12 +1,12 @@
+use crate::consts::nfsv3::NFS3_FHSIZE;
+use crate::nlm::cookie::Cookie;
 use crate::nlm::lock::Nlm4Lock;
 use crate::nlm::procedures::lock::Nlm4LockArgs;
 use crate::nlm::procedures::unlock::Nlm4UnlockArgs;
-
-use super::{ActiveLock, LockRegistry};
-use crate::consts::nfsv3::NFS3_FHSIZE;
-use crate::nlm::cookie::Cookie;
 use crate::nlm::OpaqueHandle;
 use crate::vfs::file::Handle;
+
+use super::{ActiveLock, LockRegistry};
 
 pub const FH_DEFAULT: u8 = 1;
 pub const FH_OTHER: u8 = 2;

--- a/nfs-mamont/src/service/nlm/tests/operations/cancel.rs
+++ b/nfs-mamont/src/service/nlm/tests/operations/cancel.rs
@@ -1,12 +1,12 @@
-use super::super::{
-    fill_fh, fill_opaque, make_lock_args_with_block, make_lock_args_without_block, FH_DEFAULT,
-    LOCK_WHOLE_LENGTH,
-};
 use crate::nlm::cookie::Cookie;
 use crate::nlm::lock::Nlm4Lock;
 use crate::nlm::procedures::cancel::{Cancel, Nlm4CancelArgs};
 use crate::nlm::procedures::lock::Lock;
 use crate::nlm::Nlm4Stats;
+use crate::service::nlm::tests::{
+    fill_fh, fill_opaque, make_lock_args_with_block, make_lock_args_without_block, FH_DEFAULT,
+    LOCK_WHOLE_LENGTH,
+};
 use crate::service::nlm::NlmService;
 
 fn make_cancel_args(fh_value: u8, caller: &str, pid: i32, cookie_value: u64) -> Nlm4CancelArgs {

--- a/nfs-mamont/src/service/nlm/tests/operations/lock.rs
+++ b/nfs-mamont/src/service/nlm/tests/operations/lock.rs
@@ -1,10 +1,10 @@
-use super::super::{
-    make_lock_args_with_block, make_lock_args_without_block, make_unlock_args, FH_DEFAULT,
-    FH_OTHER, LOCK_WHOLE_LENGTH,
-};
 use crate::nlm::procedures::lock::{Lock, Nlm4LockArgs};
 use crate::nlm::procedures::unlock::Unlock;
 use crate::nlm::Nlm4Stats;
+use crate::service::nlm::tests::{
+    make_lock_args_with_block, make_lock_args_without_block, make_unlock_args, FH_DEFAULT,
+    FH_OTHER, LOCK_WHOLE_LENGTH,
+};
 use crate::service::nlm::NlmService;
 
 #[tokio::test]

--- a/nfs-mamont/src/service/nlm/tests/operations/test.rs
+++ b/nfs-mamont/src/service/nlm/tests/operations/test.rs
@@ -1,11 +1,11 @@
-use super::super::{
-    fill_fh, fill_opaque, make_lock_args_without_block, FH_DEFAULT, LOCK_WHOLE_LENGTH,
-};
 use crate::nlm::cookie::Cookie;
 use crate::nlm::lock::Nlm4Lock;
 use crate::nlm::procedures::lock::Lock;
 use crate::nlm::procedures::test::{Nlm4TestArgs, Test};
 use crate::nlm::Nlm4Stats;
+use crate::service::nlm::tests::{
+    fill_fh, fill_opaque, make_lock_args_without_block, FH_DEFAULT, LOCK_WHOLE_LENGTH,
+};
 use crate::service::nlm::NlmService;
 
 fn make_test_args(

--- a/nfs-mamont/src/service/nlm/tests/operations/unlock.rs
+++ b/nfs-mamont/src/service/nlm/tests/operations/unlock.rs
@@ -1,10 +1,10 @@
-use super::super::{
-    make_lock_args_with_block, make_lock_args_without_block, make_unlock_args, FH_DEFAULT,
-    LOCK_WHOLE_LENGTH,
-};
 use crate::nlm::procedures::lock::Lock;
 use crate::nlm::procedures::unlock::Unlock;
 use crate::nlm::Nlm4Stats;
+use crate::service::nlm::tests::{
+    make_lock_args_with_block, make_lock_args_without_block, make_unlock_args, FH_DEFAULT,
+    LOCK_WHOLE_LENGTH,
+};
 use crate::service::nlm::NlmService;
 
 #[tokio::test]

--- a/nfs-mamont/src/service/nlm/tests/ranges.rs
+++ b/nfs-mamont/src/service/nlm/tests/ranges.rs
@@ -1,4 +1,4 @@
-use super::super::ranges_overlap;
+use crate::service::nlm::ranges_overlap;
 
 #[test]
 fn overlapping_ranges_detect_overlap() {

--- a/nfs-mamont/src/service/nlm/tests/registry.rs
+++ b/nfs-mamont/src/service/nlm/tests/registry.rs
@@ -1,6 +1,6 @@
-use super::super::ActiveLock;
+use crate::service::nlm::{ActiveLock, LockRegistry};
+
 use super::{fill_fh, make_active_lock, push_lock, FH_DEFAULT, FH_OTHER, LOCK_WHOLE_LENGTH};
-use crate::service::nlm::LockRegistry;
 
 fn other_request() -> ActiveLock {
     make_active_lock("other", 999, false, 0, 0, 0)


### PR DESCRIPTION
Little refactor: since client defines format of `nlm::OpaqueHandle` it does not necessarily use all `OPAQUE_HANDLE_SIZE` bytes, so probably we don't need to store exactly `OPAQUE_HANDLE_SIZE` in array:
```
pub struct OpaqueHandle([u8; OPAQUE_HANDLE_SIZE]);
```
I suggest we move to vector with size checks in constructor, so we could save some space

Resolves: #251