### PR TITLE
xdr: explicit message size calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,12 +390,23 @@ dependencies = [
  "async-channel",
  "byteorder",
  "crossbeam-queue",
+ "nfs-mamont-derive",
  "num-derive",
  "num-traits",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "trait-variant",
+]
+
+[[package]]
+name = "nfs-mamont-derive"
+version = "0.0.0"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -482,6 +493,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -722,7 +742,7 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
@@ -735,6 +755,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -932,6 +973,9 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["nfs-mamont", "mirror_fs"]
+members = ["nfs-mamont", "nfs-mamont-derive", "mirror_fs"]
 resolver = "2"
 
 [workspace.package]
@@ -22,3 +22,8 @@ trait-variant = "0.1.2"
 
 # Internal dependencies
 nfs-mamont.path = "nfs-mamont"
+nfs-mamont-derive.path = "nfs-mamont-derive"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }
+proc-macro-crate = "3.2"

--- a/nfs-mamont-derive/Cargo.toml
+++ b/nfs-mamont-derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "nfs-mamont-derive"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+publish = false
+rust-version.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
+proc-macro-crate.workspace = true

--- a/nfs-mamont-derive/src/lib.rs
+++ b/nfs-mamont-derive/src/lib.rs
@@ -7,14 +7,19 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields, Meta, Path};
 pub fn derive_xdr_size(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
-    let crate_path = crate_path(&input.attrs);
 
-    let mut generics = input.generics.clone();
-    let xdr_size_bound = format!("{}::xdr::XDRSize", path_to_string(&crate_path));
-    for param in generics.type_params_mut() {
-        param.bounds.push(syn::parse_str(&xdr_size_bound).expect("XDRSize bound"));
+    let crate_path = crate_path(&input.attrs);
+    let xdr_size = parse_xdr_size_path(&crate_path);
+
+    let original_generics = input.generics.clone();
+    let mut impl_generics_src = input.generics.clone();
+
+    for param in impl_generics_src.type_params_mut() {
+        param.bounds.push(syn::parse_quote!(#xdr_size));
     }
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let (impl_generics, _, where_clause) = impl_generics_src.split_for_impl();
+    let (_, ty_generics, _) = original_generics.split_for_impl();
 
     let body = match &input.data {
         Data::Struct(data) => struct_body(&crate_path, &data.fields),
@@ -25,8 +30,6 @@ pub fn derive_xdr_size(input: TokenStream) -> TokenStream {
                 .into();
         }
     };
-
-    let xdr_size = parse_xdr_size_path(&crate_path);
 
     quote! {
         impl #impl_generics #xdr_size for #name #ty_generics #where_clause {
@@ -43,10 +46,13 @@ fn crate_path(attrs: &[syn::Attribute]) -> Path {
         if !attr.path().is_ident("xdr") {
             continue;
         }
+
         let Meta::List(list) = &attr.meta else {
             continue;
         };
-        let mut crate_name = None;
+
+        let mut crate_name_override = None;
+
         for nested in list
             .parse_args_with(syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated)
             .unwrap_or_default()
@@ -54,20 +60,25 @@ fn crate_path(attrs: &[syn::Attribute]) -> Path {
             let Meta::NameValue(name_value) = nested else {
                 continue;
             };
+
             if !name_value.path.is_ident("crate") {
                 continue;
             }
+
             let syn::Expr::Lit(expr_lit) = name_value.value else {
                 continue;
             };
+
             let syn::Lit::Str(lit_str) = expr_lit.lit else {
                 continue;
             };
-            crate_name = Some(lit_str);
+
+            crate_name_override = Some(lit_str);
         }
-        if let Some(lit_str) = crate_name {
+
+        if let Some(lit_str) = crate_name_override {
             return syn::parse_str::<Path>(&lit_str.value())
-                .unwrap_or_else(|_err| default_crate_path());
+                .unwrap_or_else(|_| default_crate_path());
         }
     }
 
@@ -76,14 +87,15 @@ fn crate_path(attrs: &[syn::Attribute]) -> Path {
 
 fn default_crate_path() -> Path {
     match crate_name("nfs_mamont") {
-        Ok(FoundCrate::Itself) | Err(_) => syn::parse_str("crate").expect("crate path"),
+        Ok(FoundCrate::Itself) => syn::parse_str("crate").expect("crate path"),
         Ok(FoundCrate::Name(name)) => syn::parse_str(&name)
             .unwrap_or_else(|_| syn::parse_str("nfs_mamont").expect("nfs_mamont path")),
+        Err(_) => syn::parse_str("crate").expect("crate path"),
     }
 }
 
 fn path_to_string(path: &Path) -> String {
-    quote::quote!(#path).to_string().replace(' ', "")
+    quote!(#path).to_string().replace(' ', "")
 }
 
 fn parse_xdr_size_path(crate_path: &Path) -> Path {
@@ -97,18 +109,26 @@ fn struct_body(crate_path: &Path, fields: &Fields) -> proc_macro2::TokenStream {
     match fields {
         Fields::Named(fields) => {
             let sizes = fields.named.iter().map(|field| {
-                let ident = &field.ident;
+                let ident = field.ident.as_ref().expect("named field");
                 quote! { #xdr_size::xdr_size(&self.#ident) }
             });
-            quote! { 0 #(+ #sizes)* }
+
+            quote! {
+                0 #(+ #sizes)*
+            }
         }
+
         Fields::Unnamed(fields) => {
             let sizes = fields.unnamed.iter().enumerate().map(|(idx, _)| {
                 let index = syn::Index::from(idx);
                 quote! { #xdr_size::xdr_size(&self.#index) }
             });
-            quote! { 0 #(+ #sizes)* }
+
+            quote! {
+                0 #(+ #sizes)*
+            }
         }
+
         Fields::Unit => quote! { 0 },
     }
 }
@@ -122,18 +142,26 @@ fn enum_body(
 
     let variants = data.variants.iter().map(|variant| {
         let variant_ident = &variant.ident;
+
         match &variant.fields {
             Fields::Named(fields) => {
-                let idents = fields.named.iter().map(|field| &field.ident);
-                let sizes = idents.clone().map(|ident| {
+                let bindings: Vec<_> = fields
+                    .named
+                    .iter()
+                    .map(|field| field.ident.clone().expect("named enum field"))
+                    .collect();
+
+                let sizes = bindings.iter().map(|ident| {
                     quote! { #xdr_size::xdr_size(#ident) }
                 });
+
                 quote! {
-                    #name::#variant_ident { #( #idents ),* } => {
+                    #name::#variant_ident { #( ref #bindings ),* } => {
                         Self::INTEGER #(+ #sizes)*
                     }
                 }
             }
+
             Fields::Unnamed(fields) => {
                 let bindings: Vec<_> = fields
                     .unnamed
@@ -143,15 +171,18 @@ fn enum_body(
                         syn::Ident::new(&format!("field_{idx}"), proc_macro2::Span::call_site())
                     })
                     .collect();
+
                 let sizes = bindings.iter().map(|ident| {
                     quote! { #xdr_size::xdr_size(#ident) }
                 });
+
                 quote! {
-                    #name::#variant_ident( #( #bindings ),* ) => {
+                    #name::#variant_ident( #( ref #bindings ),* ) => {
                         Self::INTEGER #(+ #sizes)*
                     }
                 }
             }
+
             Fields::Unit => {
                 quote! {
                     #name::#variant_ident => Self::INTEGER
@@ -162,7 +193,7 @@ fn enum_body(
 
     quote! {
         match self {
-            #(#variants,)*
+            #(#variants),*
         }
     }
 }

--- a/nfs-mamont-derive/src/lib.rs
+++ b/nfs-mamont-derive/src/lib.rs
@@ -1,7 +1,5 @@
-//! Proc-macro derives for [`nfs_mamont::xdr::XDRSize`].
-
-use proc_macro_crate::{crate_name, FoundCrate};
 use proc_macro::TokenStream;
+use proc_macro_crate::{crate_name, FoundCrate};
 use quote::quote;
 use syn::{parse_macro_input, Data, DeriveInput, Fields, Meta, Path};
 
@@ -14,9 +12,7 @@ pub fn derive_xdr_size(input: TokenStream) -> TokenStream {
     let mut generics = input.generics.clone();
     let xdr_size_bound = format!("{}::xdr::XDRSize", path_to_string(&crate_path));
     for param in generics.type_params_mut() {
-        param
-            .bounds
-            .push(syn::parse_str(&xdr_size_bound).expect("XDRSize bound"));
+        param.bounds.push(syn::parse_str(&xdr_size_bound).expect("XDRSize bound"));
     }
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
@@ -51,10 +47,9 @@ fn crate_path(attrs: &[syn::Attribute]) -> Path {
             continue;
         };
         let mut crate_name = None;
-        for nested in list.parse_args_with(
-            syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
-        )
-        .unwrap_or_default()
+        for nested in list
+            .parse_args_with(syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated)
+            .unwrap_or_default()
         {
             let Meta::NameValue(name_value) = nested else {
                 continue;
@@ -71,9 +66,8 @@ fn crate_path(attrs: &[syn::Attribute]) -> Path {
             crate_name = Some(lit_str);
         }
         if let Some(lit_str) = crate_name {
-            return syn::parse_str::<Path>(&lit_str.value()).unwrap_or_else(|_err| {
-                default_crate_path()
-            });
+            return syn::parse_str::<Path>(&lit_str.value())
+                .unwrap_or_else(|_err| default_crate_path());
         }
     }
 
@@ -83,9 +77,8 @@ fn crate_path(attrs: &[syn::Attribute]) -> Path {
 fn default_crate_path() -> Path {
     match crate_name("nfs_mamont") {
         Ok(FoundCrate::Itself) | Err(_) => syn::parse_str("crate").expect("crate path"),
-        Ok(FoundCrate::Name(name)) => syn::parse_str(&name).unwrap_or_else(|_| {
-            syn::parse_str("nfs_mamont").expect("nfs_mamont path")
-        }),
+        Ok(FoundCrate::Name(name)) => syn::parse_str(&name)
+            .unwrap_or_else(|_| syn::parse_str("nfs_mamont").expect("nfs_mamont path")),
     }
 }
 
@@ -120,7 +113,11 @@ fn struct_body(crate_path: &Path, fields: &Fields) -> proc_macro2::TokenStream {
     }
 }
 
-fn enum_body(crate_path: &Path, name: &syn::Ident, data: &syn::DataEnum) -> proc_macro2::TokenStream {
+fn enum_body(
+    crate_path: &Path,
+    name: &syn::Ident,
+    data: &syn::DataEnum,
+) -> proc_macro2::TokenStream {
     let xdr_size = parse_xdr_size_path(crate_path);
 
     let variants = data.variants.iter().map(|variant| {
@@ -143,10 +140,7 @@ fn enum_body(crate_path: &Path, name: &syn::Ident, data: &syn::DataEnum) -> proc
                     .iter()
                     .enumerate()
                     .map(|(idx, _)| {
-                        syn::Ident::new(
-                            &format!("field_{idx}"),
-                            proc_macro2::Span::call_site(),
-                        )
+                        syn::Ident::new(&format!("field_{idx}"), proc_macro2::Span::call_site())
                     })
                     .collect();
                 let sizes = bindings.iter().map(|ident| {

--- a/nfs-mamont-derive/src/lib.rs
+++ b/nfs-mamont-derive/src/lib.rs
@@ -1,0 +1,174 @@
+//! Proc-macro derives for [`nfs_mamont::xdr::XDRSize`].
+
+use proc_macro_crate::{crate_name, FoundCrate};
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Fields, Meta, Path};
+
+#[proc_macro_derive(XDRSize, attributes(xdr))]
+pub fn derive_xdr_size(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    let crate_path = crate_path(&input.attrs);
+
+    let mut generics = input.generics.clone();
+    let xdr_size_bound = format!("{}::xdr::XDRSize", path_to_string(&crate_path));
+    for param in generics.type_params_mut() {
+        param
+            .bounds
+            .push(syn::parse_str(&xdr_size_bound).expect("XDRSize bound"));
+    }
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let body = match &input.data {
+        Data::Struct(data) => struct_body(&crate_path, &data.fields),
+        Data::Enum(data) => enum_body(&crate_path, name, data),
+        Data::Union(_) => {
+            return syn::Error::new_spanned(name, "XDRSize cannot be derived for unions")
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    let xdr_size = parse_xdr_size_path(&crate_path);
+
+    quote! {
+        impl #impl_generics #xdr_size for #name #ty_generics #where_clause {
+            fn xdr_size(&self) -> usize {
+                #body
+            }
+        }
+    }
+    .into()
+}
+
+fn crate_path(attrs: &[syn::Attribute]) -> Path {
+    for attr in attrs {
+        if !attr.path().is_ident("xdr") {
+            continue;
+        }
+        let Meta::List(list) = &attr.meta else {
+            continue;
+        };
+        let mut crate_name = None;
+        for nested in list.parse_args_with(
+            syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
+        )
+        .unwrap_or_default()
+        {
+            let Meta::NameValue(name_value) = nested else {
+                continue;
+            };
+            if !name_value.path.is_ident("crate") {
+                continue;
+            }
+            let syn::Expr::Lit(expr_lit) = name_value.value else {
+                continue;
+            };
+            let syn::Lit::Str(lit_str) = expr_lit.lit else {
+                continue;
+            };
+            crate_name = Some(lit_str);
+        }
+        if let Some(lit_str) = crate_name {
+            return syn::parse_str::<Path>(&lit_str.value()).unwrap_or_else(|_err| {
+                default_crate_path()
+            });
+        }
+    }
+
+    default_crate_path()
+}
+
+fn default_crate_path() -> Path {
+    match crate_name("nfs_mamont") {
+        Ok(FoundCrate::Itself) | Err(_) => syn::parse_str("crate").expect("crate path"),
+        Ok(FoundCrate::Name(name)) => syn::parse_str(&name).unwrap_or_else(|_| {
+            syn::parse_str("nfs_mamont").expect("nfs_mamont path")
+        }),
+    }
+}
+
+fn path_to_string(path: &Path) -> String {
+    quote::quote!(#path).to_string().replace(' ', "")
+}
+
+fn parse_xdr_size_path(crate_path: &Path) -> Path {
+    syn::parse_str::<Path>(&format!("{}::xdr::XDRSize", path_to_string(crate_path)))
+        .expect("xdr size path")
+}
+
+fn struct_body(crate_path: &Path, fields: &Fields) -> proc_macro2::TokenStream {
+    let xdr_size = parse_xdr_size_path(crate_path);
+
+    match fields {
+        Fields::Named(fields) => {
+            let sizes = fields.named.iter().map(|field| {
+                let ident = &field.ident;
+                quote! { #xdr_size::xdr_size(&self.#ident) }
+            });
+            quote! { 0 #(+ #sizes)* }
+        }
+        Fields::Unnamed(fields) => {
+            let sizes = fields.unnamed.iter().enumerate().map(|(idx, _)| {
+                let index = syn::Index::from(idx);
+                quote! { #xdr_size::xdr_size(&self.#index) }
+            });
+            quote! { 0 #(+ #sizes)* }
+        }
+        Fields::Unit => quote! { 0 },
+    }
+}
+
+fn enum_body(crate_path: &Path, name: &syn::Ident, data: &syn::DataEnum) -> proc_macro2::TokenStream {
+    let xdr_size = parse_xdr_size_path(crate_path);
+
+    let variants = data.variants.iter().map(|variant| {
+        let variant_ident = &variant.ident;
+        match &variant.fields {
+            Fields::Named(fields) => {
+                let idents = fields.named.iter().map(|field| &field.ident);
+                let sizes = idents.clone().map(|ident| {
+                    quote! { #xdr_size::xdr_size(#ident) }
+                });
+                quote! {
+                    #name::#variant_ident { #( #idents ),* } => {
+                        Self::INTEGER #(+ #sizes)*
+                    }
+                }
+            }
+            Fields::Unnamed(fields) => {
+                let bindings: Vec<_> = fields
+                    .unnamed
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, _)| {
+                        syn::Ident::new(
+                            &format!("field_{idx}"),
+                            proc_macro2::Span::call_site(),
+                        )
+                    })
+                    .collect();
+                let sizes = bindings.iter().map(|ident| {
+                    quote! { #xdr_size::xdr_size(#ident) }
+                });
+                quote! {
+                    #name::#variant_ident( #( #bindings ),* ) => {
+                        Self::INTEGER #(+ #sizes)*
+                    }
+                }
+            }
+            Fields::Unit => {
+                quote! {
+                    #name::#variant_ident => Self::INTEGER
+                }
+            }
+        }
+    });
+
+    quote! {
+        match self {
+            #(#variants,)*
+        }
+    }
+}

--- a/nfs-mamont/Cargo.toml
+++ b/nfs-mamont/Cargo.toml
@@ -21,3 +21,4 @@ tracing-subscriber.workspace = true
 async-channel.workspace = true
 crossbeam-queue.workspace = true
 trait-variant.workspace = true
+nfs-mamont-derive.workspace = true

--- a/nfs-mamont/src/allocator/mod.rs
+++ b/nfs-mamont/src/allocator/mod.rs
@@ -15,6 +15,8 @@ use std::sync::Arc;
 use crossbeam_queue::ArrayQueue;
 use tokio::sync::Semaphore;
 
+use crate::xdr;
+
 pub use buffer::UnownedBuffer;
 pub use slice::Slice;
 
@@ -40,7 +42,7 @@ impl Drop for AllocatorState {
 /// Abstract buffer type returned by [`Allocator`].
 ///
 /// Implementations provide chunked read/write access to the allocated memory.
-pub trait Buffer: Send + Sync {
+pub trait Buffer: Send + Sync + xdr::XDRSize {
     /// Returns an iterator over read-only byte chunks of this buffer.
     fn chunks(&self) -> impl Iterator<Item = &[u8]> + Send + '_;
 

--- a/nfs-mamont/src/allocator/slice.rs
+++ b/nfs-mamont/src/allocator/slice.rs
@@ -2,6 +2,8 @@
 
 use std::sync::Arc;
 
+use crate::xdr;
+
 use super::Buffer;
 
 /// Represents bounded by custome range list of buffers.
@@ -241,6 +243,12 @@ impl Buffer for Slice {
 
     fn empty() -> Self {
         Self::empty()
+    }
+}
+
+impl xdr::XDRSize for Slice {
+    fn xdr_size(&self) -> usize {
+        Self::INTEGER + ((self.len() + (Self::ALIGNMENT - 1)) & !(Self::ALIGNMENT - 1))
     }
 }
 

--- a/nfs-mamont/src/lib.rs
+++ b/nfs-mamont/src/lib.rs
@@ -12,6 +12,7 @@ mod serializer;
 pub mod service;
 mod task;
 pub mod vfs;
+pub mod xdr;
 
 use std::sync::Arc;
 

--- a/nfs-mamont/src/mount/dump.rs
+++ b/nfs-mamont/src/mount/dump.rs
@@ -2,6 +2,7 @@
 //!
 //! as defined in RFC 1813 section 5.2.2.
 //! <https://datatracker.ietf.org/doc/html/rfc1813#section-5.2.2>.
+use crate::xdr;
 
 use super::MountEntry;
 
@@ -13,6 +14,14 @@ pub struct Success {
     /// of clients that have requested file handles with the MNT procedure.
     pub mount_list: Vec<MountEntry>,
 }
+
+impl xdr::XDRSize for Success {
+    fn xdr_size(&self) -> usize {
+        self.mount_list.iter().map(|entry| entry.xdr_size() + Self::INTEGER).sum::<usize>()
+            + Self::INTEGER
+    }
+}
+
 #[trait_variant::make(Send)]
 pub trait Dump {
     /// Retrieves the list of remotely mounted file systems.

--- a/nfs-mamont/src/mount/export.rs
+++ b/nfs-mamont/src/mount/export.rs
@@ -2,6 +2,7 @@
 //!
 //! as defined in RFC 1813 section 5.2.5.
 //! <https://datatracker.ietf.org/doc/html/rfc1813#section-5.2.5>.
+use crate::xdr::XDRSize;
 
 use super::ExportEntry;
 
@@ -12,6 +13,14 @@ pub struct Success {
     /// to mount the specified directory.
     pub exports: Vec<ExportEntry>,
 }
+
+impl XDRSize for Success {
+    fn xdr_size(&self) -> usize {
+        self.exports.iter().map(|entry| entry.xdr_size() + Self::INTEGER).sum::<usize>()
+            + Self::INTEGER
+    }
+}
+
 #[trait_variant::make(Send)]
 pub trait Export {
     /// Retrieves a vector of all the exported file systems and which clients

--- a/nfs-mamont/src/mount/mnt.rs
+++ b/nfs-mamont/src/mount/mnt.rs
@@ -5,12 +5,13 @@
 
 use std::net::SocketAddr;
 
+use nfs_mamont_derive::XDRSize;
 use num_derive::{FromPrimitive, ToPrimitive};
 
 use crate::rpc::{AuthFlavor, OpaqueAuth};
 use crate::vfs::file;
 
-#[derive(Debug, ToPrimitive, FromPrimitive)]
+#[derive(Debug, ToPrimitive, FromPrimitive, XDRSize)]
 /// Possible MOUNT errors
 pub enum Fail {
     /// Not owner
@@ -34,6 +35,7 @@ pub enum Fail {
 }
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// The file handle for the mounted directory.
     /// This file handle may be used in the NFS protocol.

--- a/nfs-mamont/src/mount/mod.rs
+++ b/nfs-mamont/src/mount/mod.rs
@@ -60,6 +60,7 @@ impl xdr::XDRSize for ExportEntry {
 }
 
 /// Wrapper for mount procedure result bodies.
+#[derive(XDRSize)]
 pub enum MountRes {
     Null,
     Mount(Result<mnt::Success, mnt::Fail>),

--- a/nfs-mamont/src/mount/mod.rs
+++ b/nfs-mamont/src/mount/mod.rs
@@ -8,11 +8,13 @@ pub mod umntall;
 
 use std::io;
 
+use nfs_mamont_derive::XDRSize;
+
 use crate::consts::mount::MOUNT_HOST_NAME_LEN;
 use crate::vfs::file;
-
+use crate::xdr;
 /// Client host name.
-#[derive(Clone, Debug, PartialEq, Hash, Eq)]
+#[derive(Clone, Debug, PartialEq, Hash, Eq, XDRSize)]
 pub struct HostName(String);
 
 impl HostName {
@@ -30,7 +32,7 @@ impl HostName {
 
 /// Entry of the list maintained on the server of clients
 /// that have requested file handles with the MNT procedure.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, XDRSize)]
 pub struct MountEntry {
     /// Name of the client host that is sending RPC.
     pub hostname: HostName,
@@ -47,6 +49,14 @@ pub struct ExportEntry {
     /// Client host names. They are implementation specific
     /// and cannot be directly interpreted by clients.
     pub names: Vec<HostName>,
+}
+
+impl xdr::XDRSize for ExportEntry {
+    fn xdr_size(&self) -> usize {
+        self.directory.xdr_size()
+            + Self::INTEGER
+            + self.names.iter().map(|name| name.xdr_size() + Self::INTEGER).sum::<usize>()
+    }
 }
 
 /// Wrapper for mount procedure result bodies.

--- a/nfs-mamont/src/mount/mod.rs
+++ b/nfs-mamont/src/mount/mod.rs
@@ -60,7 +60,6 @@ impl xdr::XDRSize for ExportEntry {
 }
 
 /// Wrapper for mount procedure result bodies.
-#[derive(XDRSize)]
 pub enum MountRes {
     Null,
     Mount(Result<mnt::Success, mnt::Fail>),
@@ -68,6 +67,22 @@ pub enum MountRes {
     Export(export::Success),
     Dump(dump::Success),
     UnmountAll,
+}
+
+impl xdr::XDRSize for MountRes {
+    fn xdr_size(&self) -> usize {
+        match self {
+            MountRes::Null => 0,
+            MountRes::Mount(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            MountRes::Unmount => 0,
+            MountRes::Dump(res) => res.xdr_size(),
+            MountRes::UnmountAll => 0,
+            MountRes::Export(res) => res.xdr_size(),
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/nfs-mamont/src/nlm/cookie.rs
+++ b/nfs-mamont/src/nlm/cookie.rs
@@ -1,5 +1,7 @@
+use nfs_mamont_derive::XDRSize;
+
 /// Identifies a point in the directory.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, XDRSize)]
 pub struct Cookie(u64);
 
 impl Cookie {

--- a/nfs-mamont/src/nlm/holder.rs
+++ b/nfs-mamont/src/nlm/holder.rs
@@ -2,9 +2,12 @@
 //!
 //! Contains [`Nlm4Holder`] which represents the current holder of a lock.
 
+use nfs_mamont_derive::XDRSize;
+
 use super::OpaqueHandle;
 
 /// This structure indicates the holder of a lock.
+#[derive(XDRSize)]
 pub struct Nlm4Holder {
     /// Tells whether the holder has an exclusive lock or a shared lock.
     pub exclusive: bool,

--- a/nfs-mamont/src/nlm/mod.rs
+++ b/nfs-mamont/src/nlm/mod.rs
@@ -10,15 +10,15 @@ pub mod share;
 
 use std::io;
 
-use num_derive::{FromPrimitive, ToPrimitive};
-
 use crate::consts::nlm::OPAQUE_HANDLE_SIZE;
 use crate::nlm::procedures::{
     cancel::Nlm4CancelRes, lock::Nlm4LockRes, test::Nlm4TestRes, unlock::Nlm4UnlockRes,
 };
+use nfs_mamont_derive::XDRSize;
+use num_derive::{FromPrimitive, ToPrimitive};
 
 /// `Nlm4Stats` indicates the success or failure of a call.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, ToPrimitive, FromPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, ToPrimitive, FromPrimitive, XDRSize)]
 pub enum Nlm4Stats {
     /// The call was successfully completed, and the lock was set.
     Granted = 0,
@@ -65,7 +65,7 @@ pub enum NlmRes {
 }
 
 /// The unique identifier of the lock owner.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, XDRSize)]
 pub struct OpaqueHandle(Vec<u8>);
 
 impl OpaqueHandle {

--- a/nfs-mamont/src/nlm/mod.rs
+++ b/nfs-mamont/src/nlm/mod.rs
@@ -14,6 +14,7 @@ use crate::consts::nlm::OPAQUE_HANDLE_SIZE;
 use crate::nlm::procedures::{
     cancel::Nlm4CancelRes, lock::Nlm4LockRes, test::Nlm4TestRes, unlock::Nlm4UnlockRes,
 };
+use crate::xdr;
 use nfs_mamont_derive::XDRSize;
 use num_derive::{FromPrimitive, ToPrimitive};
 
@@ -51,7 +52,6 @@ pub enum Nlm4Stats {
 }
 
 /// Wrapper for all supported NLMv4 procedure result types.
-#[derive(XDRSize)]
 pub enum NlmRes {
     /// NLM NULL procedure — no data.
     Null,
@@ -63,6 +63,18 @@ pub enum NlmRes {
     Test(Box<Nlm4TestRes>),
     /// NLM CANCEL procedure response.
     Cancel(Nlm4CancelRes),
+}
+
+impl xdr::XDRSize for NlmRes {
+    fn xdr_size(&self) -> usize {
+        match self {
+            NlmRes::Null => 0,
+            NlmRes::Lock(res) => res.xdr_size(),
+            NlmRes::Unlock(res) => res.xdr_size(),
+            NlmRes::Test(res) => res.xdr_size(),
+            NlmRes::Cancel(res) => res.xdr_size(),
+        }
+    }
 }
 
 /// The unique identifier of the lock owner.

--- a/nfs-mamont/src/nlm/mod.rs
+++ b/nfs-mamont/src/nlm/mod.rs
@@ -51,6 +51,7 @@ pub enum Nlm4Stats {
 }
 
 /// Wrapper for all supported NLMv4 procedure result types.
+#[derive(XDRSize)]
 pub enum NlmRes {
     /// NLM NULL procedure — no data.
     Null,

--- a/nfs-mamont/src/nlm/procedures/cancel.rs
+++ b/nfs-mamont/src/nlm/procedures/cancel.rs
@@ -3,6 +3,8 @@
 //! Defines argument and result structures for the `NLMPROC4_CANCEL`
 //! operation as specified in RFC 1813.
 
+use nfs_mamont_derive::XDRSize;
+
 use crate::nlm::cookie::Cookie;
 use crate::nlm::lock::Nlm4Lock;
 use crate::nlm::Nlm4Stats;
@@ -24,6 +26,7 @@ pub struct Nlm4CancelArgs {
 /// NLM CANCEL result.
 ///
 /// Returned by [`NLMPROC4_CANCEL`](crate::consts::nlm::NLMPROC4_CANCEL) procedure.
+#[derive(XDRSize)]
 pub struct Nlm4CancelRes {
     /// Transaction identifier for matching request/response.
     pub cookie: Cookie,

--- a/nfs-mamont/src/nlm/procedures/lock.rs
+++ b/nfs-mamont/src/nlm/procedures/lock.rs
@@ -6,6 +6,7 @@
 use crate::nlm::cookie::Cookie;
 use crate::nlm::lock::Nlm4Lock;
 use crate::nlm::Nlm4Stats;
+use nfs_mamont_derive::XDRSize;
 
 /// Defines the information needed to request a lock on a server.
 pub struct Nlm4LockArgs {
@@ -27,6 +28,7 @@ pub struct Nlm4LockArgs {
 /// NLM LOCK result.
 ///
 /// Returned by [`NLMPROC4_LOCK`](crate::consts::nlm::NLMPROC4_LOCK) procedure.
+#[derive(XDRSize)]
 pub struct Nlm4LockRes {
     /// Transaction identifier for matching request/response.
     pub cookie: Cookie,

--- a/nfs-mamont/src/nlm/procedures/test.rs
+++ b/nfs-mamont/src/nlm/procedures/test.rs
@@ -2,12 +2,13 @@
 //!
 //! Defines argument and result structures for the `NLMPROC4_TEST`
 //! operation as specified in RFC 1813.
+use nfs_mamont_derive::XDRSize;
 
 use crate::nlm::cookie::Cookie;
 use crate::nlm::holder::Nlm4Holder;
 use crate::nlm::lock::Nlm4Lock;
 use crate::nlm::Nlm4Stats;
-use nfs_mamont_derive::XDRSize;
+use crate::xdr;
 
 /// NLM TEST arguments.
 ///
@@ -35,12 +36,21 @@ pub struct Nlm4TestRes {
 /// NLM TEST reply status union.
 ///
 /// Contains either granted status (no holder), or denied with holder info.
-#[derive(XDRSize)]
 pub struct Nlm4TestReply {
     /// Status code (Granted, Denied, etc.).
     pub stat: Nlm4Stats,
     /// Present only when stat is Denied — info about current lock holder.
     pub holder: Option<Nlm4Holder>,
+}
+
+impl xdr::XDRSize for Nlm4TestReply {
+    fn xdr_size(&self) -> usize {
+        if let Some(ref x) = self.holder {
+            x.xdr_size() + self.stat.xdr_size()
+        } else {
+            self.stat.xdr_size()
+        }
+    }
 }
 
 /// Trait for handling NLMv4 `TEST` procedure calls.

--- a/nfs-mamont/src/nlm/procedures/test.rs
+++ b/nfs-mamont/src/nlm/procedures/test.rs
@@ -7,6 +7,7 @@ use crate::nlm::cookie::Cookie;
 use crate::nlm::holder::Nlm4Holder;
 use crate::nlm::lock::Nlm4Lock;
 use crate::nlm::Nlm4Stats;
+use nfs_mamont_derive::XDRSize;
 
 /// NLM TEST arguments.
 ///
@@ -23,6 +24,7 @@ pub struct Nlm4TestArgs {
 /// NLM TEST result.
 ///
 /// Returned by [`NLMPROC4_TEST`](crate::consts::nlm::NLMPROC4_TEST) procedure.
+#[derive(XDRSize)]
 pub struct Nlm4TestRes {
     /// Transaction identifier for matching request/response.
     pub cookie: Cookie,
@@ -33,6 +35,7 @@ pub struct Nlm4TestRes {
 /// NLM TEST reply status union.
 ///
 /// Contains either granted status (no holder), or denied with holder info.
+#[derive(XDRSize)]
 pub struct Nlm4TestReply {
     /// Status code (Granted, Denied, etc.).
     pub stat: Nlm4Stats,

--- a/nfs-mamont/src/nlm/procedures/unlock.rs
+++ b/nfs-mamont/src/nlm/procedures/unlock.rs
@@ -3,6 +3,8 @@
 //! Defines argument and result structures for the `NLMPROC4_UNLOCK`
 //! operation as specified in RFC 1813.
 
+use nfs_mamont_derive::XDRSize;
+
 use crate::nlm::cookie::Cookie;
 use crate::nlm::lock::Nlm4Lock;
 use crate::nlm::Nlm4Stats;
@@ -18,6 +20,7 @@ pub struct Nlm4UnlockArgs {
 /// NLM UNLOCK result.
 ///
 /// Returned by [`NLMPROC4_UNLOCK`](crate::consts::nlm::NLMPROC4_UNLOCK) procedure.
+#[derive(XDRSize)]
 pub struct Nlm4UnlockRes {
     /// Transaction identifier for matching request/response.
     pub cookie: Cookie,

--- a/nfs-mamont/src/rpc.rs
+++ b/nfs-mamont/src/rpc.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::string::FromUtf8Error;
 
+use nfs_mamont_derive::XDRSize;
 use num_derive::{FromPrimitive, ToPrimitive};
 
 pub const RPC_VERSION: u32 = 2;
@@ -48,7 +49,7 @@ pub enum ReplyBody {
 }
 
 /// Authentication flavors.
-#[derive(Debug, Clone, ToPrimitive, FromPrimitive)]
+#[derive(Debug, Clone, ToPrimitive, FromPrimitive, XDRSize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum AuthFlavor {
     None = 0,

--- a/nfs-mamont/src/rpc.rs
+++ b/nfs-mamont/src/rpc.rs
@@ -59,7 +59,7 @@ pub enum AuthFlavor {
     RpcSecGss = 6,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, XDRSize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct OpaqueAuth {
     pub flavor: AuthFlavor,

--- a/nfs-mamont/src/serializer/server/serialize_struct.rs
+++ b/nfs-mamont/src/serializer/server/serialize_struct.rs
@@ -41,10 +41,6 @@ const MAX_FRAGMENT_SIZE: usize = 0x7FFF_FFFF;
 /// (<https://datatracker.ietf.org/doc/html/rfc5531#autoid-19>)
 const HEADER_MASK: usize = 0x8000_0000;
 
-/// Size of RMS header
-/// (<https://datatracker.ietf.org/doc/html/rfc5531#autoid-19>)
-const HEADER_SIZE: usize = 4;
-
 macro_rules! nfs_result {
     ($self:expr, $res:expr, $ok_fn:path, $fail_fn:path) => {{
         match $res {
@@ -219,12 +215,10 @@ impl<B: Buffer, T: AsyncWrite + Unpin> Serializer<B, T> {
         }
     }
 
-    /// Serializes [`ProcReply`] into a complete XDR RPC reply and writes it to the underlying writer.
+    /// Serializes [`RPCReply`] into a complete XDR RPC reply and writes it to the underlying writer.
     ///
     /// ## Arguments:
-    /// *   `reply` - procedure result of [`ProcReply`] type
-    /// *   `verifier` - an authentication verifier of [`OpaqueAuth`] type that the server generates in
-    ///     order to validate itself to the client
+    /// *   `reply` - procedure result of [`RPCReply`] type
     ///
     /// TODO:(<https://github.com/RMamonts/nfs-mamont/issues/137>)
     pub async fn form_reply(&mut self, reply: RPCReply<B>) -> io::Result<()> {

--- a/nfs-mamont/src/serializer/server/serialize_struct.rs
+++ b/nfs-mamont/src/serializer/server/serialize_struct.rs
@@ -16,7 +16,7 @@ use crate::nlm::NlmRes;
 use crate::rpc::{AcceptStat, Error, OpaqueAuth, RejectedReply, ReplyBody, RpcBody};
 
 use crate::serializer::{u32, usize_as_u32, ALIGNMENT};
-use crate::task::{ProcReply, ProcResult};
+use crate::task::{ProcReply, ProcResult, RPCReply};
 use crate::vfs::{NfsRes, STATUS_OK};
 
 use super::mount::mnt;
@@ -227,17 +227,13 @@ impl<B: Buffer, T: AsyncWrite + Unpin> Serializer<B, T> {
     ///     order to validate itself to the client
     ///
     /// TODO:(<https://github.com/RMamonts/nfs-mamont/issues/137>)
-    pub async fn form_reply(
-        &mut self,
-        reply: ProcReply<B>,
-        verifier: OpaqueAuth,
-    ) -> io::Result<()> {
+    pub async fn form_reply(&mut self, reply: RPCReply<B>) -> io::Result<()> {
         u32(&mut self.buffer, reply.xid)?;
         u32(&mut self.buffer, RpcBody::Reply as u32)?;
-        match reply.proc_result {
+        match reply.result {
             Ok(proc) => {
                 u32(&mut self.buffer, ReplyBody::MsgAccepted as u32)?;
-                auth(&mut self.buffer, verifier)?;
+                auth(&mut self.buffer, reply.verifier)?;
                 u32(&mut self.buffer, AcceptStat::Success as u32)?;
                 self.process_result(proc).await
             }
@@ -250,7 +246,7 @@ impl<B: Buffer, T: AsyncWrite + Unpin> Serializer<B, T> {
                     | Error::MaxElemLimit
                     | Error::IncorrectString(_) => {
                         u32(&mut self.buffer, ReplyBody::MsgAccepted as u32)?;
-                        auth(&mut self.buffer, verifier)?;
+                        auth(&mut self.buffer, reply.verifier)?;
                         // or maybe system error?
                         u32(&mut self.buffer, AcceptStat::GarbageArgs as u32)?;
                         self.buffer.send_inner_buffer().await
@@ -270,19 +266,19 @@ impl<B: Buffer, T: AsyncWrite + Unpin> Serializer<B, T> {
                     }
                     Error::ProgramMismatch => {
                         u32(&mut self.buffer, ReplyBody::MsgAccepted as u32)?;
-                        auth(&mut self.buffer, verifier)?;
+                        auth(&mut self.buffer, reply.verifier)?;
                         u32(&mut self.buffer, AcceptStat::ProgUnavail as u32)?;
                         self.buffer.send_inner_buffer().await
                     }
                     Error::ProcedureMismatch => {
                         u32(&mut self.buffer, ReplyBody::MsgAccepted as u32)?;
-                        auth(&mut self.buffer, verifier)?;
+                        auth(&mut self.buffer, reply.verifier)?;
                         u32(&mut self.buffer, AcceptStat::ProcUnavail as u32)?;
                         self.buffer.send_inner_buffer().await
                     }
                     Error::ProgramVersionMismatch(info) => {
                         u32(&mut self.buffer, ReplyBody::MsgAccepted as u32)?;
-                        auth(&mut self.buffer, verifier)?;
+                        auth(&mut self.buffer, reply.verifier)?;
                         u32(&mut self.buffer, AcceptStat::ProgMismatch as u32)?;
                         u32(&mut self.buffer, info.low)?;
                         u32(&mut self.buffer, info.high)?;
@@ -290,7 +286,7 @@ impl<B: Buffer, T: AsyncWrite + Unpin> Serializer<B, T> {
                     }
                     Error::IO(_) => {
                         u32(&mut self.buffer, ReplyBody::MsgAccepted as u32)?;
-                        auth(&mut self.buffer, verifier)?;
+                        auth(&mut self.buffer, reply.verifier)?;
                         u32(&mut self.buffer, AcceptStat::SystemErr as u32)?;
                         self.buffer.send_inner_buffer().await
                     }

--- a/nfs-mamont/src/serializer/server/serialize_struct.rs
+++ b/nfs-mamont/src/serializer/server/serialize_struct.rs
@@ -13,11 +13,7 @@ use tokio::io::{AsyncWrite, AsyncWriteExt};
 use crate::allocator::Buffer;
 use crate::mount::MountRes;
 use crate::nlm::NlmRes;
-use crate::rpc::{AcceptStat, Error, OpaqueAuth, RejectedReply, ReplyBody, RpcBody};
-
-use crate::serializer::{u32, usize_as_u32, ALIGNMENT};
-use crate::task::{ProcReply, ProcResult, RPCReply};
-use crate::vfs::{NfsRes, STATUS_OK};
+use crate::rpc::{AcceptStat, Error, RejectedReply, ReplyBody, RpcBody};
 
 use super::mount::mnt;
 use super::nfs::{
@@ -27,6 +23,10 @@ use super::nfs::{
 };
 use super::nlm;
 use super::rpc::auth;
+use crate::serializer::{u32, usize_as_u32, ALIGNMENT};
+use crate::task::{ProcResult, RPCReply};
+use crate::vfs::{NfsRes, STATUS_OK};
+use crate::xdr::XDRSize;
 
 /// Minimum buffer size, that could hold complete RPC message
 /// with NFSv3 or Mount protocol replies, except for NFSv3 `READ` procedure reply -
@@ -228,6 +228,8 @@ impl<B: Buffer, T: AsyncWrite + Unpin> Serializer<B, T> {
     ///
     /// TODO:(<https://github.com/RMamonts/nfs-mamont/issues/137>)
     pub async fn form_reply(&mut self, reply: RPCReply<B>) -> io::Result<()> {
+        let fragment_size = reply.xdr_size();
+        self.buffer.append_fragment_size(fragment_size)?;
         u32(&mut self.buffer, reply.xid)?;
         u32(&mut self.buffer, RpcBody::Reply as u32)?;
         match reply.result {
@@ -331,9 +333,6 @@ impl<B: Buffer, T: AsyncWrite + Unpin> WriteBuffer<B, T> {
     /// Resets the internal write cursor to the start of the buffer.
     fn clean(&mut self) {
         self.buf.clear();
-        // reserve first 4 bytes to write header by RMS
-        // https://datatracker.ietf.org/doc/html/rfc5531#autoid-19
-        self.buf.extend_from_slice(&[0, 0, 0, 0]);
     }
 
     fn append_fragment_size(&mut self, size: usize) -> io::Result<()> {
@@ -345,16 +344,13 @@ impl<B: Buffer, T: AsyncWrite + Unpin> WriteBuffer<B, T> {
                 "Fragmented messages not supported",
             ));
         }
-        // there is no need for check, since we initialize vector in new()
-        // and we append 4 bytes after clean()
-        // since we check size for MAX_FRAGMENT_SIZE (which is less than u32::MAX) cast is safe
-        self.buf[..HEADER_SIZE].copy_from_slice(&((HEADER_MASK | size) as u32).to_be_bytes());
-        Ok(())
+
+        let head = HEADER_MASK | size;
+        usize_as_u32(self, head)
     }
 
     /// Flushes the staged XDR bytes to the underlying writer.
     async fn send_inner_buffer(&mut self) -> io::Result<()> {
-        self.append_fragment_size(self.buf.len().saturating_sub(HEADER_SIZE))?;
         self.socket.write_all(&self.buf).await?;
         self.clean();
         Ok(())
@@ -373,7 +369,6 @@ impl<B: Buffer, T: AsyncWrite + Unpin> WriteBuffer<B, T> {
         u32(&mut self.buf, count as u32)?;
 
         let padding = (ALIGNMENT - count % ALIGNMENT) % ALIGNMENT;
-        self.append_fragment_size(self.buf.len().saturating_sub(HEADER_SIZE) + count + padding)?;
         self.socket.write_all(&self.buf).await?;
 
         // later change to explicit cursor (when one implemented)

--- a/nfs-mamont/src/task/connection/write.rs
+++ b/nfs-mamont/src/task/connection/write.rs
@@ -6,7 +6,7 @@ use tracing::error;
 use crate::allocator::Buffer;
 use crate::rpc::{AuthFlavor, OpaqueAuth};
 use crate::serializer;
-use crate::task::ProcReply;
+use crate::task::{ProcReply, RPCReply};
 
 /// Writes [`super::super::global::vfs::VfsPool`] responses to a network connection.
 pub struct WriteTask<B: Buffer> {
@@ -46,7 +46,9 @@ impl<B: Buffer> WriteTask<B> {
             // Use proper authentication verifier instead of None
             let verifier = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
 
-            match serializer.form_reply(reply, verifier).await {
+            let msg = RPCReply { xid: reply.xid, verifier, result: reply.proc_result };
+
+            match serializer.form_reply(msg).await {
                 Ok(_) => {
                     // Reply successfully written to socket
                 }

--- a/nfs-mamont/src/task/mod.rs
+++ b/nfs-mamont/src/task/mod.rs
@@ -2,7 +2,6 @@
 //!
 //! This module provides the task infrastructure for handling NFS server operations,
 //! including connection-specific tasks and global task coordination.
-use nfs_mamont_derive::XDRSize;
 
 use crate::allocator::Buffer;
 use crate::mount::MountRes;
@@ -15,11 +14,20 @@ pub mod connection;
 pub mod global;
 
 /// Tagged union of top-level RPC program results supported by this server.
-#[derive(XDRSize)]
 pub enum ProcResult<B: Buffer> {
     Nfs3(Box<NfsRes<B>>),
     Mount(Box<MountRes>),
     Nlm4(Box<NlmRes>),
+}
+
+impl<B: Buffer> xdr::XDRSize for ProcResult<B> {
+    fn xdr_size(&self) -> usize {
+        match self {
+            ProcResult::Nfs3(x) => x.xdr_size(),
+            ProcResult::Mount(x) => x.xdr_size(),
+            ProcResult::Nlm4(x) => x.xdr_size(),
+        }
+    }
 }
 
 /// RPC reply metadata plus a typed result to be serialized.

--- a/nfs-mamont/src/task/mod.rs
+++ b/nfs-mamont/src/task/mod.rs
@@ -2,17 +2,20 @@
 //!
 //! This module provides the task infrastructure for handling NFS server operations,
 //! including connection-specific tasks and global task coordination.
+use nfs_mamont_derive::XDRSize;
 
 use crate::allocator::Buffer;
 use crate::mount::MountRes;
 use crate::nlm::NlmRes;
 use crate::rpc::{Error, OpaqueAuth};
 use crate::vfs::NfsRes;
+use crate::xdr;
 
 pub mod connection;
 pub mod global;
 
 /// Tagged union of top-level RPC program results supported by this server.
+#[derive(XDRSize)]
 pub enum ProcResult<B: Buffer> {
     Nfs3(Box<NfsRes<B>>),
     Mount(Box<MountRes>),
@@ -29,4 +32,71 @@ pub struct RPCReply<B: Buffer> {
     pub xid: u32,
     pub verifier: OpaqueAuth,
     pub result: Result<ProcResult<B>, Error>,
+}
+
+impl<B: Buffer> xdr::XDRSize for RPCReply<B> {
+    fn xdr_size(&self) -> usize {
+        let xid = Self::INTEGER;
+        let reply_marker = Self::INTEGER;
+        let body = match self.result {
+            Ok(ref body) => {
+                let accepted_marker = Self::INTEGER;
+                let auth = self.verifier.xdr_size();
+                let success_marker = Self::INTEGER;
+                let body = body.xdr_size();
+                accepted_marker + body + auth + success_marker + body
+            }
+            Err(ref err) => match err {
+                Error::MaxElemLimit
+                | Error::EnumDiscMismatch
+                | Error::IncorrectString(_)
+                | Error::ImpossibleTypeCast
+                | Error::BadFileHandle
+                | Error::MessageTypeMismatch => {
+                    let accepted_marker = Self::INTEGER;
+                    let auth = self.verifier.xdr_size();
+                    let garbage_marker = Self::INTEGER;
+                    accepted_marker + auth + garbage_marker
+                }
+                Error::RpcVersionMismatch(_) => {
+                    let denied_marker = Self::INTEGER;
+                    let prc_mismatch = Self::INTEGER;
+                    let ans = Self::INTEGER + Self::INTEGER;
+                    denied_marker + prc_mismatch + ans
+                }
+                Error::Auth(_) => {
+                    let denied_marker = Self::INTEGER;
+                    let auth_err = Self::INTEGER;
+                    let stat = Self::INTEGER;
+                    denied_marker + auth_err + stat
+                }
+                Error::ProgramMismatch => {
+                    let accepted_marker = Self::INTEGER;
+                    let auth = self.verifier.xdr_size();
+                    let prog_unavail = Self::INTEGER;
+                    accepted_marker + auth + prog_unavail
+                }
+                Error::ProcedureMismatch => {
+                    let accepted_marker = Self::INTEGER;
+                    let auth = self.verifier.xdr_size();
+                    let proc_unavail = Self::INTEGER;
+                    accepted_marker + auth + proc_unavail
+                }
+                Error::ProgramVersionMismatch(_) => {
+                    let accepted_marker = Self::INTEGER;
+                    let auth = self.verifier.xdr_size();
+                    let prog_unavail = Self::INTEGER;
+                    let ans = Self::INTEGER + Self::INTEGER;
+                    accepted_marker + auth + prog_unavail + ans
+                }
+                Error::IO(_) => {
+                    let accepted_marker = Self::INTEGER;
+                    let auth = self.verifier.xdr_size();
+                    let sys_err = Self::INTEGER;
+                    accepted_marker + auth + sys_err
+                }
+            },
+        };
+        xid + reply_marker + body
+    }
 }

--- a/nfs-mamont/src/task/mod.rs
+++ b/nfs-mamont/src/task/mod.rs
@@ -6,7 +6,7 @@
 use crate::allocator::Buffer;
 use crate::mount::MountRes;
 use crate::nlm::NlmRes;
-use crate::rpc::Error;
+use crate::rpc::{Error, OpaqueAuth};
 use crate::vfs::NfsRes;
 
 pub mod connection;
@@ -23,4 +23,10 @@ pub enum ProcResult<B: Buffer> {
 pub struct ProcReply<B: Buffer> {
     pub xid: u32,
     pub proc_result: Result<ProcResult<B>, Error>,
+}
+
+pub struct RPCReply<B: Buffer> {
+    pub xid: u32,
+    pub verifier: OpaqueAuth,
+    pub result: Result<ProcResult<B>, Error>,
 }

--- a/nfs-mamont/src/vfs/access.rs
+++ b/nfs-mamont/src/vfs/access.rs
@@ -1,14 +1,18 @@
 //! Defines NFSv3 [`Access`] interface.
 
-use super::{file, Error};
+use nfs_mamont_derive::XDRSize;
+
+use crate::vfs::{file, Error};
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     pub object_attr: Option<file::Attr>,
     pub access: Mask,
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: Error,
@@ -16,7 +20,7 @@ pub struct Fail {
 }
 
 /// Mask of [`Access::access`] rights.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, XDRSize)]
 pub struct Mask(u32);
 
 impl Mask {

--- a/nfs-mamont/src/vfs/commit.rs
+++ b/nfs-mamont/src/vfs/commit.rs
@@ -1,9 +1,12 @@
 //! Defines NFSv3 [`Commit`] interface.
+use nfs_mamont_derive::XDRSize;
+
 use crate::vfs;
 
 use super::file;
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// Weak cache consistency data for the file.
     pub file_wcc: vfs::WccData,
@@ -14,6 +17,7 @@ pub struct Success {
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/create.rs
+++ b/nfs-mamont/src/vfs/create.rs
@@ -1,5 +1,7 @@
 //! Defines NFSv3 [`Create`] interface.
 
+use nfs_mamont_derive::XDRSize;
+
 use crate::consts::nfsv3::NFS3_CREATEVERFSIZE;
 use crate::vfs;
 
@@ -37,6 +39,7 @@ pub enum HowMode {
 }
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// The file handle of the newly created regular file.
     pub file: Option<file::Handle>,
@@ -47,6 +50,7 @@ pub struct Success {
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/file.rs
+++ b/nfs-mamont/src/vfs/file.rs
@@ -1,16 +1,16 @@
 use std::io;
 use std::path::PathBuf;
 
+use crate::xdr::XDRSize;
 use num_derive::{FromPrimitive, ToPrimitive};
 
-use crate::vfs::{MAX_NAME_LEN, MAX_PATH_LEN};
-
 use crate::consts::nfsv3::NFS3_FHSIZE;
+use crate::vfs::{MAX_NAME_LEN, MAX_PATH_LEN};
 
 /// Unique file identifier.
 ///
 /// Corresponds to the file handle from RFC 1813.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, XDRSize)]
 pub struct Handle(pub [u8; NFS3_FHSIZE]);
 
 /// A validated wrapper around a `String` representing a name.
@@ -18,7 +18,7 @@ pub struct Handle(pub [u8; NFS3_FHSIZE]);
 /// [`Name`] ensures that the inner string does not exceed [`MAX_NAME_LEN`].
 /// It provides safe construction, accessors, and conversion back into the
 /// owned inner [`String`].
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, XDRSize)]
 pub struct Name(String);
 
 impl Name {
@@ -61,7 +61,7 @@ impl Name {
 /// [`Path`] ensures that the provided path string does not exceed
 /// [`MAX_PATH_LEN`]. It offers safe construction, accessors, and
 /// conversion back into the owned [`PathBuf`].
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, XDRSize)]
 pub struct Path(PathBuf);
 
 impl Path {
@@ -94,7 +94,7 @@ impl Path {
 }
 
 /// Type of file.
-#[derive(Clone, Copy, FromPrimitive, ToPrimitive)]
+#[derive(Clone, Copy, FromPrimitive, ToPrimitive, XDRSize)]
 pub enum Type {
     /// Regular file.
     Regular = 1,
@@ -113,7 +113,7 @@ pub enum Type {
 }
 
 /// File attributes, also known as `fattr3` in RFC
-#[derive(Clone)]
+#[derive(Clone, XDRSize)]
 pub struct Attr {
     /// Type of the file, see [`Type`].
     pub file_type: Type,
@@ -155,7 +155,7 @@ pub struct Attr {
 /// times except in the case of a [`super::set_attr`] operation where the client can
 /// explicitly set the file time.
 #[cfg_attr(test, derive(PartialEq))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, XDRSize)]
 pub struct Time {
     pub seconds: u32,
     pub nanos: u32,
@@ -164,7 +164,7 @@ pub struct Time {
 /// Major and minor device pair.
 ///
 /// Used only for [`Type::BlockDevice`] and [`Type::CharacterDevice`] file types.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, XDRSize)]
 pub struct Device {
     pub major: u32,
     pub minor: u32,
@@ -172,7 +172,7 @@ pub struct Device {
 
 /// Weak cache consistency attributes.
 #[cfg_attr(test, derive(PartialEq))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, XDRSize)]
 pub struct WccAttr {
     /// The file size in bytes of the object before the operation.
     pub size: u64,

--- a/nfs-mamont/src/vfs/fs_info.rs
+++ b/nfs-mamont/src/vfs/fs_info.rs
@@ -1,9 +1,12 @@
 //! Defines NFSv3 [`FsInfo`] interface.
 
+use nfs_mamont_derive::XDRSize;
+
 use crate::vfs;
 
 use super::file;
 
+#[derive(XDRSize)]
 pub struct Properties(u32);
 
 impl Properties {
@@ -28,6 +31,7 @@ impl Properties {
 }
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// The attributes of the file system root.
     pub root_attr: Option<file::Attr>,
@@ -64,6 +68,7 @@ pub struct Success {
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/fs_stat.rs
+++ b/nfs-mamont/src/vfs/fs_stat.rs
@@ -1,10 +1,12 @@
 //! Defines NFSv3 [`FsStat`] interface.
 
 use crate::vfs;
+use nfs_mamont_derive::XDRSize;
 
 use super::file;
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// The attributes of the mount point.
     pub root_attr: Option<file::Attr>,
@@ -35,6 +37,7 @@ pub struct Success {
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/get_attr.rs
+++ b/nfs-mamont/src/vfs/get_attr.rs
@@ -1,15 +1,19 @@
 //! Defines NFSv3 [`GetAttr`] interface.
 
+use nfs_mamont_derive::XDRSize;
+
 use crate::vfs;
 
 use super::file;
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     pub object: file::Attr,
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/link.rs
+++ b/nfs-mamont/src/vfs/link.rs
@@ -1,10 +1,13 @@
 //! Defines NFSv3 [`Link`] interface.
 
+use nfs_mamont_derive::XDRSize;
+
 use crate::vfs;
 
 use super::file;
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// The post-operation attributes of the file system object identified by `file`.
     pub file_attr: Option<file::Attr>,
@@ -13,6 +16,7 @@ pub struct Success {
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/lookup.rs
+++ b/nfs-mamont/src/vfs/lookup.rs
@@ -1,10 +1,13 @@
 //! Defines NFSv3 [`Lookup`] interface.
 
+use nfs_mamont_derive::XDRSize;
+
 use crate::vfs;
 
 use super::file;
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     pub file: file::Handle,
     pub file_attr: Option<file::Attr>,
@@ -12,6 +15,7 @@ pub struct Success {
 }
 
 /// Failed result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/mk_dir.rs
+++ b/nfs-mamont/src/vfs/mk_dir.rs
@@ -1,10 +1,12 @@
 //! Defines NFSv3 [`MkDir`] interface.
 
 use crate::vfs;
+use nfs_mamont_derive::XDRSize;
 
 use super::file;
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// The file handle for the newly created directory.
     pub file: Option<file::Handle>,
@@ -15,6 +17,7 @@ pub struct Success {
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/mk_node.rs
+++ b/nfs-mamont/src/vfs/mk_node.rs
@@ -1,6 +1,7 @@
 //! Defines NFSv3 [`MkNode`] interface.
 
 use crate::vfs;
+use nfs_mamont_derive::XDRSize;
 
 use super::file;
 use super::set_attr::NewAttr;
@@ -24,6 +25,7 @@ pub enum What {
 }
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// The file handle for the newly created special file.
     pub file: Option<file::Handle>,
@@ -34,6 +36,7 @@ pub struct Success {
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/mod.rs
+++ b/nfs-mamont/src/vfs/mod.rs
@@ -1,8 +1,8 @@
 //! Defines NFSv3 Virtual File System interface --- [`Vfs`].
 
-use num_derive::{FromPrimitive, ToPrimitive};
-
 use crate::allocator::Buffer;
+use nfs_mamont_derive::XDRSize;
+use num_derive::{FromPrimitive, ToPrimitive};
 
 pub mod access;
 pub mod commit;
@@ -37,7 +37,7 @@ pub const MAX_PATH_LEN: usize = 1024;
 pub const STATUS_OK: usize = 0;
 
 /// [`Vfs`] errors.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, ToPrimitive, FromPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, ToPrimitive, FromPrimitive, XDRSize)]
 pub enum Error {
     /// Not owner. The operation was not allowed because the
     /// caller is either not a privileged user (root) or not the
@@ -132,7 +132,7 @@ pub enum Error {
     JUKEBOX = 10008,
 }
 
-#[derive(Clone)]
+#[derive(Clone, XDRSize)]
 pub struct WccData {
     pub before: Option<file::WccAttr>,
     pub after: Option<file::Attr>,

--- a/nfs-mamont/src/vfs/mod.rs
+++ b/nfs-mamont/src/vfs/mod.rs
@@ -1,6 +1,7 @@
 //! Defines NFSv3 Virtual File System interface --- [`Vfs`].
 
 use crate::allocator::Buffer;
+use crate::xdr;
 use nfs_mamont_derive::XDRSize;
 use num_derive::{FromPrimitive, ToPrimitive};
 
@@ -203,7 +204,6 @@ where
 }
 
 /// Wrapper for all supported NFSv3 procedure result types coming from [`Vfs`].
-#[derive(XDRSize)]
 pub enum NfsRes<B: Buffer> {
     Null,
     GetAttr(std::result::Result<get_attr::Success, get_attr::Fail>),
@@ -227,4 +227,97 @@ pub enum NfsRes<B: Buffer> {
     FsInfo(std::result::Result<fs_info::Success, fs_info::Fail>),
     PathConf(std::result::Result<path_conf::Success, path_conf::Fail>),
     Commit(std::result::Result<commit::Success, commit::Fail>),
+}
+
+impl<B: Buffer> xdr::XDRSize for NfsRes<B> {
+    fn xdr_size(&self) -> usize {
+        match self {
+            NfsRes::Null => 0,
+            NfsRes::GetAttr(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::SetAttr(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::SymLink(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::Commit(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::Access(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::Create(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::FsInfo(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::FsStat(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::Link(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::MkNod(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::MkDir(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::PathConf(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::ReadDir(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::ReadLink(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::Remove(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::Rename(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::RmDir(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+
+            NfsRes::LookUp(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::Read(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::Write(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+            NfsRes::ReadDirPlus(res) => match res {
+                Ok(x) => x.xdr_size() + Self::INTEGER,
+                Err(err) => err.xdr_size(),
+            },
+        }
+    }
 }

--- a/nfs-mamont/src/vfs/mod.rs
+++ b/nfs-mamont/src/vfs/mod.rs
@@ -203,6 +203,7 @@ where
 }
 
 /// Wrapper for all supported NFSv3 procedure result types coming from [`Vfs`].
+#[derive(XDRSize)]
 pub enum NfsRes<B: Buffer> {
     Null,
     GetAttr(std::result::Result<get_attr::Success, get_attr::Fail>),

--- a/nfs-mamont/src/vfs/path_conf.rs
+++ b/nfs-mamont/src/vfs/path_conf.rs
@@ -1,10 +1,12 @@
 //! Defines NFSv3 [`PathConf`] interface.
 
 use crate::vfs;
+use nfs_mamont_derive::XDRSize;
 
 use super::file;
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// The attributes of the object specified by `file`.
     pub file_attr: Option<file::Attr>,
@@ -33,6 +35,7 @@ pub struct Success {
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/read.rs
+++ b/nfs-mamont/src/vfs/read.rs
@@ -1,11 +1,13 @@
 //! Defines NFSv3 [`Read`] interface.
 
+use nfs_mamont_derive::XDRSize;
+
+use super::file;
 use crate::allocator::Buffer;
 use crate::vfs;
 
-use super::file;
-
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success<B: Buffer> {
     /// The attributes of the file on completion of the read.
     pub head: SuccessPartial,
@@ -13,6 +15,7 @@ pub struct Success<B: Buffer> {
     pub data: B,
 }
 
+#[derive(XDRSize)]
 pub struct SuccessPartial {
     /// The attributes of the file on completion of the read.
     pub file_attr: Option<file::Attr>,
@@ -23,6 +26,7 @@ pub struct SuccessPartial {
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/read_dir.rs
+++ b/nfs-mamont/src/vfs/read_dir.rs
@@ -1,12 +1,14 @@
 //! Defines NFSv3 [`ReadDir`] interface.
 
+use nfs_mamont_derive::XDRSize;
+
 use crate::consts::nfsv3::NFS3_COOKIEVERFSIZE;
-use crate::vfs;
+use crate::{vfs, xdr};
 
 use super::file;
 
 /// Identifies a point in the directory.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, XDRSize)]
 pub struct Cookie(u64);
 
 impl Cookie {
@@ -44,7 +46,7 @@ impl Cookie {
 }
 
 /// Verifies that point identified by [`Cookie`] is still valid.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, XDRSize)]
 pub struct CookieVerifier([u8; NFS3_COOKIEVERFSIZE]);
 
 impl CookieVerifier {
@@ -82,6 +84,7 @@ impl CookieVerifier {
 }
 
 // not exactly as in RFC, but possible
+#[derive(XDRSize)]
 pub struct Entry {
     /// Since UNIX clients give a special meaning to the fileid
     /// value zero, UNIX clients should be careful to map zero
@@ -103,7 +106,20 @@ pub struct Success {
     pub eof: bool,
 }
 
+impl xdr::XDRSize for Success {
+    fn xdr_size(&self) -> usize {
+        let entries_len =
+            self.entries.iter().map(|entry| entry.xdr_size() + Self::INTEGER).sum::<usize>()
+                + Self::INTEGER;
+        self.dir_attr.xdr_size()
+            + self.cookie_verifier.xdr_size()
+            + entries_len
+            + self.eof.xdr_size()
+    }
+}
+
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/read_dir_plus.rs
+++ b/nfs-mamont/src/vfs/read_dir_plus.rs
@@ -1,11 +1,13 @@
 //! Defines NFSv3 [`ReadDirPlus`] interface.
 
-use crate::vfs;
-use crate::vfs::read_dir::Cookie;
-use crate::vfs::read_dir::CookieVerifier;
+use nfs_mamont_derive::XDRSize;
 
 use super::file;
+use crate::vfs::read_dir::Cookie;
+use crate::vfs::read_dir::CookieVerifier;
+use crate::{vfs, xdr};
 
+#[derive(XDRSize)]
 pub struct Entry {
     /// Since UNIX clients give a special meaning to the fileid
     /// value zero, UNIX clients should be careful to map zero
@@ -35,7 +37,20 @@ pub struct Success {
     pub eof: bool,
 }
 
+impl xdr::XDRSize for Success {
+    fn xdr_size(&self) -> usize {
+        let entries_len =
+            self.entries.iter().map(|entry| entry.xdr_size() + Self::INTEGER).sum::<usize>()
+                + Self::INTEGER;
+        self.dir_attr.xdr_size()
+            + self.cookie_verifier.xdr_size()
+            + entries_len
+            + self.eof.xdr_size()
+    }
+}
+
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/read_link.rs
+++ b/nfs-mamont/src/vfs/read_link.rs
@@ -1,10 +1,12 @@
 //! Defines NFSv3 [`ReadLink`] interface.
 
 use crate::vfs;
+use nfs_mamont_derive::XDRSize;
 
 use super::file;
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// The post-operation attributes for the symbolic link.
     pub symlink_attr: Option<file::Attr>,
@@ -13,6 +15,7 @@ pub struct Success {
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// The post-operation attributes for the symbolic link.
     pub symlink_attr: Option<file::Attr>,

--- a/nfs-mamont/src/vfs/remove.rs
+++ b/nfs-mamont/src/vfs/remove.rs
@@ -1,14 +1,18 @@
 //! Defines NFSv3 [`Remove`] interface.
 
+use nfs_mamont_derive::XDRSize;
+
 use crate::vfs;
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// Weak cache consistency data for the directory.
     pub wcc_data: vfs::WccData,
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/rename.rs
+++ b/nfs-mamont/src/vfs/rename.rs
@@ -1,8 +1,11 @@
 //! Defines NFSv3 [`Rename`] interface.
 
+use nfs_mamont_derive::XDRSize;
+
 use crate::vfs;
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// Weak cache consistency data for the directory, `from_dir`.
     pub from_dir_wcc: vfs::WccData,
@@ -11,6 +14,7 @@ pub struct Success {
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/rm_dir.rs
+++ b/nfs-mamont/src/vfs/rm_dir.rs
@@ -1,14 +1,17 @@
 //! Defines NFSv3 [`RmDir`] interface.
 
 use crate::vfs;
+use nfs_mamont_derive::XDRSize;
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// Weak cache consistency data for the directory.
     pub wcc_data: vfs::WccData,
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/set_attr.rs
+++ b/nfs-mamont/src/vfs/set_attr.rs
@@ -1,6 +1,7 @@
 //! Defines NFSv3 [`SetAttr`] interface.
 
 use crate::vfs;
+use nfs_mamont_derive::XDRSize;
 
 use super::file;
 
@@ -39,11 +40,13 @@ pub struct Args {
 }
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     pub wcc_data: vfs::WccData,
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/symlink.rs
+++ b/nfs-mamont/src/vfs/symlink.rs
@@ -1,10 +1,12 @@
 //! Defines NFSv3 [`Symlink`] interface.
 
 use crate::vfs;
+use nfs_mamont_derive::XDRSize;
 
 use super::file;
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// The file handle for the newly created symbolic link.
     pub file: Option<file::Handle>,
@@ -15,6 +17,7 @@ pub struct Success {
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/vfs/write.rs
+++ b/nfs-mamont/src/vfs/write.rs
@@ -1,10 +1,10 @@
 //! Defines NFSv3 [`Write`] interface.
 
-use num_derive::{FromPrimitive, ToPrimitive};
-
 use crate::allocator::Buffer;
 use crate::consts::nfsv3::NFS3_WRITEVERFSIZE;
 use crate::vfs;
+use nfs_mamont_derive::XDRSize;
+use num_derive::{FromPrimitive, ToPrimitive};
 
 use super::file;
 
@@ -18,7 +18,7 @@ use super::file;
 /// `data` and the metadata to stable storage, including all or none, before returning a reply
 /// the client. There is no guarantee whether or when any uncommitted data will subsequently be
 /// committed to stable storage.
-#[derive(Clone, Copy, Eq, PartialEq, FromPrimitive, ToPrimitive, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, FromPrimitive, ToPrimitive, Debug, XDRSize)]
 pub enum StableHow {
     Unstable = 0,
     DataSync = 1,
@@ -26,9 +26,11 @@ pub enum StableHow {
 }
 
 /// Opaque byte array of [`NFS3_WRITEVERFSIZE`] used in [`Success`]
+#[derive(XDRSize)]
 pub struct Verifier(pub [u8; NFS3_WRITEVERFSIZE]);
 
 /// Success result.
+#[derive(XDRSize)]
 pub struct Success {
     /// Weak cache consistency data for the file.
     pub file_wcc: vfs::WccData,
@@ -41,6 +43,7 @@ pub struct Success {
 }
 
 /// Fail result.
+#[derive(XDRSize)]
 pub struct Fail {
     /// Error on failure.
     pub error: vfs::Error,

--- a/nfs-mamont/src/xdr/mod.rs
+++ b/nfs-mamont/src/xdr/mod.rs
@@ -1,63 +1,207 @@
-pub use nfs_mamont_derive::XDRSize;
+//! Utilities for computing the serialized size of values in the
+//! [XDR (External Data Representation)](https://datatracker.ietf.org/doc/html/rfc4506) format.
+//!
+//! This module defines the [`XDRSize`] trait together with implementations for
+//! the primitive and container types that are used by the project.
+//!
+//! `XDRSize::xdr_size()` returns the number of bytes that a value will occupy
+//! **after XDR serialization**.
+//!
+//! In this module, all XDR values are assumed to be laid out according to the
+//! XDR 4-byte alignment rule:
+//!
+//! - every serialized value occupies a number of bytes that is a multiple of 4;
+//! - fixed-size scalar values already satisfy this naturally (`u32`, `bool`, `u64`, etc.);
+//! - opaque/string-like values are padded with zero bytes up to the next 4-byte boundary;
+//! - compound values are built from components whose serialized sizes also follow
+//!   this alignment rule.
+//!
+//! The returned size therefore includes:
+//! - the actual payload size;
+//! - XDR-required padding up to a 4-byte boundary;
+//! - length prefixes for variable-length values such as `String` and `Vec<u8>`;
+//! - discriminants for `Option<T>` / `Result<T, E>` represented as XDR booleans.
+//!
+//! # Encoding rules used in this module
+//!
+//! All serialized values are assumed to satisfy the XDR alignment rule:
+//! **their serialized size must be a multiple of 4 bytes**.
+//!
+//! For fixed-size scalar types this is already true by construction.
+//! For fixed and variable opaque values (`[u8; N]`, `Vec<u8>`, `String`, `PathBuf`),
+//! the payload is padded to the next multiple of 4 bytes.
+//!
+//! The implementations in this module follow these conventions:
+//!
+//! - `u32`, `i32`, `usize`, `bool` are treated as XDR **4-byte integers**;
+//! - `u64` is treated as an XDR **8-byte hyper integer**;
+//! - `[u8; N]` is treated as a fixed opaque byte array padded to a multiple of 4 bytes;
+//! - `Vec<u8>` is treated as an XDR variable-length opaque value:
+//!   4-byte length prefix + padded byte payload;
+//! - `String` and `PathBuf` are treated as XDR strings/opaque byte sequences:
+//!   4-byte length prefix + padded UTF-8 payload;
+//! - `Vec<T>` for `T != u8` is treated as a variable-length XDR array:
+//!   4-byte length prefix + sum of serialized element sizes;
+//! - `Option<T>` is encoded as an XDR boolean flag followed by the payload for `Some(T)`;
+//! - `Result<T, E>` is encoded as an XDR boolean flag followed by either the `Ok` payload
+//!   or the `Err` payload.
+//!
+//! # Important note about `usize`
+//!
+//! `usize` is encoded here as a **4-byte XDR integer**. This is convenient in code that
+//! conceptually uses `usize` as a size/count field but still serializes it as an XDR `u32`.
+//! Note that this is a project-level convention rather than a property of Rust `usize` itself.
+//!
+//! # Derive support
+//!
+//! The trait can be derived with [`XDRSize`](nfs_mamont_derive::XDRSize) for structs and enums.
+//!
+//! For structs, the derived implementation sums the XDR sizes of all fields in declaration order.
+//! For enums, the derived implementation adds a 4-byte discriminant and then the size of the
+//! payload of the active variant.
+
+#[cfg(test)]
+mod tests;
+
 use std::path::PathBuf;
 
+pub use nfs_mamont_derive::XDRSize;
+
+/// Returns the size of a value in its XDR-serialized representation.
+///
+/// This trait is used to compute how many bytes a value will occupy when
+/// encoded using the XDR rules adopted by this project.
+///
+/// # Alignment invariant
+///
+/// All serialized values are assumed to obey the XDR 4-byte alignment rule:
+/// the total serialized size of a value must be a multiple of 4 bytes.
+///
+/// For fixed-size scalar types this is naturally true. For variable-size and
+/// opaque/string-like values, the serialized representation includes enough
+/// padding bytes to round the payload size up to the next multiple of 4.
+///
+/// As a consequence, every correct `XDRSize` implementation should return
+/// a size that is aligned to [`XDRSize::ALIGNMENT`].
+///
+/// # Constants
+///
+/// The trait exposes several associated constants that correspond to common XDR sizes:
+///
+/// - [`ALIGNMENT`](XDRSize::ALIGNMENT) — XDR alignment boundary in bytes (always 4);
+/// - [`INTEGER`](XDRSize::INTEGER) — size of an XDR integer (`u32`/`i32`/`bool`) in bytes;
+/// - [`HYPER_INTEGER`](XDRSize::HYPER_INTEGER) — size of an XDR hyper integer (`u64`) in bytes.
 pub trait XDRSize {
+    /// XDR alignment boundary in bytes.
+    ///
+    /// XDR requires values of variable-length opaque/string-like types to be padded
+    /// so that the total payload length is aligned to a 4-byte boundary.
     const ALIGNMENT: usize = 4;
+
+    /// Size of an XDR integer in bytes.
+    ///
+    /// Used for values encoded as XDR 32-bit integers, including `u32`, `i32`,
+    /// booleans, and length/discriminant fields.
     const INTEGER: usize = 4;
+
+    /// Size of an XDR hyper integer in bytes.
+    ///
+    /// Used for values encoded as XDR 64-bit integers such as `u64`.
     const HYPER_INTEGER: usize = 8;
 
+    /// Returns the number of bytes this value occupies when serialized as XDR.
+    ///
+    /// The returned size is expected to satisfy the XDR alignment rule, i.e.
+    /// it should be a multiple of [`XDRSize::ALIGNMENT`].
+    ///
+    /// For variable-size values this includes any required trailing padding.
     fn xdr_size(&self) -> usize;
 }
 
+/// `u32` is encoded as a 4-byte XDR integer.
 impl XDRSize for u32 {
     fn xdr_size(&self) -> usize {
         Self::INTEGER
     }
 }
 
+/// `i32` is encoded as a 4-byte XDR integer.
 impl XDRSize for i32 {
     fn xdr_size(&self) -> usize {
         Self::INTEGER
     }
 }
 
+/// `u64` is encoded as an 8-byte XDR hyper integer.
 impl XDRSize for u64 {
     fn xdr_size(&self) -> usize {
         Self::HYPER_INTEGER
     }
 }
 
+/// `usize` is encoded as a 4-byte XDR integer.
+///
+/// # Note
+///
+/// This is a project-level convention: although Rust `usize` is platform-dependent,
+/// it is treated here as an XDR integer and therefore always occupies 4 bytes in the
+/// serialized representation.
 impl XDRSize for usize {
     fn xdr_size(&self) -> usize {
-        //sure?
         Self::INTEGER
     }
 }
 
+/// A fixed-size byte array is treated as XDR fixed opaque data.
+///
+/// Its serialized size is the array length rounded up to the next multiple of 4.
 impl<const N: usize> XDRSize for [u8; N] {
     fn xdr_size(&self) -> usize {
         (N + (Self::ALIGNMENT - 1)) & !(Self::ALIGNMENT - 1)
     }
 }
 
+/// `Vec<u8>` is treated as XDR variable-length opaque data.
+///
+/// The serialized size is:
+///
+/// `4-byte length prefix + padded byte payload`.
 impl XDRSize for Vec<u8> {
     fn xdr_size(&self) -> usize {
         Self::INTEGER + ((self.len() + (Self::ALIGNMENT - 1)) & !(Self::ALIGNMENT - 1))
     }
 }
 
+/// `Vec<T>` is treated as an XDR variable-length array.
+///
+/// The serialized size is:
+///
+/// `4-byte length prefix + sum of serialized element sizes`.
+///
+/// This implementation is intended for general XDR arrays. Note that `Vec<u8>`
+/// has a dedicated implementation and is treated as XDR opaque data instead.
 impl<T: XDRSize> XDRSize for Vec<T> {
     fn xdr_size(&self) -> usize {
         Self::INTEGER + self.iter().map(|item| item.xdr_size()).sum::<usize>()
     }
 }
 
+/// `bool` is encoded as a 4-byte XDR boolean/integer.
 impl XDRSize for bool {
     fn xdr_size(&self) -> usize {
         Self::INTEGER
     }
 }
 
+/// `Option<T>` is encoded as:
+///
+/// - an XDR boolean discriminant;
+/// - followed by the payload only for `Some(T)`.
+///
+/// Therefore:
+///
+/// - `None` occupies 4 bytes;
+/// - `Some(x)` occupies `4 + x.xdr_size()`.
 impl<T: XDRSize> XDRSize for Option<T> {
     fn xdr_size(&self) -> usize {
         match self {
@@ -67,12 +211,22 @@ impl<T: XDRSize> XDRSize for Option<T> {
     }
 }
 
+/// `String` is encoded as a variable-length XDR string.
+///
+/// The serialized size is:
+///
+/// `4-byte length prefix + padded UTF-8 byte payload`.
 impl XDRSize for String {
     fn xdr_size(&self) -> usize {
         Self::INTEGER + ((self.len() + (Self::ALIGNMENT - 1)) & !(Self::ALIGNMENT - 1))
     }
 }
 
+/// `PathBuf` is encoded as a variable-length XDR string-like value.
+///
+/// The serialized size is:
+///
+/// `4-byte length prefix + padded UTF-8 byte payload`.
 impl XDRSize for PathBuf {
     fn xdr_size(&self) -> usize {
         let path_str = self.to_string_lossy();
@@ -80,6 +234,15 @@ impl XDRSize for PathBuf {
     }
 }
 
+/// `Result<T, E>` is encoded as:
+///
+/// - an XDR boolean discriminant;
+/// - followed by either the `Ok(T)` payload or the `Err(E)` payload.
+///
+/// Therefore:
+///
+/// - `Ok(v)` occupies `4 + v.xdr_size()`
+/// - `Err(e)` occupies `4 + e.xdr_size()`
 impl<T: XDRSize, E: XDRSize> XDRSize for Result<T, E> {
     fn xdr_size(&self) -> usize {
         match self {
@@ -89,40 +252,12 @@ impl<T: XDRSize, E: XDRSize> XDRSize for Result<T, E> {
     }
 }
 
+/// `Box<T>` has the same serialized size as `T`.
+///
+/// Boxing only changes ownership/allocation strategy in Rust and does not affect
+/// the XDR wire representation.
 impl<T: XDRSize> XDRSize for Box<T> {
     fn xdr_size(&self) -> usize {
         (**self).xdr_size()
-    }
-}
-
-//TODO: more tests!!!
-#[cfg(test)]
-mod tests {
-    use super::XDRSize;
-
-    #[derive(XDRSize)]
-    struct Pair {
-        a: u32,
-        b: u64,
-    }
-
-    #[derive(XDRSize)]
-    enum Choice {
-        A,
-        B(u32),
-        C { x: u32, y: u64 },
-    }
-
-    #[test]
-    fn derive_struct_sums_field_sizes() {
-        let pair = Pair { a: 1, b: 2 };
-        assert_eq!(pair.xdr_size(), 4 + 8);
-    }
-
-    #[test]
-    fn derive_enum_includes_discriminant() {
-        assert_eq!(Choice::A.xdr_size(), 4);
-        assert_eq!(Choice::B(0).xdr_size(), 4 + 4);
-        assert_eq!(Choice::C { x: 0, y: 0 }.xdr_size(), 4 + 4 + 8);
     }
 }

--- a/nfs-mamont/src/xdr/mod.rs
+++ b/nfs-mamont/src/xdr/mod.rs
@@ -30,13 +30,13 @@ impl XDRSize for usize {
 
 impl<const N: usize> XDRSize for [u8; N] {
     fn xdr_size(&self) -> usize {
-        (N + Self::ALIGNMENT) & !Self::ALIGNMENT
+        (N + (Self::ALIGNMENT - 1)) & !(Self::ALIGNMENT - 1)
     }
 }
 
 impl XDRSize for Vec<u8> {
     fn xdr_size(&self) -> usize {
-        Self::INTEGER + ((self.len() + Self::ALIGNMENT) & !Self::ALIGNMENT)
+        Self::INTEGER + ((self.len() + (Self::ALIGNMENT - 1)) & !(Self::ALIGNMENT - 1))
     }
 }
 
@@ -57,17 +57,18 @@ impl<T: XDRSize> XDRSize for Option<T> {
 
 impl XDRSize for String {
     fn xdr_size(&self) -> usize {
-        Self::INTEGER + ((self.len() + Self::ALIGNMENT) & !Self::ALIGNMENT)
+        Self::INTEGER + ((self.len() + (Self::ALIGNMENT - 1)) & !(Self::ALIGNMENT - 1))
     }
 }
 
 impl XDRSize for PathBuf {
     fn xdr_size(&self) -> usize {
         let path_str = self.to_string_lossy();
-        Self::INTEGER + ((path_str.len() + Self::ALIGNMENT) & !Self::ALIGNMENT)
+        Self::INTEGER + ((path_str.len() + (Self::ALIGNMENT - 1)) & !(Self::ALIGNMENT - 1))
     }
 }
 
+//TODO: more tests!!!
 #[cfg(test)]
 mod tests {
     use super::XDRSize;

--- a/nfs-mamont/src/xdr/mod.rs
+++ b/nfs-mamont/src/xdr/mod.rs
@@ -40,6 +40,12 @@ impl XDRSize for Vec<u8> {
     }
 }
 
+impl<T: XDRSize> XDRSize for Vec<T> {
+    fn xdr_size(&self) -> usize {
+        Self::INTEGER + self.iter().map(|item| item.xdr_size()).sum::<usize>()
+    }
+}
+
 impl XDRSize for bool {
     fn xdr_size(&self) -> usize {
         Self::INTEGER

--- a/nfs-mamont/src/xdr/mod.rs
+++ b/nfs-mamont/src/xdr/mod.rs
@@ -80,6 +80,21 @@ impl XDRSize for PathBuf {
     }
 }
 
+impl<T: XDRSize, E: XDRSize> XDRSize for Result<T, E> {
+    fn xdr_size(&self) -> usize {
+        match self {
+            Ok(value) => true.xdr_size() + value.xdr_size(),
+            Err(err) => false.xdr_size() + err.xdr_size(),
+        }
+    }
+}
+
+impl<T: XDRSize> XDRSize for Box<T> {
+    fn xdr_size(&self) -> usize {
+        (**self).xdr_size()
+    }
+}
+
 //TODO: more tests!!!
 #[cfg(test)]
 mod tests {

--- a/nfs-mamont/src/xdr/mod.rs
+++ b/nfs-mamont/src/xdr/mod.rs
@@ -1,0 +1,53 @@
+pub trait XDRSize {
+    const ALIGNMENT: usize = 4;
+    const INTEGER: usize = 4;
+    const HYPER_INTEGER: usize = 8;
+
+    fn xdr_size(&self) -> usize;
+}
+
+impl XDRSize for u32 {
+    fn xdr_size(&self) -> usize {
+        Self::INTEGER
+    }
+}
+
+impl XDRSize for u64 {
+    fn xdr_size(&self) -> usize {
+        Self::HYPER_INTEGER
+    }
+}
+
+impl XDRSize for usize {
+    fn xdr_size(&self) -> usize {
+        //sure?
+        Self::INTEGER
+    }
+}
+
+impl<const N: usize> XDRSize for [u8; N] {
+    fn xdr_size(&self) -> usize {
+        (N + Self::ALIGNMENT) & !Self::ALIGNMENT
+    }
+}
+
+impl XDRSize for Vec<u8> {
+    fn xdr_size(&self) -> usize {
+        Self::INTEGER + ((self.len() + Self::ALIGNMENT) & !Self::ALIGNMENT)
+    }
+}
+
+impl XDRSize for bool {
+    fn xdr_size(&self) -> usize {
+        Self::INTEGER
+    }
+}
+
+impl<T: XDRSize> XDRSize for Option<T> {
+    fn xdr_size(&self) -> usize {
+        match self {
+            Some(x) => true.xdr_size() + x.xdr_size(),
+            None => false.xdr_size(),
+        }
+    }
+}

--- a/nfs-mamont/src/xdr/mod.rs
+++ b/nfs-mamont/src/xdr/mod.rs
@@ -15,6 +15,12 @@ impl XDRSize for u32 {
     }
 }
 
+impl XDRSize for i32 {
+    fn xdr_size(&self) -> usize {
+        Self::INTEGER
+    }
+}
+
 impl XDRSize for u64 {
     fn xdr_size(&self) -> usize {
         Self::HYPER_INTEGER

--- a/nfs-mamont/src/xdr/mod.rs
+++ b/nfs-mamont/src/xdr/mod.rs
@@ -1,3 +1,6 @@
+pub use nfs_mamont_derive::XDRSize;
+use std::path::PathBuf;
+
 pub trait XDRSize {
     const ALIGNMENT: usize = 4;
     const INTEGER: usize = 4;
@@ -49,5 +52,49 @@ impl<T: XDRSize> XDRSize for Option<T> {
             Some(x) => true.xdr_size() + x.xdr_size(),
             None => false.xdr_size(),
         }
+    }
+}
+
+impl XDRSize for String {
+    fn xdr_size(&self) -> usize {
+        Self::INTEGER + ((self.len() + Self::ALIGNMENT) & !Self::ALIGNMENT)
+    }
+}
+
+impl XDRSize for PathBuf {
+    fn xdr_size(&self) -> usize {
+        let path_str = self.to_string_lossy();
+        Self::INTEGER + ((path_str.len() + Self::ALIGNMENT) & !Self::ALIGNMENT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::XDRSize;
+
+    #[derive(XDRSize)]
+    struct Pair {
+        a: u32,
+        b: u64,
+    }
+
+    #[derive(XDRSize)]
+    enum Choice {
+        A,
+        B(u32),
+        C { x: u32, y: u64 },
+    }
+
+    #[test]
+    fn derive_struct_sums_field_sizes() {
+        let pair = Pair { a: 1, b: 2 };
+        assert_eq!(pair.xdr_size(), 4 + 8);
+    }
+
+    #[test]
+    fn derive_enum_includes_discriminant() {
+        assert_eq!(Choice::A.xdr_size(), 4);
+        assert_eq!(Choice::B(0).xdr_size(), 4 + 4);
+        assert_eq!(Choice::C { x: 0, y: 0 }.xdr_size(), 4 + 4 + 8);
     }
 }

--- a/nfs-mamont/src/xdr/tests.rs
+++ b/nfs-mamont/src/xdr/tests.rs
@@ -1,0 +1,515 @@
+use std::path::PathBuf;
+
+use super::XDRSize;
+
+fn pad(len: usize) -> usize {
+    (4 - (len % 4)) % 4
+}
+
+fn opaque_size(len: usize) -> usize {
+    len + pad(len)
+}
+
+fn variable_opaque_size(len: usize) -> usize {
+    4 + opaque_size(len)
+}
+
+#[derive(XDRSize)]
+struct Pair {
+    a: u32,
+    b: u64,
+}
+
+#[derive(XDRSize)]
+struct Triple {
+    a: u32,
+    b: u32,
+    c: u64,
+}
+
+#[derive(XDRSize)]
+struct TuplePair(u32, u64);
+
+#[derive(XDRSize)]
+struct UnitStruct;
+
+#[derive(XDRSize)]
+struct Nested {
+    pair: Pair,
+    flag: bool,
+}
+
+#[derive(XDRSize)]
+struct NestedTuple(TuplePair, bool);
+
+#[derive(XDRSize)]
+struct Generic<T> {
+    value: T,
+}
+
+#[derive(XDRSize)]
+struct GenericPair<T, U> {
+    left: T,
+    right: U,
+}
+
+#[derive(XDRSize)]
+struct WithVec {
+    items: Vec<u32>,
+}
+
+#[derive(XDRSize)]
+struct WithString {
+    value: String,
+}
+
+#[derive(XDRSize)]
+struct WithBytes {
+    value: Vec<u8>,
+}
+
+#[derive(XDRSize)]
+struct WithArray {
+    value: [u8; 5],
+}
+
+#[derive(XDRSize)]
+struct WithOption {
+    value: Option<u32>,
+}
+
+#[derive(XDRSize)]
+struct WithResult {
+    value: Result<u32, u64>,
+}
+
+#[derive(XDRSize)]
+struct WithBox {
+    value: Box<u32>,
+}
+
+#[derive(XDRSize)]
+struct WithPath {
+    value: PathBuf,
+}
+
+#[derive(XDRSize)]
+enum Choice {
+    Unit,
+    Tuple(u32),
+    Struct { x: u32, y: u64 },
+}
+
+#[derive(XDRSize)]
+enum GenericChoice<T> {
+    Empty,
+    One(T),
+    Two { value: T, flag: bool },
+}
+
+#[derive(XDRSize)]
+enum ComplexEnum {
+    A,
+    B(Pair),
+    C { nested: Nested, name: String },
+}
+
+#[test]
+fn xdr_size_u32() {
+    assert_eq!(0u32.xdr_size(), 4);
+    assert_eq!(123u32.xdr_size(), 4);
+}
+
+#[test]
+fn xdr_size_i32() {
+    assert_eq!(0i32.xdr_size(), 4);
+    assert_eq!((-123i32).xdr_size(), 4);
+}
+
+#[test]
+fn xdr_size_u64() {
+    assert_eq!(0u64.xdr_size(), 8);
+    assert_eq!(123u64.xdr_size(), 8);
+}
+
+#[test]
+fn xdr_size_usize() {
+    assert_eq!(0usize.xdr_size(), 4);
+    assert_eq!(123usize.xdr_size(), 4);
+}
+
+#[test]
+fn xdr_size_bool() {
+    assert_eq!(true.xdr_size(), 4);
+    assert_eq!(false.xdr_size(), 4);
+}
+
+#[test]
+fn xdr_size_byte_array_empty() {
+    assert_eq!([0u8; 0].xdr_size(), 0);
+}
+
+#[test]
+fn xdr_size_byte_array_1() {
+    assert_eq!([0u8; 1].xdr_size(), 4);
+}
+
+#[test]
+fn xdr_size_byte_array_2() {
+    assert_eq!([0u8; 2].xdr_size(), 4);
+}
+
+#[test]
+fn xdr_size_byte_array_3() {
+    assert_eq!([0u8; 3].xdr_size(), 4);
+}
+
+#[test]
+fn xdr_size_byte_array_4() {
+    assert_eq!([0u8; 4].xdr_size(), 4);
+}
+
+#[test]
+fn xdr_size_byte_array_5() {
+    assert_eq!([0u8; 5].xdr_size(), 8);
+}
+
+#[test]
+fn xdr_size_byte_array_7() {
+    assert_eq!([0u8; 7].xdr_size(), 8);
+}
+
+#[test]
+fn xdr_size_byte_array_8() {
+    assert_eq!([0u8; 8].xdr_size(), 8);
+}
+
+#[test]
+fn xdr_size_empty_vec_u8() {
+    assert_eq!(Vec::<u8>::new().xdr_size(), variable_opaque_size(0));
+}
+
+#[test]
+fn xdr_size_vec_u8_1() {
+    assert_eq!(vec![1u8].xdr_size(), variable_opaque_size(1));
+}
+
+#[test]
+fn xdr_size_vec_u8_2() {
+    assert_eq!(vec![1u8, 2].xdr_size(), variable_opaque_size(2));
+}
+
+#[test]
+fn xdr_size_vec_u8_3() {
+    assert_eq!(vec![1u8, 2, 3].xdr_size(), variable_opaque_size(3));
+}
+
+#[test]
+fn xdr_size_vec_u8_4() {
+    assert_eq!(vec![1u8, 2, 3, 4].xdr_size(), variable_opaque_size(4));
+}
+
+#[test]
+fn xdr_size_vec_u8_5() {
+    assert_eq!(vec![1u8, 2, 3, 4, 5].xdr_size(), variable_opaque_size(5));
+}
+
+#[test]
+fn xdr_size_string_empty() {
+    assert_eq!("".to_string().xdr_size(), variable_opaque_size(0));
+}
+
+#[test]
+fn xdr_size_string_1() {
+    assert_eq!("a".to_string().xdr_size(), variable_opaque_size(1));
+}
+
+#[test]
+fn xdr_size_string_3() {
+    assert_eq!("abc".to_string().xdr_size(), variable_opaque_size(3));
+}
+
+#[test]
+fn xdr_size_string_4() {
+    assert_eq!("abcd".to_string().xdr_size(), variable_opaque_size(4));
+}
+
+#[test]
+fn xdr_size_string_5() {
+    assert_eq!("abcde".to_string().xdr_size(), variable_opaque_size(5));
+}
+
+#[test]
+fn xdr_size_pathbuf() {
+    let p = PathBuf::from("abc");
+    assert_eq!(p.xdr_size(), variable_opaque_size(3));
+}
+
+#[test]
+fn xdr_size_vec_u32_empty() {
+    let v: Vec<u32> = vec![];
+    assert_eq!(v.xdr_size(), 4);
+}
+
+#[test]
+fn xdr_size_vec_u32_non_empty() {
+    let v = vec![1u32, 2u32, 3u32];
+    assert_eq!(v.xdr_size(), 4 + 3 * 4);
+}
+
+#[test]
+fn xdr_size_vec_pair() {
+    let v = vec![Pair { a: 1, b: 2 }, Pair { a: 3, b: 4 }];
+    assert_eq!(v.xdr_size(), 4 + 2 * (4 + 8));
+}
+
+#[test]
+fn xdr_size_option_none() {
+    let v: Option<u32> = None;
+    assert_eq!(v.xdr_size(), 4);
+}
+
+#[test]
+fn xdr_size_option_some() {
+    let v = Some(10u32);
+    assert_eq!(v.xdr_size(), 4 + 4);
+}
+
+#[test]
+fn xdr_size_result_ok() {
+    let v: Result<u32, u64> = Ok(10u32);
+    assert_eq!(v.xdr_size(), 4 + 4);
+}
+
+#[test]
+fn xdr_size_result_err() {
+    let v: Result<u32, u64> = Err(10u64);
+    assert_eq!(v.xdr_size(), 4 + 8);
+}
+
+#[test]
+fn xdr_size_box_u32() {
+    let v = Box::new(123u32);
+    assert_eq!(v.xdr_size(), 4);
+}
+
+#[test]
+fn derive_named_struct_pair() {
+    let v = Pair { a: 1, b: 2 };
+    assert_eq!(v.xdr_size(), 4 + 8);
+}
+
+#[test]
+fn derive_named_struct_triple() {
+    let v = Triple { a: 1, b: 2, c: 3 };
+    assert_eq!(v.xdr_size(), 4 + 4 + 8);
+}
+
+#[test]
+fn derive_tuple_struct() {
+    let v = TuplePair(1, 2);
+    assert_eq!(v.xdr_size(), 4 + 8);
+}
+
+#[test]
+fn derive_unit_struct() {
+    let v = UnitStruct;
+    assert_eq!(v.xdr_size(), 0);
+}
+
+#[test]
+fn derive_nested_struct() {
+    let v = Nested { pair: Pair { a: 1, b: 2 }, flag: true };
+    assert_eq!(v.xdr_size(), (4 + 8) + 4);
+}
+
+#[test]
+fn derive_nested_tuple_struct() {
+    let v = NestedTuple(TuplePair(1, 2), true);
+    assert_eq!(v.xdr_size(), (4 + 8) + 4);
+}
+
+#[test]
+fn derive_struct_with_vec() {
+    let v = WithVec { items: vec![1u32, 2u32, 3u32] };
+    assert_eq!(v.xdr_size(), 4 + 3 * 4);
+}
+
+#[test]
+fn derive_struct_with_string() {
+    let s = "hello".to_string();
+    let v = WithString { value: s.clone() };
+    assert_eq!(v.xdr_size(), variable_opaque_size(s.len()));
+}
+
+#[test]
+fn derive_struct_with_bytes() {
+    let bytes = vec![1u8, 2, 3, 4, 5];
+    let v = WithBytes { value: bytes.clone() };
+    assert_eq!(v.xdr_size(), variable_opaque_size(bytes.len()));
+}
+
+#[test]
+fn derive_struct_with_array() {
+    let v = WithArray { value: [1u8; 5] };
+    assert_eq!(v.xdr_size(), 8);
+}
+
+#[test]
+fn derive_struct_with_option() {
+    let v = WithOption { value: Some(5) };
+    assert_eq!(v.xdr_size(), 4 + 4);
+}
+
+#[test]
+fn derive_struct_with_result() {
+    let v = WithResult { value: Ok(5u32) };
+    assert_eq!(v.xdr_size(), 4 + 4);
+}
+
+#[test]
+fn derive_struct_with_box() {
+    let v = WithBox { value: Box::new(10u32) };
+    assert_eq!(v.xdr_size(), 4);
+}
+
+#[test]
+fn derive_struct_with_path() {
+    let path = PathBuf::from("abcde");
+    let v = WithPath { value: path.clone() };
+    assert_eq!(v.xdr_size(), variable_opaque_size(5));
+}
+
+#[test]
+fn derive_generic_struct_u32() {
+    let v = Generic { value: 42u32 };
+    assert_eq!(v.xdr_size(), 4);
+}
+
+#[test]
+fn derive_generic_struct_pair() {
+    let v = Generic { value: Pair { a: 1, b: 2 } };
+    assert_eq!(v.xdr_size(), 4 + 8);
+}
+
+#[test]
+fn derive_generic_pair() {
+    let v = GenericPair { left: 10u32, right: 20u64 };
+    assert_eq!(v.xdr_size(), 4 + 8);
+}
+
+#[test]
+fn derive_enum_unit_variant() {
+    assert_eq!(Choice::Unit.xdr_size(), 4);
+}
+
+#[test]
+fn derive_enum_tuple_variant() {
+    assert_eq!(Choice::Tuple(5).xdr_size(), 4 + 4);
+}
+
+#[test]
+fn derive_enum_struct_variant() {
+    assert_eq!(Choice::Struct { x: 1, y: 2 }.xdr_size(), 4 + 4 + 8);
+}
+
+#[test]
+fn derive_generic_enum_empty() {
+    let v: GenericChoice<u32> = GenericChoice::Empty;
+    assert_eq!(v.xdr_size(), 4);
+}
+
+#[test]
+fn derive_generic_enum_one() {
+    let v = GenericChoice::One(7u32);
+    assert_eq!(v.xdr_size(), 4 + 4);
+}
+
+#[test]
+fn derive_generic_enum_two() {
+    let v = GenericChoice::Two { value: 7u32, flag: true };
+    assert_eq!(v.xdr_size(), 4 + 4 + 4);
+}
+
+#[test]
+fn derive_complex_enum_a() {
+    assert_eq!(ComplexEnum::A.xdr_size(), 4);
+}
+
+#[test]
+fn derive_complex_enum_b() {
+    let v = ComplexEnum::B(Pair { a: 1, b: 2 });
+    assert_eq!(v.xdr_size(), 4 + (4 + 8));
+}
+
+#[test]
+fn derive_complex_enum_c() {
+    let nested = Nested { pair: Pair { a: 1, b: 2 }, flag: true };
+    let name = "abc".to_string();
+
+    let expected_nested = (4 + 8) + 4;
+    let expected_name = variable_opaque_size(name.len());
+
+    let v = ComplexEnum::C { nested, name };
+    assert_eq!(v.xdr_size(), 4 + expected_nested + expected_name);
+}
+
+#[test]
+fn nested_option_vec_pair() {
+    let v = Some(vec![Pair { a: 1, b: 2 }, Pair { a: 3, b: 4 }]);
+    assert_eq!(v.xdr_size(), 4 + 4 + 2 * (4 + 8));
+}
+
+#[test]
+fn nested_result_pair_u32_ok() {
+    let v: Result<Pair, u32> = Ok(Pair { a: 1, b: 2 });
+    assert_eq!(v.xdr_size(), 4 + (4 + 8));
+}
+
+#[test]
+fn nested_result_pair_u32_err() {
+    let v: Result<Pair, u32> = Err(5u32);
+    assert_eq!(v.xdr_size(), 4 + 4);
+}
+
+#[test]
+fn nested_derive_inside_generic() {
+    let v = Generic { value: Nested { pair: Pair { a: 1, b: 2 }, flag: true } };
+
+    assert_eq!(v.xdr_size(), (4 + 8) + 4);
+}
+
+#[test]
+fn vec_of_generic_structs() {
+    let v = vec![Generic { value: 1u32 }, Generic { value: 2u32 }, Generic { value: 3u32 }];
+
+    assert_eq!(v.xdr_size(), 4 + 3 * 4);
+}
+
+#[test]
+fn padding_helper() {
+    assert_eq!(pad(0), 0);
+    assert_eq!(pad(1), 3);
+    assert_eq!(pad(2), 2);
+    assert_eq!(pad(3), 1);
+    assert_eq!(pad(4), 0);
+    assert_eq!(pad(5), 3);
+}
+
+#[test]
+fn opaque_size_helper() {
+    assert_eq!(opaque_size(0), 0);
+    assert_eq!(opaque_size(1), 4);
+    assert_eq!(opaque_size(2), 4);
+    assert_eq!(opaque_size(3), 4);
+    assert_eq!(opaque_size(4), 4);
+    assert_eq!(opaque_size(5), 8);
+}
+
+#[test]
+fn variable_opaque_size_helper() {
+    assert_eq!(variable_opaque_size(0), 4);
+    assert_eq!(variable_opaque_size(1), 8);
+    assert_eq!(variable_opaque_size(4), 8);
+    assert_eq!(variable_opaque_size(5), 12);
+}


### PR DESCRIPTION
Introduce trait, that calculates size of type in XDR format, and separate crate to allow deriving.

This is first step to solve #276 and #269 issues, but also it might be a good way to check inside serializer (maybe in fizz), that actual size of message matches expected