### PR TITLE
feat: vectorized serialization of read responces

### DIFF
--- a/nfs-mamont/src/serializer/server/serialize_struct.rs
+++ b/nfs-mamont/src/serializer/server/serialize_struct.rs
@@ -394,7 +394,6 @@ impl<B: Buffer, T: AsyncWrite + Unpin> WriteBuffer<B, T> {
             let mut to_skip = written;
             let mut iov: Vec<IoSlice<'_>> = Vec::new();
 
-            // skip fully-written chunks, partial-write starts at the correct offset
             for chunk in &chunks {
                 if to_skip == 0 {
                     iov.push(IoSlice::new(chunk));
@@ -406,7 +405,6 @@ impl<B: Buffer, T: AsyncWrite + Unpin> WriteBuffer<B, T> {
                 }
             }
 
-            // append padding (or its remainder after partial write)
             if to_skip < padding {
                 iov.push(IoSlice::new(&padding_bytes[to_skip..padding]));
             }

--- a/nfs-mamont/src/serializer/server/serialize_struct.rs
+++ b/nfs-mamont/src/serializer/server/serialize_struct.rs
@@ -384,19 +384,18 @@ impl<B: Buffer, T: AsyncWrite + Unpin> WriteBuffer<B, T> {
 
         self.socket.write_all(&self.buf).await?;
 
-        let chunks: Vec<&[u8]> = buffer.chunks().collect();
         let padding_bytes = [0u8; ALIGNMENT];
 
         let mut written: usize = 0;
-        let total_payload: usize = chunks.iter().map(|c| c.len()).sum::<usize>() + padding;
+        let total_payload: usize = buffer.len() + padding;
 
-        let mut iov: Vec<IoSlice<'_>> = Vec::with_capacity(chunks.len() + 1);
+        let mut iov: Vec<IoSlice<'_>> = Vec::with_capacity(buffer.chunks().count() + 1);
 
         while written < total_payload {
             iov.clear();
             let mut to_skip = written;
 
-            for chunk in &chunks {
+            for chunk in buffer.chunks() {
                 if to_skip == 0 {
                     iov.push(IoSlice::new(chunk));
                 } else if to_skip < chunk.len() {

--- a/nfs-mamont/src/serializer/server/serialize_struct.rs
+++ b/nfs-mamont/src/serializer/server/serialize_struct.rs
@@ -6,7 +6,7 @@
 //! RPC reply to an async writer.
 
 use std::io;
-use std::io::{ErrorKind, Write};
+use std::io::{ErrorKind, IoSlice, Write};
 
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
@@ -365,6 +365,9 @@ impl<B: Buffer, T: AsyncWrite + Unpin> WriteBuffer<B, T> {
     }
 
     /// Flushes the staged XDR bytes followed by a streamed payload [`Buffer`] (used for READ data).
+    ///
+    /// Uses vectored I/O to coalesce all data chunks and padding into a single
+    /// `writev`-style syscall, reducing kernel transitions.
     async fn send_inner_with_buffer(&mut self, buffer: B, count: usize) -> io::Result<()> {
         // this place is a bit paradox
         // In READ procedure (https://datatracker.ietf.org/doc/html/rfc1813#autoid-25) opaque data
@@ -378,16 +381,50 @@ impl<B: Buffer, T: AsyncWrite + Unpin> WriteBuffer<B, T> {
 
         let padding = (ALIGNMENT - count % ALIGNMENT) % ALIGNMENT;
         self.append_fragment_size(self.buf.len().saturating_sub(HEADER_SIZE) + count + padding)?;
+
         self.socket.write_all(&self.buf).await?;
 
-        // later change to explicit cursor (when one implemented)
-        for buf in buffer.chunks() {
-            self.socket.write_all(buf).await?;
+        let chunks: Vec<&[u8]> = buffer.chunks().collect();
+        let padding_bytes = [0u8; ALIGNMENT];
+
+        let mut written: usize = 0;
+        let total_payload: usize = chunks.iter().map(|c| c.len()).sum::<usize>() + padding;
+
+        while written < total_payload {
+            let mut to_skip = written;
+            let mut iov: Vec<IoSlice<'_>> = Vec::new();
+
+            // skip fully-written chunks, partial-write starts at the correct offset
+            for chunk in &chunks {
+                if to_skip == 0 {
+                    iov.push(IoSlice::new(chunk));
+                } else if to_skip < chunk.len() {
+                    iov.push(IoSlice::new(&chunk[to_skip..]));
+                    to_skip = 0;
+                } else {
+                    to_skip -= chunk.len();
+                }
+            }
+
+            // append padding (or its remainder after partial write)
+            if to_skip < padding {
+                iov.push(IoSlice::new(&padding_bytes[to_skip..padding]));
+            }
+
+            if !iov.is_empty() {
+                let n = self.socket.write_vectored(&iov).await?;
+                if n == 0 {
+                    return Err(io::Error::new(
+                        ErrorKind::WriteZero,
+                        "failed to write data to socket",
+                    ));
+                }
+                written += n;
+            } else {
+                break;
+            }
         }
 
-        // write padding directly to socket
-        let slice = [0u8; ALIGNMENT];
-        self.socket.write_all(&slice[..padding]).await?;
         self.clean();
         Ok(())
     }

--- a/nfs-mamont/src/serializer/server/serialize_struct.rs
+++ b/nfs-mamont/src/serializer/server/serialize_struct.rs
@@ -390,9 +390,11 @@ impl<B: Buffer, T: AsyncWrite + Unpin> WriteBuffer<B, T> {
         let mut written: usize = 0;
         let total_payload: usize = chunks.iter().map(|c| c.len()).sum::<usize>() + padding;
 
+        let mut iov: Vec<IoSlice<'_>> = Vec::with_capacity(chunks.len() + 1);
+
         while written < total_payload {
+            iov.clear();
             let mut to_skip = written;
-            let mut iov: Vec<IoSlice<'_>> = Vec::new();
 
             for chunk in &chunks {
                 if to_skip == 0 {


### PR DESCRIPTION
this pr introduces changes to speed up large block requests, for example 1M that is handled be many smaller allocator blocks, for example 64K

This change reduces N+1 syscalls (header + N read payloads) to just 2 syscalls