### PR TITLE
refactor(allocator): unify buffer pools and move read alloc to parser

### DIFF
--- a/mirror_fs/config.toml
+++ b/mirror_fs/config.toml
@@ -1,8 +1,6 @@
 [allocator]
-read_buffer_size = 1048576
-read_buffer_count = 2048
-write_buffer_size = 1048576
-write_buffer_count = 2048
+buffer_size = 1048576
+buffer_count = 2048
 
 [exports]
 root = "/tmp/nfs"

--- a/mirror_fs/src/config.rs
+++ b/mirror_fs/src/config.rs
@@ -102,7 +102,11 @@ pub fn load_config(path: &Path) -> std::io::Result<Config> {
     Ok(Config { allocator, vfs_pool_size, export_root: root, exports })
 }
 
+// Unknown keys are rejected so that a config written for an older layout
+// (`read_buffer_size` / `write_buffer_size`) fails loudly instead of silently
+// falling back to the defaults below.
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawConfig {
     allocator: Option<RawAllocatorConfig>,
     vfs_pool_size: Option<usize>,
@@ -110,12 +114,14 @@ struct RawConfig {
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawAllocatorConfig {
     buffer_size: Option<usize>,
     buffer_count: Option<usize>,
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawExportsConfig {
     root: PathBuf,
     paths: Vec<PathBuf>,
@@ -209,4 +215,43 @@ fn invalid_input(message: impl Into<String>) -> std::io::Error {
 fn non_zero(value: usize, field: &str) -> std::io::Result<NonZeroUsize> {
     NonZeroUsize::new(value)
         .ok_or_else(|| invalid_input(format!("{field} must be greater than zero")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RawAllocatorConfig, RawConfig};
+
+    /// The example config must keep parsing after any key rename.
+    #[test]
+    fn parses_current_allocator_keys() {
+        let raw: RawAllocatorConfig =
+            toml::from_str("buffer_size = 1024\nbuffer_count = 8\n").unwrap();
+
+        assert_eq!(raw.buffer_size, Some(1024));
+        assert_eq!(raw.buffer_count, Some(8));
+    }
+
+    /// A config written for the old split read/write pools must fail loudly
+    /// instead of silently falling back to the built-in defaults.
+    #[test]
+    fn rejects_legacy_allocator_keys() {
+        let legacy = "[allocator]\n\
+             read_buffer_size = 1048576\n\
+             read_buffer_count = 2048\n\
+             write_buffer_size = 1048576\n\
+             write_buffer_count = 2048\n";
+
+        let Err(error) = toml::from_str::<RawConfig>(legacy) else {
+            panic!("legacy allocator keys must be rejected");
+        };
+        assert!(
+            error.to_string().contains("unknown field"),
+            "error should point at the stale key, got: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_keys() {
+        assert!(toml::from_str::<RawConfig>("vfs_poll_size = 4\n").is_err());
+    }
 }

--- a/mirror_fs/src/config.rs
+++ b/mirror_fs/src/config.rs
@@ -5,10 +5,8 @@ use serde::Deserialize;
 
 const DEFAULT_VFS_POOL_SIZE: usize = 10;
 const MAX_EXPORTS_COUNT: usize = 256;
-const DEFAULT_READ_BUFFER_SIZE: usize = 64 * 1024;
-const DEFAULT_READ_BUFFER_COUNT: usize = 2048;
-const DEFAULT_WRITE_BUFFER_SIZE: usize = 64 * 1024;
-const DEFAULT_WRITE_BUFFER_COUNT: usize = 2048;
+const DEFAULT_BUFFER_SIZE: usize = 64 * 1024;
+const DEFAULT_BUFFER_COUNT: usize = 2048;
 
 #[derive(Debug)]
 pub struct Config {
@@ -20,10 +18,8 @@ pub struct Config {
 
 #[derive(Debug)]
 pub struct AllocatorConfig {
-    pub read_buffer_size: NonZeroUsize,
-    pub read_buffer_count: NonZeroUsize,
-    pub write_buffer_size: NonZeroUsize,
-    pub write_buffer_count: NonZeroUsize,
+    pub buffer_size: NonZeroUsize,
+    pub buffer_count: NonZeroUsize,
 }
 
 #[derive(Debug)]
@@ -46,10 +42,8 @@ impl Default for Config {
 impl Default for AllocatorConfig {
     fn default() -> Self {
         Self {
-            read_buffer_size: NonZeroUsize::new(DEFAULT_READ_BUFFER_SIZE).unwrap(),
-            read_buffer_count: NonZeroUsize::new(DEFAULT_READ_BUFFER_COUNT).unwrap(),
-            write_buffer_size: NonZeroUsize::new(DEFAULT_WRITE_BUFFER_SIZE).unwrap(),
-            write_buffer_count: NonZeroUsize::new(DEFAULT_WRITE_BUFFER_COUNT).unwrap(),
+            buffer_size: NonZeroUsize::new(DEFAULT_BUFFER_SIZE).unwrap(),
+            buffer_count: NonZeroUsize::new(DEFAULT_BUFFER_COUNT).unwrap(),
         }
     }
 }
@@ -65,21 +59,13 @@ pub fn load_config(path: &Path) -> std::io::Result<Config> {
 
     let allocator = match raw_config.allocator {
         Some(raw_alloc) => AllocatorConfig {
-            read_buffer_size: non_zero(
-                raw_alloc.read_buffer_size.unwrap_or(DEFAULT_READ_BUFFER_SIZE),
-                "read_buffer_size",
+            buffer_size: non_zero(
+                raw_alloc.buffer_size.unwrap_or(DEFAULT_BUFFER_SIZE),
+                "buffer_size",
             )?,
-            read_buffer_count: non_zero(
-                raw_alloc.read_buffer_count.unwrap_or(DEFAULT_READ_BUFFER_COUNT),
-                "read_buffer_count",
-            )?,
-            write_buffer_size: non_zero(
-                raw_alloc.write_buffer_size.unwrap_or(DEFAULT_WRITE_BUFFER_SIZE),
-                "write_buffer_size",
-            )?,
-            write_buffer_count: non_zero(
-                raw_alloc.write_buffer_count.unwrap_or(DEFAULT_WRITE_BUFFER_COUNT),
-                "write_buffer_count",
+            buffer_count: non_zero(
+                raw_alloc.buffer_count.unwrap_or(DEFAULT_BUFFER_COUNT),
+                "buffer_count",
             )?,
         },
         None => AllocatorConfig::default(),
@@ -125,10 +111,8 @@ struct RawConfig {
 
 #[derive(Deserialize)]
 struct RawAllocatorConfig {
-    read_buffer_size: Option<usize>,
-    read_buffer_count: Option<usize>,
-    write_buffer_size: Option<usize>,
-    write_buffer_count: Option<usize>,
+    buffer_size: Option<usize>,
+    buffer_count: Option<usize>,
 }
 
 #[derive(Deserialize)]

--- a/mirror_fs/src/main.rs
+++ b/mirror_fs/src/main.rs
@@ -32,11 +32,7 @@ async fn main() -> std::io::Result<()> {
 
     let context = ServerContext::new(
         fs.clone(),
-        Arc::new(Impl::new(config.allocator.read_buffer_size, config.allocator.read_buffer_count)),
-        Arc::new(Impl::new(
-            config.allocator.write_buffer_size,
-            config.allocator.write_buffer_count,
-        )),
+        Arc::new(Impl::new(config.allocator.buffer_size, config.allocator.buffer_count)),
         config.vfs_pool_size,
     );
 

--- a/nfs-mamont/src/allocator/mod.rs
+++ b/nfs-mamont/src/allocator/mod.rs
@@ -72,20 +72,31 @@ pub trait Allocator {
 
     /// Returns a buffer of at least `size` bytes.
     ///
+    /// Waits until enough memory is available, so the returned future may stay
+    /// pending while the pool is exhausted.
+    ///
     /// # Parameters
     ///
     /// - `size` --- minimum size of the returned buffer in bytes.
     ///
-    /// # Panic
+    /// # Returns
     ///
-    /// This method returns [`None`] if size is greater then allocator capacity.
+    /// Returns [`None`] if `size` is greater than [`Allocator::capacity`],
+    /// since such a request can never be satisfied.
     fn allocate(&self, size: NonZeroUsize) -> impl Future<Output = Option<Self::Buffer>> + Send;
+
+    /// Returns the largest size [`Allocator::allocate`] can ever satisfy.
+    ///
+    /// Callers that are free to shorten their request (for example NFSv3 `READ`,
+    /// where a short read is legal) should clamp to this value instead of
+    /// failing on an oversized request.
+    fn capacity(&self) -> NonZeroUsize;
 }
 
 pub struct Impl {
     state: Arc<AllocatorState>,
     buffer_size: NonZeroUsize,
-    buffer_count: NonZeroUsize,
+    capacity: NonZeroUsize,
 }
 
 impl Impl {
@@ -131,12 +142,9 @@ impl Impl {
         Self {
             state: Arc::new(AllocatorState { pool, semaphore, base_ptr, layout }),
             buffer_size: size,
-            buffer_count: count,
+            // `total_size` is a product of two non-zero values, checked above.
+            capacity: NonZeroUsize::new(total_size).expect("capacity must be non-zero"),
         }
-    }
-
-    fn capacity(&self) -> usize {
-        self.buffer_size.get() * self.buffer_count.get()
     }
 }
 
@@ -144,7 +152,7 @@ impl Allocator for Impl {
     type Buffer = slice::Slice;
 
     async fn allocate(&self, size: NonZeroUsize) -> Option<Self::Buffer> {
-        if size.get() > self.capacity() {
+        if size > self.capacity {
             return None;
         }
 
@@ -168,5 +176,9 @@ impl Allocator for Impl {
         permit.forget();
 
         Some(Slice::new(buffers, 0..size.get(), Some(Arc::clone(&self.state))))
+    }
+
+    fn capacity(&self) -> NonZeroUsize {
+        self.capacity
     }
 }

--- a/nfs-mamont/src/context.rs
+++ b/nfs-mamont/src/context.rs
@@ -16,8 +16,8 @@ where
 {
     /// Pool of async workers that execute NFS procedures against [`crate::vfs::Vfs`].
     vfs_pool: VfsPool<B>,
-    /// Single allocator serving both READ output buffers and WRITE data buffers,
-    /// used on the read side of each connection.
+    /// Allocator backing all user-data buffers: READ output buffers and WRITE
+    /// payload buffers are served from this single pool.
     allocator: Arc<A>,
     /// Filesystem implementation backing all NFS operations.
     backend: Arc<V>,

--- a/nfs-mamont/src/context.rs
+++ b/nfs-mamont/src/context.rs
@@ -5,7 +5,7 @@ use crate::allocator::{Allocator, Buffer};
 use crate::task::global::vfs::VfsPool;
 use crate::vfs;
 
-/// Shared server resources: VFS worker pool, buffer allocators, and backend.
+/// Shared server resources: VFS worker pool, buffer allocator, and backend.
 ///
 /// Construct once at startup and share across connection handlers.
 pub struct ServerContext<A, V, B>
@@ -16,10 +16,9 @@ where
 {
     /// Pool of async workers that execute NFS procedures against [`crate::vfs::Vfs`].
     vfs_pool: VfsPool<B>,
-    /// Allocator for read buffers (sliced from a pre-sized pool).
-    read_allocator: Arc<A>,
-    /// Allocator for write-side buffers when needed by the stack.
-    write_allocator: Arc<A>,
+    /// Single allocator serving both READ output buffers and WRITE data buffers,
+    /// used on the read side of each connection.
+    allocator: Arc<A>,
     /// Filesystem implementation backing all NFS operations.
     backend: Arc<V>,
 }
@@ -30,17 +29,11 @@ where
     B: Buffer + 'static,
     V: vfs::Vfs<B> + Send + Sync + 'static,
 {
-    /// Creates a context with the given backend and buffer pool sizes.
-    pub fn new(
-        backend: Arc<V>,
-        read_allocator: Arc<A>,
-        write_allocator: Arc<A>,
-        vfs_pool_size: NonZeroUsize,
-    ) -> Self {
-        let vfs_pool =
-            VfsPool::new(vfs_pool_size, Arc::clone(&backend), Arc::clone(&read_allocator));
+    /// Creates a context with the given backend and buffer pool size.
+    pub fn new(backend: Arc<V>, allocator: Arc<A>, vfs_pool_size: NonZeroUsize) -> Self {
+        let vfs_pool = VfsPool::new(vfs_pool_size, Arc::clone(&backend));
 
-        Self { vfs_pool, read_allocator, write_allocator, backend }
+        Self { vfs_pool, allocator, backend }
     }
 
     /// Returns the shared VFS worker pool used to dispatch NFS procedure work.
@@ -55,15 +48,9 @@ where
         Arc::clone(&self.backend)
     }
 
-    /// Returns a clone of the read buffer allocator.
+    /// Returns a clone of the shared buffer allocator.
     #[inline]
-    pub fn get_read_allocator(&self) -> Arc<A> {
-        Arc::clone(&self.read_allocator)
-    }
-
-    /// Returns a clone of the write buffer allocator.
-    #[inline]
-    pub fn get_write_allocator(&self) -> Arc<A> {
-        Arc::clone(&self.write_allocator)
+    pub fn get_allocator(&self) -> Arc<A> {
+        Arc::clone(&self.allocator)
     }
 }

--- a/nfs-mamont/src/parser/mod.rs
+++ b/nfs-mamont/src/parser/mod.rs
@@ -106,8 +106,9 @@ pub enum NfsArguments<B: Buffer> {
     Access(access::Args),
     /// Arguments for the [`read_link`] operation.
     ReadLink(read_link::Args),
-    /// Arguments for the [`read`] operation.
-    Read(read::Args),
+    /// Arguments for the [`read`] operation together with the output buffer
+    /// the backend fills with the read result.
+    Read(read::Args, B),
     /// Arguments for the [`mod@write`] operation.
     Write(write::Args<B>),
     /// Arguments for the [`create`] operation.

--- a/nfs-mamont/src/parser/parser_struct.rs
+++ b/nfs-mamont/src/parser/parser_struct.rs
@@ -257,7 +257,10 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
             READLINK => {
                 NfsArguments::ReadLink(self.buffer.parse_with_retry(read_link::args).await?)
             }
-            READ => NfsArguments::Read(self.buffer.parse_with_retry(read::args).await?),
+            READ => {
+                let (args, data) = adapter_for_read(&self.allocator, &mut self.buffer).await?;
+                NfsArguments::Read(args, data)
+            }
             WRITE => {
                 NfsArguments::Write(adapter_for_write(&self.allocator, &mut self.buffer).await?)
             }
@@ -644,6 +647,46 @@ where
         stable: part_arg.stable,
         data: buffer_data,
     })
+}
+
+/// Special adapter for parsing READ procedure arguments.
+///
+/// Unlike WRITE, the READ request carries no opaque data on the wire; the
+/// buffer allocated here is the server-side *output* buffer that the backend
+/// fills with the read result. Allocating it on the read side keeps a single
+/// allocator serving both READ and WRITE and removes the allocator from the
+/// VFS worker pool.
+///
+/// # Arguments
+///
+/// * `alloc` - The allocator to use for allocating the read output buffer
+/// * `buffer` - The buffer to read the fixed arguments from
+///
+/// # Returns
+///
+/// Returns the parsed [`vfs::read::Args`] together with the allocated output
+/// buffer, or an error if parsing fails or memory allocation fails. A zero-byte
+/// read yields an empty buffer without touching the allocator.
+async fn adapter_for_read<A, S>(
+    alloc: &Arc<A>,
+    buffer: &mut CountBuffer<S>,
+) -> Result<(vfs::read::Args, A::Buffer)>
+where
+    A: Allocator,
+    S: AsyncRead + Unpin,
+{
+    let args = buffer.parse_with_retry(read::args).await?;
+
+    let data = if args.count == 0 {
+        A::Buffer::empty()
+    } else {
+        let size = NonZeroUsize::new(args.count as usize).unwrap();
+        alloc.allocate(size).await.ok_or_else(|| {
+            Error::IO(io::Error::new(ErrorKind::OutOfMemory, "cannot allocate memory"))
+        })?
+    };
+
+    Ok((args, data))
 }
 
 /// Reads data into a slice asynchronously from the `CountBuffer`.

--- a/nfs-mamont/src/parser/parser_struct.rs
+++ b/nfs-mamont/src/parser/parser_struct.rs
@@ -543,6 +543,11 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     /// this method discards the remaining message data to maintain stream alignment
     /// for subsequent messages. For other errors, it returns them as-is.
     ///
+    /// Allocation failures are discarded as well: the frame itself is well-formed,
+    /// so leaving it half-consumed would desync [`CountBuffer::total_bytes`] and
+    /// make every later [`Self::finalize_parsing`] fail with "Unparsed data
+    /// remaining in frame".
+    ///
     /// # Arguments
     ///
     /// * `error` - The error that occurred during parsing
@@ -551,13 +556,18 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     ///
     /// Returns the error, potentially after attempting to discard the message.
     async fn match_errors(&mut self, error: Error) -> Error {
-        if let Error::RpcVersionMismatch(_)
-        | Error::ProgramMismatch
-        | Error::ProcedureMismatch
-        | Error::Auth(_)
-        | Error::MessageTypeMismatch
-        | Error::ProgramVersionMismatch(_) = &error
-        {
+        let recoverable = match &error {
+            Error::RpcVersionMismatch(_)
+            | Error::ProgramMismatch
+            | Error::ProcedureMismatch
+            | Error::Auth(_)
+            | Error::MessageTypeMismatch
+            | Error::ProgramVersionMismatch(_) => true,
+            Error::IO(err) => err.kind() == ErrorKind::OutOfMemory,
+            _ => false,
+        };
+
+        if recoverable {
             proc_nested_errors(error, self.discard_current_message()).await
         } else {
             error
@@ -622,11 +632,13 @@ where
     let part_arg = buffer.parse_with_retry(write::args).await?;
     let size = buffer.parse_with_retry(u32_as_usize).await?;
 
-    // Attempt allocation with the given size, or fallback to NonZeroUsize::MIN.
-    let non_zero_size = NonZeroUsize::new(size).unwrap_or(NonZeroUsize::MIN);
-    let mut buffer_data = alloc.allocate(non_zero_size).await.ok_or_else(|| {
-        Error::IO(io::Error::new(ErrorKind::OutOfMemory, "cannot allocate memory"))
-    })?;
+    // A zero-length write needs no buffer at all, so it never takes a pool slot.
+    let mut buffer_data = match NonZeroUsize::new(size) {
+        None => A::Buffer::empty(),
+        Some(non_zero_size) => alloc.allocate(non_zero_size).await.ok_or_else(|| {
+            Error::IO(io::Error::new(ErrorKind::OutOfMemory, "cannot allocate memory"))
+        })?,
+    };
 
     // Calculate necessary padding to maintain ALIGNMENT
     let padding = (ALIGNMENT - (size % ALIGNMENT)) % ALIGNMENT;
@@ -657,6 +669,12 @@ where
 /// allocator serving both READ and WRITE and removes the allocator from the
 /// VFS worker pool.
 ///
+/// A `count` larger than the allocator can ever serve is clamped instead of
+/// rejected: RFC 1813 allows the server to answer with fewer bytes than
+/// requested, so an oversized request becomes a short read rather than an
+/// error. The clamped value is written back into the returned arguments so the
+/// backend never sees a `count` larger than the buffer it is handed.
+///
 /// # Arguments
 ///
 /// * `alloc` - The allocator to use for allocating the read output buffer
@@ -675,15 +693,16 @@ where
     A: Allocator,
     S: AsyncRead + Unpin,
 {
-    let args = buffer.parse_with_retry(read::args).await?;
+    let mut args = buffer.parse_with_retry(read::args).await?;
 
-    let data = if args.count == 0 {
-        A::Buffer::empty()
-    } else {
-        let size = NonZeroUsize::new(args.count as usize).unwrap();
-        alloc.allocate(size).await.ok_or_else(|| {
+    let count = min(args.count as usize, alloc.capacity().get());
+    args.count = count as u32;
+
+    let data = match NonZeroUsize::new(count) {
+        None => A::Buffer::empty(),
+        Some(size) => alloc.allocate(size).await.ok_or_else(|| {
             Error::IO(io::Error::new(ErrorKind::OutOfMemory, "cannot allocate memory"))
-        })?
+        })?,
     };
 
     Ok((args, data))

--- a/nfs-mamont/src/parser/tests/allocator.rs
+++ b/nfs-mamont/src/parser/tests/allocator.rs
@@ -29,4 +29,11 @@ impl Allocator for MockAllocator {
             None
         }
     }
+
+    /// `max_size == 0` means "every allocation fails"; it cannot be expressed as
+    /// a [`NonZeroUsize`], so such a mock reports a capacity of one byte that
+    /// [`Self::allocate`] still refuses.
+    fn capacity(&self) -> NonZeroUsize {
+        NonZeroUsize::new(self.max_size).unwrap_or(NonZeroUsize::MIN)
+    }
 }

--- a/nfs-mamont/src/parser/tests/parser_struct.rs
+++ b/nfs-mamont/src/parser/tests/parser_struct.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::allocator::Buffer;
 use crate::consts::mount::{MOUNT_PROGRAM, MOUNT_VERSION};
-use crate::consts::nfsv3::{FSSTAT, NFS_PROGRAM, NFS_VERSION, WRITE};
+use crate::consts::nfsv3::{FSSTAT, NFS_PROGRAM, NFS_VERSION, READ, WRITE};
 use crate::parser::parser_struct::RpcParser;
 use crate::parser::tests::allocator::MockAllocator;
 use crate::parser::tests::socket::MockSocket;
@@ -157,6 +157,29 @@ fn fsstat_args(root: [u8; 8]) -> Vec<u8> {
     let mut args = Vec::new();
     push_opaque(&mut args, &root);
     args
+}
+
+/// Serializes read (NFS procedure 6) arguments: file handle, offset and count.
+fn read_args(file: [u8; 8], offset: u64, count: u32) -> Vec<u8> {
+    let mut args = Vec::new();
+    push_opaque(&mut args, &file);
+    push_u64(&mut args, offset);
+    push_u32(&mut args, count);
+    args
+}
+
+/// Helper to assert parsed READ arguments and the size of the attached output buffer.
+fn assert_read_proc_result<B: Buffer>(result: &ProcArguments<B>, expected: (u64, u32, usize)) {
+    let (expected_offset, expected_count, expected_len) = expected;
+    let ProcArguments::Nfs3(args) = result else {
+        panic!("Wrong program argument type");
+    };
+    let NfsArguments::Read(args, data) = args.as_ref() else {
+        panic!("Wrong NFS argument type");
+    };
+    assert_eq!(args.offset, expected_offset);
+    assert_eq!(args.count, expected_count);
+    assert_eq!(data.len(), expected_len);
 }
 
 /// Serializes write (NFS procedure 7) arguments, including count, offset, stable, and data.
@@ -333,6 +356,115 @@ async fn parse_after_error() {
 
     let result = parser.next_message().await;
     assert!(result.is_err());
+    let result = parser.next_message().await.unwrap();
+    assert_arg_wrapper(
+        result,
+        &header,
+        |proc, opaque| assert_fsstat_proc_result(proc, opaque),
+        &[1, 2, 3, 4, 5, 6, 7, 8],
+    );
+}
+
+/// Test: READ parsing allocates an output buffer of the requested size.
+#[tokio::test]
+async fn parse_read() {
+    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
+    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+
+    let frame = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, READ, |buf| {
+        buf.extend_from_slice(&read_args([1, 2, 3, 4, 5, 6, 7, 8], 0x8000, 512));
+    });
+
+    let socket = MockSocket::new(frame.as_slice());
+    let alloc = Arc::new(MockAllocator::new(4096));
+    let mut parser = RpcParser::with_capacity(socket, alloc, 96);
+
+    let result = parser.next_message().await.unwrap();
+    assert_arg_wrapper(result, &header, assert_read_proc_result, (0x8000, 512, 512));
+}
+
+/// Test: READ with `count == 0` yields an empty buffer without touching the allocator.
+#[tokio::test]
+async fn parse_read_with_zero_count() {
+    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
+    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+
+    let frame = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, READ, |buf| {
+        buf.extend_from_slice(&read_args([1, 2, 3, 4, 5, 6, 7, 8], 0, 0));
+    });
+
+    let socket = MockSocket::new(frame.as_slice());
+    // An allocator that fails every request: a zero-count READ must not consult it.
+    let alloc = Arc::new(MockAllocator::new(0));
+    let mut parser = RpcParser::with_capacity(socket, alloc, 96);
+
+    let result = parser.next_message().await.unwrap();
+    assert_arg_wrapper(result, &header, assert_read_proc_result, (0, 0, 0));
+}
+
+/// Test: a `count` the allocator can never serve is clamped into a short read
+/// instead of failing the request.
+#[tokio::test]
+async fn parse_read_clamps_oversized_count() {
+    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
+    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+
+    let frame = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, READ, |buf| {
+        buf.extend_from_slice(&read_args([1, 2, 3, 4, 5, 6, 7, 8], 0, u32::MAX));
+    });
+
+    let socket = MockSocket::new(frame.as_slice());
+    let alloc = Arc::new(MockAllocator::new(1024));
+    let mut parser = RpcParser::with_capacity(socket, alloc, 96);
+
+    let result = parser.next_message().await.unwrap();
+    // `count` is rewritten so the backend never sees more than the buffer holds.
+    assert_arg_wrapper(result, &header, assert_read_proc_result, (0, 1024, 1024));
+}
+
+/// Test: an allocation failure leaves the stream aligned, so the next frame still parses.
+///
+/// Regression test: the failing frame used to be left half-consumed, which
+/// desynced the byte counter and made every subsequent frame fail with
+/// "Unparsed data remaining in frame".
+#[tokio::test]
+async fn parse_after_allocation_failure() {
+    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
+    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+
+    let data = [0x01_u8, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+    let write = WriteWrapper {
+        part: write::ArgsPartial {
+            file: Handle([1, 2, 3, 4, 5, 6, 7, 8]),
+            offset: 0x8000,
+            size: 0xFF,
+            stable: StableHow::Unstable,
+        },
+        data: &data,
+    };
+
+    let first = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, WRITE, |buf| {
+        buf.extend_from_slice(&write_args(&write));
+    });
+    let second = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, FSSTAT, |buf| {
+        buf.extend_from_slice(&fsstat_args([1, 2, 3, 4, 5, 6, 7, 8]));
+    });
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&first);
+    buf.extend_from_slice(&second);
+
+    let socket = MockSocket::new(buf.as_slice());
+    // Too small for the 8-byte WRITE payload, so allocation fails.
+    let alloc = Arc::new(MockAllocator::new(4));
+    let mut parser = RpcParser::with_capacity(socket, alloc, 80);
+
+    let result = parser.next_message().await;
+    assert!(matches!(
+        result,
+        Err(ErrorWrapper { error: Error::IO(ref err), xid: Some(XID) })
+            if err.kind() == std::io::ErrorKind::OutOfMemory
+    ));
+
     let result = parser.next_message().await.unwrap();
     assert_arg_wrapper(
         result,

--- a/nfs-mamont/src/task/connection/mod.rs
+++ b/nfs-mamont/src/task/connection/mod.rs
@@ -50,7 +50,7 @@ pub async fn new<A, V, B>(
         mount_sender,
         nlm_sender,
         result_sender.clone(),
-        context.get_write_allocator(),
+        context.get_allocator(),
         context.get_vfs_pool().sender(),
     )
     .spawn();

--- a/nfs-mamont/src/task/global/vfs.rs
+++ b/nfs-mamont/src/task/global/vfs.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use tracing::{error, warn};
 
-use crate::allocator::{Allocator, Buffer};
+use crate::allocator::Buffer;
 use crate::parser::{NfsArgWrapper, NfsArguments};
 use crate::task::{ProcReply, ProcResult};
 use crate::vfs::{self, NfsRes, Vfs};
@@ -29,21 +29,19 @@ impl<B: Buffer + 'static> VfsPool<B> {
     ///
     /// - `num` --- number of workers to create
     /// - `backend` --- shared filesystem implementation
-    /// - `allocator` --- allocator used for read buffers
     ///
     /// # Returns
     ///
     /// A new [`VfsPool`] with the given number of workers.
-    pub fn new<A, V>(num: NonZeroUsize, backend: Arc<V>, allocator: Arc<A>) -> Self
+    pub fn new<V>(num: NonZeroUsize, backend: Arc<V>) -> Self
     where
-        A: Allocator<Buffer = B> + Send + Sync + 'static,
         V: Vfs<B> + Send + Sync + 'static,
     {
         let (tx, rx) = async_channel::unbounded::<VfsCommand<B>>();
 
         (0..num.get()).for_each(|_| {
             let rx_clone = rx.clone();
-            VfsTask::new(Arc::clone(&backend), Arc::clone(&allocator), rx_clone).spawn();
+            VfsTask::new(Arc::clone(&backend), rx_clone).spawn();
         });
 
         Self { sender: tx }
@@ -63,23 +61,19 @@ impl<B: Buffer> Drop for VfsPool<B> {
 }
 
 /// Task that executes NFS procedures against [`Vfs`] and sends the result to the writer pipeline.
-pub struct VfsTask<A, V, B>
+pub struct VfsTask<V, B>
 where
-    A: Allocator<Buffer = B> + Send + Sync + 'static,
     B: Buffer,
     V: vfs::Vfs<B> + Send + Sync + 'static,
 {
     /// Shared filesystem implementation.
     backend: Arc<V>,
-    /// Allocator used for read buffers.
-    allocator: Arc<A>,
     /// Shared receiver from the pool, each worker competes for the same command stream.
     command_receiver: VfsCommandReceiver<B>,
 }
 
-impl<A, V, B> VfsTask<A, V, B>
+impl<V, B> VfsTask<V, B>
 where
-    A: Allocator<Buffer = B> + Send + Sync + 'static,
     B: Buffer + 'static,
     V: vfs::Vfs<B> + Send + Sync + 'static,
 {
@@ -88,18 +82,13 @@ where
     /// # Parameters
     ///
     /// - `backend` --- shared filesystem implementation
-    /// - `allocator` --- allocator used for read buffers
     /// - `command_receiver` --- receiver from the pool
     ///
     /// # Returns
     ///
     /// A new [`VfsTask`] that reads commands from the pool and executes them.
-    pub fn new(
-        backend: Arc<V>,
-        allocator: Arc<A>,
-        command_receiver: VfsCommandReceiver<B>,
-    ) -> Self {
-        Self { backend, allocator, command_receiver }
+    pub fn new(backend: Arc<V>, command_receiver: VfsCommandReceiver<B>) -> Self {
+        Self { backend, command_receiver }
     }
 
     /// Spawns a [`VfsTask`].
@@ -128,23 +117,7 @@ where
                 NfsArguments::ReadLink(args) => {
                     NfsRes::ReadLink(self.backend.read_link(args).await)
                 }
-                NfsArguments::Read(args) => {
-                    let data_result = if args.count == 0 {
-                        Ok(B::empty())
-                    } else {
-                        let requested_size = NonZeroUsize::new(args.count as usize).unwrap();
-
-                        self.allocator
-                            .allocate(requested_size)
-                            .await
-                            .ok_or(vfs::read::Fail { error: vfs::Error::TooSmall, file_attr: None })
-                    };
-
-                    match data_result {
-                        Ok(data) => NfsRes::Read(self.backend.read(args, data).await),
-                        Err(err) => NfsRes::Read(Err(err)),
-                    }
-                }
+                NfsArguments::Read(args, data) => NfsRes::Read(self.backend.read(args, data).await),
                 NfsArguments::Write(args) => NfsRes::Write(self.backend.write(args).await),
                 NfsArguments::Create(args) => NfsRes::Create(self.backend.create(args).await),
                 NfsArguments::MkDir(args) => NfsRes::MkDir(self.backend.mk_dir(args).await),
@@ -191,7 +164,7 @@ where
             NfsArguments::LookUp(_) => "LOOKUP",
             NfsArguments::Access(_) => "ACCESS",
             NfsArguments::ReadLink(_) => "READLINK",
-            NfsArguments::Read(_) => "READ",
+            NfsArguments::Read(..) => "READ",
             NfsArguments::Write(_) => "WRITE",
             NfsArguments::Create(_) => "CREATE",
             NfsArguments::MkDir(_) => "MKDIR",


### PR DESCRIPTION
Remopved read allocator. All allocations now are inside readtask