### PR TITLE
feat: vectorized write in mirrorfs

### DIFF
--- a/mirror_fs/src/fs/mod.rs
+++ b/mirror_fs/src/fs/mod.rs
@@ -12,7 +12,6 @@ use nfs_mamont::vfs::file;
 use nfs_mamont::vfs::read_dir;
 use nfs_mamont::vfs::set_attr;
 use nfs_mamont::vfs::write;
-use nfs_mamont::Buffer;
 
 use crate::fs_map::FsMap;
 
@@ -206,18 +205,6 @@ impl MirrorFS {
         } else {
             Err(vfs::Error::InvalidArgument)
         }
-    }
-
-    fn collect_buffer_bytes(slice: &impl Buffer, size: u32) -> Vec<u8> {
-        let mut data = Vec::with_capacity(size as usize);
-        for part in slice.chunks() {
-            data.extend_from_slice(part);
-            if data.len() >= size as usize {
-                data.truncate(size as usize);
-                break;
-            }
-        }
-        data
     }
 
     fn file_attr(path: &Path) -> Option<file::Attr> {

--- a/mirror_fs/src/fs/write_impl.rs
+++ b/mirror_fs/src/fs/write_impl.rs
@@ -1,4 +1,4 @@
-use std::io::SeekFrom;
+use std::io::{IoSlice, SeekFrom};
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
@@ -37,19 +37,24 @@ impl<B: Buffer> write::Write<B> for MirrorFS {
             }
         };
 
-        let data = Self::collect_buffer_bytes(&args.data, args.size);
+        let data: Vec<IoSlice<'_>> = args.data.chunks().map(IoSlice::new).collect();
         if let Err(error) = file.seek(SeekFrom::Start(args.offset)).await {
             return Err(write::Fail {
                 error: Self::io_error_to_vfs(&error),
                 wcc_data: Self::wcc_data(&path, before),
             });
         }
-        if let Err(error) = file.write_all(&data).await {
-            return Err(write::Fail {
-                error: Self::io_error_to_vfs(&error),
-                wcc_data: Self::wcc_data(&path, before),
-            });
-        }
+
+        let size = match file.write_vectored(&data).await {
+            Ok(n) => n as u32,
+            Err(error) => {
+                return Err(write::Fail {
+                    error: Self::io_error_to_vfs(&error),
+                    wcc_data: Self::wcc_data(&path, before),
+                });
+            }
+        };
+
         let sync_result = match args.stable {
             write::StableHow::Unstable => Ok(()),
             write::StableHow::DataSync => file.sync_data().await,
@@ -64,7 +69,7 @@ impl<B: Buffer> write::Write<B> for MirrorFS {
 
         Ok(write::Success {
             file_wcc: Self::wcc_data(&path, before),
-            count: data.len() as u32,
+            count: size,
             committed: args.stable,
             verifier: self.write_verifier(),
         })

--- a/mirror_fs/src/fs/write_impl.rs
+++ b/mirror_fs/src/fs/write_impl.rs
@@ -37,7 +37,19 @@ impl<B: Buffer> write::Write<B> for MirrorFS {
             }
         };
 
-        let data: Vec<IoSlice<'_>> = args.data.chunks().map(IoSlice::new).collect();
+        let mut remaining = args.size as usize;
+        let data: Vec<IoSlice<'_>> = args
+            .data
+            .chunks()
+            .filter_map(|chunk| {
+                if remaining == 0 {
+                    return None;
+                }
+                let take = chunk.len().min(remaining);
+                remaining -= take;
+                Some(IoSlice::new(&chunk[..take]))
+            })
+            .collect();
         if let Err(error) = file.seek(SeekFrom::Start(args.offset)).await {
             return Err(write::Fail {
                 error: Self::io_error_to_vfs(&error),


### PR DESCRIPTION
Before this pr we had extra copy of data to write it with just one syscall - write_all, but we dont actually need extra copy for that, so i just replaced write_all with vectorized call