### PR TITLE
refactor(allocator): introduce non-blocking try_allocate with fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,6 @@ version = "0.0.0"
 dependencies = [
  "async-channel",
  "byteorder",
- "crossbeam-queue",
  "libc",
  "num-derive",
  "num-traits",

--- a/nfs-mamont/Cargo.toml
+++ b/nfs-mamont/Cargo.toml
@@ -23,6 +23,5 @@ num-traits.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 async-channel.workspace = true
-crossbeam-queue.workspace = true
 trait-variant.workspace = true
 libc = { version = "0.2.186", optional = true }

--- a/nfs-mamont/src/allocator/mod.rs
+++ b/nfs-mamont/src/allocator/mod.rs
@@ -70,26 +70,53 @@ pub trait Allocator {
     /// Type of buffer returned by this allocator.
     type Buffer: Buffer;
 
-    /// Returns a buffer of at least `size` bytes.
+    /// Attempts to allocate a buffer of (at most) `size` bytes without blocking.
     ///
-    /// Waits until enough memory is available, so the returned future may stay
-    /// pending while the pool is exhausted.
+    /// This is a "best-effort" operation: the returned buffer may be smaller
+    /// than `size` (partial allocation). If no memory can be granted right now,
+    /// [`None`] is returned — the caller should either retry later or fall back
+    /// to the blocking [`Self::allocate_block`].
     ///
     /// # Parameters
     ///
-    /// - `size` --- minimum size of the returned buffer in bytes.
-    ///
-    /// # Returns
-    ///
-    /// Returns [`None`] if `size` is greater than [`Allocator::capacity`],
-    /// since such a request can never be satisfied.
-    fn allocate(&self, size: NonZeroUsize) -> impl Future<Output = Option<Self::Buffer>> + Send;
+    /// - `size` --- maximum size of the returned buffer in bytes.
+    fn try_allocate(&self, size: NonZeroUsize) -> Option<Self::Buffer>;
 
-    /// Returns the largest size [`Allocator::allocate`] can ever satisfy.
+    /// Allocates a single minimal buffer, blocking until one is available.
+    ///
+    /// The returned buffer is exactly one allocation unit of the allocator and
+    /// is not guaranteed to satisfy the originally requested `size`.
+    fn allocate_block(&self) -> impl Future<Output = Self::Buffer> + Send;
+
+    /// Returns a buffer of at most `size` bytes.
+    ///
+    /// This is a convenience combination of [`Self::try_allocate`] and
+    /// [`Self::allocate_block`]: it first attempts a non-blocking allocation,
+    /// and if the pool is exhausted, falls back to blocking for a single block.
+    /// The returned buffer is best-effort: it may be partial (`len() < size`)
+    /// when the allocator cannot provide the full size without waiting.
+    ///
+    /// # Parameters
+    ///
+    /// - `size` --- requested size of the returned buffer in bytes.
+    fn allocate(&self, size: NonZeroUsize) -> impl Future<Output = Option<Self::Buffer>> + Send
+    where
+        Self: Sync,
+    {
+        async move {
+            match self.try_allocate(size) {
+                Some(buffer) => Some(buffer),
+                None => Some(self.allocate_block().await),
+            }
+        }
+    }
+
+    /// Returns the largest size an allocation can ever be fully satisfied for.
     ///
     /// Callers that are free to shorten their request (for example NFSv3 `READ`,
     /// where a short read is legal) should clamp to this value instead of
-    /// failing on an oversized request.
+    /// failing on an oversized request. Beyond this size only partial
+    /// allocations or single blocks are available.
     fn capacity(&self) -> NonZeroUsize;
 }
 
@@ -151,18 +178,14 @@ impl Impl {
 impl Allocator for Impl {
     type Buffer = slice::Slice;
 
-    async fn allocate(&self, size: NonZeroUsize) -> Option<Self::Buffer> {
+    fn try_allocate(&self, size: NonZeroUsize) -> Option<Self::Buffer> {
         if size > self.capacity {
             return None;
         }
 
-        let remain_size = size.get();
-        let count_needed = remain_size.div_ceil(self.buffer_size.get());
+        let count_needed = size.get().div_ceil(self.buffer_size.get());
 
-        let permit = match self.state.semaphore.acquire_many(count_needed as u32).await {
-            Ok(p) => p,
-            Err(_) => return None,
-        };
+        let permit = self.state.semaphore.try_acquire_many(count_needed as u32).ok()?;
 
         let mut buffers = Vec::with_capacity(count_needed);
         for _ in 0..count_needed {
@@ -176,6 +199,17 @@ impl Allocator for Impl {
         permit.forget();
 
         Some(Slice::new(buffers, 0..size.get(), Some(Arc::clone(&self.state))))
+    }
+
+    async fn allocate_block(&self) -> Self::Buffer {
+        let permit =
+            self.state.semaphore.acquire().await.expect("allocator semaphore is never closed");
+
+        let buf = self.state.pool.pop().expect("Semaphore permitted allocation but pool was empty");
+
+        permit.forget();
+
+        Slice::new(vec![buf], 0..self.buffer_size.get(), Some(Arc::clone(&self.state)))
     }
 
     fn capacity(&self) -> NonZeroUsize {

--- a/nfs-mamont/src/allocator/mod.rs
+++ b/nfs-mamont/src/allocator/mod.rs
@@ -59,6 +59,18 @@ pub trait Buffer: Send + Sync {
     /// Returns `true` if the buffer is empty.
     fn is_empty(&self) -> bool;
 
+    /// Shrinks the buffer to at most `len` bytes.
+    ///
+    /// Buffers handed out by an allocator may be larger than the payload that
+    /// was actually written into them (see [`Allocator::allocate_block`]).
+    /// Truncating hides the untouched tail --- which still holds bytes of
+    /// whatever request used the memory before --- from every later consumer.
+    ///
+    /// Does nothing when `len` is not smaller than the current length. The
+    /// backing memory is kept and released as a whole when the buffer is
+    /// dropped.
+    fn truncate(&mut self, len: usize);
+
     /// Creates an empty, zero-length buffer with no backing memory.
     fn empty() -> Self
     where
@@ -73,9 +85,11 @@ pub trait Allocator {
     /// Attempts to allocate a buffer of (at most) `size` bytes without blocking.
     ///
     /// This is a "best-effort" operation: the returned buffer may be smaller
-    /// than `size` (partial allocation). If no memory can be granted right now,
-    /// [`None`] is returned — the caller should either retry later or fall back
-    /// to the blocking [`Self::allocate_block`].
+    /// than `size` (partial allocation), both when `size` exceeds
+    /// [`Self::capacity`] and when part of the pool is currently held by
+    /// someone else. If no memory at all can be granted right now, [`None`] is
+    /// returned — the caller should either retry later or fall back to the
+    /// blocking [`Self::allocate_block`].
     ///
     /// # Parameters
     ///
@@ -85,7 +99,10 @@ pub trait Allocator {
     /// Allocates a single minimal buffer, blocking until one is available.
     ///
     /// The returned buffer is exactly one allocation unit of the allocator and
-    /// is not guaranteed to satisfy the originally requested `size`.
+    /// is not guaranteed to satisfy the originally requested `size`. It may
+    /// therefore be *larger* than what the caller intends to fill, so a caller
+    /// that hands the buffer on must [`Buffer::truncate`] it to the number of
+    /// bytes it actually wrote.
     fn allocate_block(&self) -> impl Future<Output = Self::Buffer> + Send;
 
     /// Returns a buffer of at most `size` bytes.
@@ -94,19 +111,20 @@ pub trait Allocator {
     /// [`Self::allocate_block`]: it first attempts a non-blocking allocation,
     /// and if the pool is exhausted, falls back to blocking for a single block.
     /// The returned buffer is best-effort: it may be partial (`len() < size`)
-    /// when the allocator cannot provide the full size without waiting.
+    /// when the allocator cannot provide the full size without waiting, and it
+    /// may exceed `size` when the fallback block is bigger than the request.
     ///
     /// # Parameters
     ///
     /// - `size` --- requested size of the returned buffer in bytes.
-    fn allocate(&self, size: NonZeroUsize) -> impl Future<Output = Option<Self::Buffer>> + Send
+    fn allocate(&self, size: NonZeroUsize) -> impl Future<Output = Self::Buffer> + Send
     where
         Self: Sync,
     {
         async move {
             match self.try_allocate(size) {
-                Some(buffer) => Some(buffer),
-                None => Some(self.allocate_block().await),
+                Some(buffer) => buffer,
+                None => self.allocate_block().await,
             }
         }
     }
@@ -179,16 +197,31 @@ impl Allocator for Impl {
     type Buffer = slice::Slice;
 
     fn try_allocate(&self, size: NonZeroUsize) -> Option<Self::Buffer> {
-        if size > self.capacity {
-            return None;
-        }
+        // A request beyond the pool size can never be satisfied in full, so it
+        // is clamped instead of rejected: a capacity-sized buffer serves the
+        // caller far better than the single block it would fall back to.
+        let wanted = size.get().min(self.capacity.get());
 
-        let count_needed = size.get().div_ceil(self.buffer_size.get());
+        // Grant as many blocks as the pool can spare right now. Each failed
+        // attempt lowers the request by at least one block, so the loop always
+        // terminates, and it drops straight to the observed permit count
+        // instead of walking down one block at a time.
+        let mut count = wanted.div_ceil(self.buffer_size.get());
+        let permit = loop {
+            if count == 0 {
+                return None;
+            }
+            match self.state.semaphore.try_acquire_many(count as u32) {
+                Ok(permit) => break permit,
+                Err(_) => {
+                    let available = self.state.semaphore.available_permits();
+                    count = count.saturating_sub(1).min(available);
+                }
+            }
+        };
 
-        let permit = self.state.semaphore.try_acquire_many(count_needed as u32).ok()?;
-
-        let mut buffers = Vec::with_capacity(count_needed);
-        for _ in 0..count_needed {
+        let mut buffers = Vec::with_capacity(count);
+        for _ in 0..count {
             if let Some(buf) = self.state.pool.pop() {
                 buffers.push(buf);
             } else {
@@ -198,7 +231,9 @@ impl Allocator for Impl {
 
         permit.forget();
 
-        Some(Slice::new(buffers, 0..size.get(), Some(Arc::clone(&self.state))))
+        let granted = wanted.min(count * self.buffer_size.get());
+
+        Some(Slice::new(buffers, 0..granted, Some(Arc::clone(&self.state))))
     }
 
     async fn allocate_block(&self) -> Self::Buffer {

--- a/nfs-mamont/src/allocator/mod.rs
+++ b/nfs-mamont/src/allocator/mod.rs
@@ -12,19 +12,28 @@ use std::future::Future;
 #[cfg(feature = "mlock")]
 use std::io;
 use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use crossbeam_queue::ArrayQueue;
-use tokio::sync::Semaphore;
+use async_channel::{Receiver, Sender};
 
 pub use buffer::UnownedBuffer;
 pub use slice::Slice;
 
-/// Shared state of the allocator to allow return of buffers and permit restoration.
+/// Shared state of the allocator, letting buffers find their way back to the pool.
+///
+/// The channel is both the list of free blocks and the queue of callers waiting
+/// for one, so there is no second counter to keep in sync with it.
 #[derive(Debug)]
 pub struct AllocatorState {
-    pub pool: ArrayQueue<UnownedBuffer>,
-    pub semaphore: Semaphore,
+    /// Blocks that are currently free.
+    free: Receiver<UnownedBuffer>,
+    /// Returns blocks to [`Self::free`]. Never blocks: the channel capacity
+    /// equals the number of blocks in circulation, and a slice only ever gives
+    /// back the blocks it took.
+    ret: Sender<UnownedBuffer>,
+    /// How many callers are parked in [`Allocator::allocate_block`] right now.
+    waiting: AtomicUsize,
     base_ptr: *mut u8,
     layout: Layout,
 }
@@ -32,14 +41,45 @@ pub struct AllocatorState {
 unsafe impl Send for AllocatorState {}
 unsafe impl Sync for AllocatorState {}
 
+impl AllocatorState {
+    /// Puts a block back into the pool, waking one parked caller.
+    ///
+    /// Returns `false` if the pool refused the block, which cannot happen for a
+    /// block that came from this allocator.
+    fn return_buffer(&self, buffer: UnownedBuffer) -> bool {
+        self.ret.try_send(buffer).is_ok()
+    }
+}
+
 impl Drop for AllocatorState {
     fn drop(&mut self) {
-        while self.pool.pop().is_some() {}
+        while self.free.try_recv().is_ok() {}
         #[cfg(feature = "mlock")]
         unsafe {
             libc::munlock(self.base_ptr as *mut libc::c_void, self.layout.size());
         }
         unsafe { alloc::dealloc(self.base_ptr, self.layout) };
+    }
+}
+
+/// Marks its owner as parked in [`Allocator::allocate_block`] for as long as it lives.
+///
+/// The count has to be restored when the future is dropped mid-wait --- a
+/// cancelled connection task does exactly that --- otherwise
+/// [`Allocator::try_allocate`] would keep a block reserved for a caller that no
+/// longer exists.
+struct Parked<'a>(&'a AllocatorState);
+
+impl<'a> Parked<'a> {
+    fn enter(state: &'a AllocatorState) -> Self {
+        state.waiting.fetch_add(1, Ordering::AcqRel);
+        Self(state)
+    }
+}
+
+impl Drop for Parked<'_> {
+    fn drop(&mut self) {
+        self.0.waiting.fetch_sub(1, Ordering::AcqRel);
     }
 }
 
@@ -152,8 +192,8 @@ impl Impl {
     /// - `size` --- size of each buffer to allocate
     /// - `count` --- number of buffers to allocate
     pub fn new(size: NonZeroUsize, count: NonZeroUsize) -> Self {
-        let pool = ArrayQueue::new(count.get());
-        let semaphore = Semaphore::new(count.get());
+        // Capacity matches the block count, so returning a block never blocks.
+        let (ret, free) = async_channel::bounded(count.get());
 
         let buffer_size = size.get();
         let buffer_count = count.get();
@@ -180,12 +220,18 @@ impl Impl {
         let mut current_ptr = base_ptr;
         for _ in 0..buffer_count {
             let buffer = unsafe { UnownedBuffer::from_raw_parts(current_ptr, buffer_size) };
-            pool.push(buffer).expect("can't initialize allocator");
+            ret.try_send(buffer).expect("can't initialize allocator");
             current_ptr = unsafe { current_ptr.add(buffer_size) };
         }
 
         Self {
-            state: Arc::new(AllocatorState { pool, semaphore, base_ptr, layout }),
+            state: Arc::new(AllocatorState {
+                free,
+                ret,
+                waiting: AtomicUsize::new(0),
+                base_ptr,
+                layout,
+            }),
             buffer_size: size,
             // `total_size` is a product of two non-zero values, checked above.
             capacity: NonZeroUsize::new(total_size).expect("capacity must be non-zero"),
@@ -201,50 +247,44 @@ impl Allocator for Impl {
         // is clamped instead of rejected: a capacity-sized buffer serves the
         // caller far better than the single block it would fall back to.
         let wanted = size.get().min(self.capacity.get());
+        let needed = wanted.div_ceil(self.buffer_size.get());
 
-        // Grant as many blocks as the pool can spare right now. Each failed
-        // attempt lowers the request by at least one block, so the loop always
-        // terminates, and it drops straight to the observed permit count
-        // instead of walking down one block at a time.
-        let mut count = wanted.div_ceil(self.buffer_size.get());
-        let permit = loop {
-            if count == 0 {
-                return None;
-            }
-            match self.state.semaphore.try_acquire_many(count as u32) {
-                Ok(permit) => break permit,
-                Err(_) => {
-                    let available = self.state.semaphore.available_permits();
-                    count = count.saturating_sub(1).min(available);
-                }
-            }
-        };
+        // Leave one block behind for every parked caller. `allocate_block`
+        // waits on this same channel, but `try_recv` bypasses its FIFO wake-up
+        // queue, so without the reservation a steady stream of `try_allocate`
+        // calls could starve a blocked one indefinitely. One block each is
+        // enough --- that is all a parked caller needs to make progress.
+        let state = &self.state;
+        let spare = state.free.len().saturating_sub(state.waiting.load(Ordering::Acquire));
+        let take = needed.min(spare);
 
-        let mut buffers = Vec::with_capacity(count);
-        for _ in 0..count {
-            if let Some(buf) = self.state.pool.pop() {
-                buffers.push(buf);
-            } else {
-                unreachable!("Semaphore permitted allocation but pool was empty");
+        let mut buffers = Vec::with_capacity(take);
+        while buffers.len() < take {
+            match state.free.try_recv() {
+                Ok(buffer) => buffers.push(buffer),
+                // Both counts above are snapshots, so the pool may have been
+                // drained in the meantime. Whatever was collected still stands.
+                Err(_) => break,
             }
         }
 
-        permit.forget();
+        if buffers.is_empty() {
+            return None;
+        }
 
-        let granted = wanted.min(count * self.buffer_size.get());
+        let granted = wanted.min(buffers.len() * self.buffer_size.get());
 
-        Some(Slice::new(buffers, 0..granted, Some(Arc::clone(&self.state))))
+        Some(Slice::new(buffers, 0..granted, Some(Arc::clone(state))))
     }
 
     async fn allocate_block(&self) -> Self::Buffer {
-        let permit =
-            self.state.semaphore.acquire().await.expect("allocator semaphore is never closed");
+        let _parked = Parked::enter(&self.state);
 
-        let buf = self.state.pool.pop().expect("Semaphore permitted allocation but pool was empty");
+        // The state owns both ends of the channel and outlives every slice, so
+        // the channel cannot be closed while this call can be made.
+        let buffer = self.state.free.recv().await.expect("allocator channel is never closed");
 
-        permit.forget();
-
-        Slice::new(vec![buf], 0..self.buffer_size.get(), Some(Arc::clone(&self.state)))
+        Slice::new(vec![buffer], 0..self.buffer_size.get(), Some(Arc::clone(&self.state)))
     }
 
     fn capacity(&self) -> NonZeroUsize {

--- a/nfs-mamont/src/allocator/slice.rs
+++ b/nfs-mamont/src/allocator/slice.rs
@@ -76,19 +76,20 @@ impl Slice {
         self.into_iter()
     }
 
-    /// Deallocates all buffers by returning them to the allocator state (pool)
-    /// and restoring the corresponding permits on its semaphore.
+    /// Deallocates all buffers by returning them to the allocator's pool.
     ///
     /// The allocator state is provided when constructing the slice via [`Self::new`].
     fn deallocate(&mut self) {
         if let Some(state) = &self.state {
-            let count = self.buffers.len();
             for buffer in self.buffers.drain(..) {
-                // Ignore allocator drop
-                let _ = state.pool.push(buffer);
-            }
-            if count > 0 {
-                state.semaphore.add_permits(count);
+                // The channel capacity equals the number of blocks in
+                // circulation and this slice only gives back blocks it took, so
+                // it cannot be full; it cannot be closed either while `state`
+                // is alive. Keep the send outside the assertion --- a release
+                // build drops the argument of `debug_assert!` and would leak
+                // every block.
+                let returned = state.return_buffer(buffer);
+                debug_assert!(returned, "allocator pool rejected a returned block");
             }
         }
     }

--- a/nfs-mamont/src/allocator/slice.rs
+++ b/nfs-mamont/src/allocator/slice.rs
@@ -59,6 +59,15 @@ impl Slice {
         self.range.len() == 0
     }
 
+    /// Shrinks the accessible range to at most `len` bytes.
+    ///
+    /// Does nothing when `len` is not smaller than the current length. The
+    /// buffers themselves are kept, so the whole allocation is still returned
+    /// to the pool on drop.
+    pub fn truncate(&mut self, len: usize) {
+        self.range.end = self.range.end.min(self.range.start.saturating_add(len));
+    }
+
     pub fn iter_mut(&mut self) -> IterMut<'_> {
         self.into_iter()
     }
@@ -237,6 +246,10 @@ impl Buffer for Slice {
 
     fn is_empty(&self) -> bool {
         self.range.len() == 0
+    }
+
+    fn truncate(&mut self, len: usize) {
+        Self::truncate(self, len);
     }
 
     fn empty() -> Self {

--- a/nfs-mamont/src/allocator/tests/allocator/allocate.rs
+++ b/nfs-mamont/src/allocator/tests/allocator/allocate.rs
@@ -2,6 +2,7 @@
 
 use std::io::Write;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::allocator::Allocator as _;
@@ -203,8 +204,119 @@ async fn allocate_block_returns_single_block() {
 
     drop(slice);
 
-    // The permit is restored after drop, so the pool can be fully saturated again.
+    // The block is back in the pool after drop, so it can be fully saturated again.
     let slice = allocator.allocate(NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap()).await;
+    assert_eq!(slice.iter().count(), COUNT.get());
+}
+
+/// `try_allocate` shares the pool with `allocate_block`, and its non-blocking
+/// take bypasses the wake-up queue, so it has to leave a block behind for every
+/// caller already parked --- otherwise a busy caller starves a blocked one.
+#[tokio::test]
+async fn try_allocate_leaves_a_block_for_a_parked_caller() {
+    const SIZE: NonZeroUsize = NonZeroUsize::new(13).unwrap();
+    const COUNT: NonZeroUsize = NonZeroUsize::new(2).unwrap();
+
+    let allocator = Arc::new(Impl::new(SIZE, COUNT));
+
+    // Occupy both blocks with separate slices, so one can be released alone.
+    let first = allocator.try_allocate(SIZE).unwrap();
+    let second = allocator.try_allocate(SIZE).unwrap();
+
+    // Park a caller on the drained pool.
+    let parked = tokio::spawn({
+        let allocator = Arc::clone(&allocator);
+        async move { allocator.allocate_block().await }
+    });
+    // One scheduler turn is enough for the spawned task to reach its `await`
+    // and register; the rest are slack.
+    for _ in 0..32 {
+        tokio::task::yield_now().await;
+    }
+
+    // Hand back a single block. It belongs to the parked caller, and this task
+    // does not await in between, so nothing else could have taken it yet.
+    drop(first);
+
+    assert!(
+        allocator.try_allocate(SIZE).is_none(),
+        "try_allocate took the block reserved for the parked caller"
+    );
+
+    let slice = tokio::time::timeout(Duration::from_secs(5), parked)
+        .await
+        .expect("the parked caller was starved")
+        .unwrap();
+    assert_eq!(slice.len(), SIZE.get());
+
+    // With nobody parked any more, the remaining block is grantable again.
+    drop(second);
+    assert!(allocator.try_allocate(SIZE).is_some());
+}
+
+/// Dropping an `allocate_block` future mid-wait --- what a cancelled connection
+/// task does --- must release the block it had reserved.
+#[tokio::test]
+async fn cancelled_allocate_block_releases_its_reservation() {
+    const SIZE: NonZeroUsize = NonZeroUsize::new(13).unwrap();
+    const COUNT: NonZeroUsize = NonZeroUsize::new(4).unwrap();
+    const WHOLE_POOL: NonZeroUsize = NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap();
+
+    let allocator = Impl::new(SIZE, COUNT);
+
+    let pool = allocator.allocate(WHOLE_POOL).await;
+
+    {
+        let mut parked = Box::pin(allocator.allocate_block());
+        // Poll once so the caller registers as waiting, then drop it unfinished.
+        assert!(tokio::time::timeout(Duration::from_millis(120), &mut parked).await.is_err());
+    }
+
+    drop(pool);
+
+    // With the reservation gone the whole pool is grantable again.
+    let slice = allocator.try_allocate(WHOLE_POOL).expect("the pool is free");
+    assert_eq!(slice.iter().count(), COUNT.get());
+}
+
+/// Many callers contending for a pool far smaller than the demand: every one of
+/// them must eventually be served, whichever entry point they use.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn every_caller_is_eventually_served_under_contention() {
+    const SIZE: NonZeroUsize = NonZeroUsize::new(64).unwrap();
+    const COUNT: NonZeroUsize = NonZeroUsize::new(4).unwrap();
+    const TASKS: usize = 64;
+
+    let allocator = Arc::new(Impl::new(SIZE, COUNT));
+
+    let tasks: Vec<_> = (0..TASKS)
+        .map(|n| {
+            let allocator = Arc::clone(&allocator);
+            tokio::spawn(async move {
+                for _ in 0..16 {
+                    // Half the tasks ask for more than the pool holds, half for
+                    // a single block; both must make progress.
+                    let want = if n % 2 == 0 { SIZE.get() * COUNT.get() } else { SIZE.get() };
+                    let slice = allocator.allocate(NonZeroUsize::new(want).unwrap()).await;
+                    assert!(!slice.is_empty());
+                    tokio::task::yield_now().await;
+                    drop(slice);
+                }
+            })
+        })
+        .collect();
+
+    for task in tasks {
+        tokio::time::timeout(Duration::from_secs(10), task)
+            .await
+            .expect("a caller was starved")
+            .expect("a caller panicked");
+    }
+
+    // Nothing leaked: the pool is whole again.
+    let slice = allocator
+        .try_allocate(NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap())
+        .expect("every block came back");
     assert_eq!(slice.iter().count(), COUNT.get());
 }
 

--- a/nfs-mamont/src/allocator/tests/allocator/allocate.rs
+++ b/nfs-mamont/src/allocator/tests/allocator/allocate.rs
@@ -9,7 +9,7 @@ use crate::allocator::Impl;
 
 async fn check_allocate(buffer_size: NonZeroUsize, count: NonZeroUsize, alloc_size: NonZeroUsize) {
     let allocator = Impl::new(buffer_size, count);
-    let mut slice = allocator.allocate(alloc_size).await.unwrap();
+    let mut slice = allocator.allocate(alloc_size).await;
 
     let verify: Vec<u8> = (0..alloc_size.get()).map(|u| (u + 1) as u8).collect();
 
@@ -40,7 +40,7 @@ async fn check_allocate(buffer_size: NonZeroUsize, count: NonZeroUsize, alloc_si
     drop(slice);
 
     let allocator_capacity = NonZeroUsize::new(buffer_size.get() * count.get()).unwrap();
-    let slice = allocator.allocate(allocator_capacity).await.unwrap();
+    let slice = allocator.allocate(allocator_capacity).await;
     assert_eq!(slice.iter().count(), count.get());
 }
 
@@ -92,11 +92,11 @@ async fn reclaiming() {
     let allocator = Impl::new(SIZE, COUNT);
 
     for _ in 0..5 {
-        let slice = allocator.allocate(ALLOC_SIZE).await.unwrap();
+        let slice = allocator.allocate(ALLOC_SIZE).await;
         assert_eq!(slice.iter().count(), COUNT.get());
 
         tokio::time::timeout(Duration::from_millis(120), async {
-            allocator.allocate(NonZeroUsize::new(1).unwrap()).await.unwrap();
+            allocator.allocate(NonZeroUsize::new(1).unwrap()).await;
             unreachable!("allocator should hang")
         })
         .await
@@ -104,25 +104,72 @@ async fn reclaiming() {
 
         drop(slice);
 
-        let slice = allocator.allocate(ALLOC_SIZE).await.unwrap();
+        let slice = allocator.allocate(ALLOC_SIZE).await;
         assert_eq!(slice.iter().count(), COUNT.get());
     }
 }
 
 #[tokio::test]
-async fn try_allocate_more_than_capacity_returns_none() {
+async fn try_allocate_more_than_capacity_is_clamped() {
     const SIZE: NonZeroUsize = NonZeroUsize::new(13).unwrap();
     const COUNT: NonZeroUsize = NonZeroUsize::new(15).unwrap();
 
     let allocator = Impl::new(SIZE, COUNT);
     let requested = NonZeroUsize::new(SIZE.get() * COUNT.get() + 1).unwrap();
 
-    assert!(allocator.try_allocate(requested).is_none());
+    // A request beyond the pool is served with the whole pool rather than
+    // rejected --- the caller would only fall back to a single block.
+    let slice = allocator.try_allocate(requested).expect("clamped to capacity");
+    assert_eq!(slice.len(), SIZE.get() * COUNT.get());
+    assert_eq!(slice.iter().count(), COUNT.get());
+}
 
-    // The convenience `allocate` falls back to a single block instead of `None`.
-    let slice = allocator.allocate(requested).await.unwrap();
-    assert_eq!(slice.len(), SIZE.get());
-    assert_eq!(slice.iter().count(), 1);
+#[tokio::test]
+async fn try_allocate_grants_what_the_pool_can_spare() {
+    const SIZE: NonZeroUsize = NonZeroUsize::new(13).unwrap();
+    const COUNT: NonZeroUsize = NonZeroUsize::new(8).unwrap();
+
+    let allocator = Impl::new(SIZE, COUNT);
+
+    // Hold three of the eight blocks.
+    let held = allocator.try_allocate(NonZeroUsize::new(SIZE.get() * 3).unwrap()).unwrap();
+    assert_eq!(held.iter().count(), 3);
+
+    // A request for the whole pool is served partially with the remaining five
+    // blocks instead of failing outright.
+    let partial = allocator.try_allocate(NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap());
+    let partial = partial.expect("partial allocation");
+    assert_eq!(partial.len(), SIZE.get() * 5);
+    assert_eq!(partial.iter().count(), 5);
+
+    // Now nothing is left.
+    assert!(allocator.try_allocate(NonZeroUsize::MIN).is_none());
+
+    drop(partial);
+    drop(held);
+
+    assert_eq!(
+        allocator.try_allocate(NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap()).unwrap().len(),
+        SIZE.get() * COUNT.get()
+    );
+}
+
+#[tokio::test]
+async fn try_allocate_partial_is_bounded_by_the_request() {
+    const SIZE: NonZeroUsize = NonZeroUsize::new(13).unwrap();
+    const COUNT: NonZeroUsize = NonZeroUsize::new(8).unwrap();
+
+    let allocator = Impl::new(SIZE, COUNT);
+
+    // Hold everything but two blocks, then ask for a size that needs three:
+    // the granted slice spans two blocks but is never longer than requested.
+    let held = allocator.try_allocate(NonZeroUsize::new(SIZE.get() * 6).unwrap()).unwrap();
+    assert_eq!(held.iter().count(), 6);
+
+    let requested = NonZeroUsize::new(SIZE.get() * 2 + 1).unwrap();
+    let partial = allocator.try_allocate(requested).expect("partial allocation");
+    assert_eq!(partial.len(), SIZE.get() * 2);
+    assert_eq!(partial.iter().count(), 2);
 }
 
 #[tokio::test]
@@ -133,8 +180,7 @@ async fn try_allocate_returns_none_when_pool_is_exhausted() {
     let allocator = Impl::new(SIZE, COUNT);
 
     // Occupy the entire pool.
-    let pool =
-        allocator.allocate(NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap()).await.unwrap();
+    let pool = allocator.allocate(NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap()).await;
 
     assert!(allocator.try_allocate(NonZeroUsize::MIN).is_none());
 
@@ -158,8 +204,7 @@ async fn allocate_block_returns_single_block() {
     drop(slice);
 
     // The permit is restored after drop, so the pool can be fully saturated again.
-    let slice =
-        allocator.allocate(NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap()).await.unwrap();
+    let slice = allocator.allocate(NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap()).await;
     assert_eq!(slice.iter().count(), COUNT.get());
 }
 
@@ -171,8 +216,7 @@ async fn allocate_block_blocks_until_a_block_is_released() {
     let allocator = Impl::new(SIZE, COUNT);
 
     // Occupy the entire pool.
-    let pool =
-        allocator.allocate(NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap()).await.unwrap();
+    let pool = allocator.allocate(NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap()).await;
 
     let (tx, mut rx) = tokio::sync::oneshot::channel();
     let handle = tokio::spawn(async move {

--- a/nfs-mamont/src/allocator/tests/allocator/allocate.rs
+++ b/nfs-mamont/src/allocator/tests/allocator/allocate.rs
@@ -110,12 +110,86 @@ async fn reclaiming() {
 }
 
 #[tokio::test]
-async fn allocate_more_than_capacity_returns_none() {
+async fn try_allocate_more_than_capacity_returns_none() {
     const SIZE: NonZeroUsize = NonZeroUsize::new(13).unwrap();
     const COUNT: NonZeroUsize = NonZeroUsize::new(15).unwrap();
 
     let allocator = Impl::new(SIZE, COUNT);
     let requested = NonZeroUsize::new(SIZE.get() * COUNT.get() + 1).unwrap();
 
-    assert!(allocator.allocate(requested).await.is_none());
+    assert!(allocator.try_allocate(requested).is_none());
+
+    // The convenience `allocate` falls back to a single block instead of `None`.
+    let slice = allocator.allocate(requested).await.unwrap();
+    assert_eq!(slice.len(), SIZE.get());
+    assert_eq!(slice.iter().count(), 1);
+}
+
+#[tokio::test]
+async fn try_allocate_returns_none_when_pool_is_exhausted() {
+    const SIZE: NonZeroUsize = NonZeroUsize::new(13).unwrap();
+    const COUNT: NonZeroUsize = NonZeroUsize::new(3).unwrap();
+
+    let allocator = Impl::new(SIZE, COUNT);
+
+    // Occupy the entire pool.
+    let pool =
+        allocator.allocate(NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap()).await.unwrap();
+
+    assert!(allocator.try_allocate(NonZeroUsize::MIN).is_none());
+
+    drop(pool);
+
+    // After the buffer is released the pool is available again.
+    assert!(allocator.try_allocate(NonZeroUsize::MIN).is_some());
+}
+
+#[tokio::test]
+async fn allocate_block_returns_single_block() {
+    const SIZE: NonZeroUsize = NonZeroUsize::new(13).unwrap();
+    const COUNT: NonZeroUsize = NonZeroUsize::new(15).unwrap();
+
+    let allocator = Impl::new(SIZE, COUNT);
+
+    let slice = allocator.allocate_block().await;
+    assert_eq!(slice.len(), SIZE.get());
+    assert_eq!(slice.iter().count(), 1);
+
+    drop(slice);
+
+    // The permit is restored after drop, so the pool can be fully saturated again.
+    let slice =
+        allocator.allocate(NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap()).await.unwrap();
+    assert_eq!(slice.iter().count(), COUNT.get());
+}
+
+#[tokio::test]
+async fn allocate_block_blocks_until_a_block_is_released() {
+    const SIZE: NonZeroUsize = NonZeroUsize::new(13).unwrap();
+    const COUNT: NonZeroUsize = NonZeroUsize::new(15).unwrap();
+
+    let allocator = Impl::new(SIZE, COUNT);
+
+    // Occupy the entire pool.
+    let pool =
+        allocator.allocate(NonZeroUsize::new(SIZE.get() * COUNT.get()).unwrap()).await.unwrap();
+
+    let (tx, mut rx) = tokio::sync::oneshot::channel();
+    let handle = tokio::spawn(async move {
+        let slice = allocator.allocate_block().await;
+        let _ = tx.send(slice);
+    });
+
+    // The task cannot complete while the pool is fully held.
+    assert!(tokio::time::timeout(Duration::from_millis(120), &mut rx).await.is_err());
+
+    drop(pool);
+
+    let slice = tokio::time::timeout(Duration::from_secs(5), rx)
+        .await
+        .expect("timed out waiting for block")
+        .unwrap();
+    assert_eq!(slice.len(), SIZE.get());
+    assert_eq!(slice.iter().count(), 1);
+    assert!(handle.await.is_ok());
 }

--- a/nfs-mamont/src/parser/parser_struct.rs
+++ b/nfs-mamont/src/parser/parser_struct.rs
@@ -262,7 +262,12 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
                 NfsArguments::Read(args, data)
             }
             WRITE => {
-                NfsArguments::Write(adapter_for_write(&self.allocator, &mut self.buffer).await?)
+                // CountBuffer counts every byte of the frame except the RMS
+                // header, so the frame ends at that many consumed bytes.
+                let frame_end = self.current_frame_size + RMS_HEADER_SIZE;
+                NfsArguments::Write(
+                    adapter_for_write(&self.allocator, &mut self.buffer, frame_end).await?,
+                )
             }
             CREATE => NfsArguments::Create(self.buffer.parse_with_retry(create::args).await?),
             MKDIR => NfsArguments::MkDir(self.buffer.parse_with_retry(mk_dir::args).await?),
@@ -543,10 +548,10 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     /// this method discards the remaining message data to maintain stream alignment
     /// for subsequent messages. For other errors, it returns them as-is.
     ///
-    /// Allocation failures are discarded as well: the frame itself is well-formed,
-    /// so leaving it half-consumed would desync [`CountBuffer::total_bytes`] and
-    /// make every later [`Self::finalize_parsing`] fail with "Unparsed data
-    /// remaining in frame".
+    /// Rejected arguments ([`Error::MaxElemLimit`]) are discarded as well: the
+    /// frame itself is well-formed, so leaving it half-consumed would desync
+    /// [`CountBuffer::total_bytes`] and make every later [`Self::finalize_parsing`]
+    /// fail with "Unparsed data remaining in frame".
     ///
     /// # Arguments
     ///
@@ -556,16 +561,16 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     ///
     /// Returns the error, potentially after attempting to discard the message.
     async fn match_errors(&mut self, error: Error) -> Error {
-        let recoverable = match &error {
+        let recoverable = matches!(
+            &error,
             Error::RpcVersionMismatch(_)
-            | Error::ProgramMismatch
-            | Error::ProcedureMismatch
-            | Error::Auth(_)
-            | Error::MessageTypeMismatch
-            | Error::ProgramVersionMismatch(_) => true,
-            Error::IO(err) => err.kind() == ErrorKind::OutOfMemory,
-            _ => false,
-        };
+                | Error::ProgramMismatch
+                | Error::ProcedureMismatch
+                | Error::Auth(_)
+                | Error::MessageTypeMismatch
+                | Error::ProgramVersionMismatch(_)
+                | Error::MaxElemLimit
+        );
 
         if recoverable {
             proc_nested_errors(error, self.discard_current_message()).await
@@ -610,24 +615,28 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
 /// 4. Discards any padding bytes
 ///
 /// The allocation is best-effort: a `try_allocate` that cannot be satisfied is
-/// followed by a blocking fallback for a single block, so a partial buffer that
-/// is smaller than the requested `size` may be returned. Only the bytes the
-/// buffer can actually hold are read from the frame; the remainder of the
-/// payload is discarded to keep the stream aligned.
+/// followed by a blocking fallback for a single block, so the buffer may be
+/// smaller than the requested `size`. Only the bytes the buffer can actually
+/// hold are read from the frame; the remainder of the payload is discarded to
+/// keep the stream aligned, and the buffer is truncated to what was read so
+/// that the untouched tail of a pooled block never reaches the backend.
 ///
 /// # Arguments
 ///
 /// * `alloc` - The allocator to use for allocating the write data buffer
 /// * `buffer` - The buffer to read from
+/// * `frame_end` - Number of consumed bytes at which the current RMS frame ends
 ///
 /// # Returns
 ///
 /// Returns the parsed [`vfs::write::Args`] with allocated data, or an error if:
 /// - Parsing fails
+/// - The announced data length does not fit into the current frame
 /// - Reading the data fails
 async fn adapter_for_write<A, S>(
     alloc: &Arc<A>,
     buffer: &mut CountBuffer<S>,
+    frame_end: usize,
 ) -> Result<vfs::write::Args<A::Buffer>>
 where
     A: Allocator,
@@ -636,6 +645,23 @@ where
     // Parse arguments for WRITE procedure.
     let part_arg = buffer.parse_with_retry(write::args).await?;
     let size = buffer.parse_with_retry(u32_as_usize).await?;
+
+    // Calculate necessary padding to maintain ALIGNMENT
+    let padding = (ALIGNMENT - (size % ALIGNMENT)) % ALIGNMENT;
+
+    // The announced length is attacker-controlled and the payload is no longer
+    // bounded by what the allocator can serve, so check it against the frame
+    // before touching the pool: otherwise a tiny frame claiming a 4 GiB write
+    // would make the discard below pull that many bytes off the socket.
+    // `size` spans the whole `u32` range, which is the whole `usize` range on a
+    // 32-bit target, so the padding is added saturating.
+    let frame_left = frame_end.saturating_sub(buffer.total_bytes());
+    if size.saturating_add(padding) > frame_left {
+        // A well-formed frame carrying an impossible length: recoverable, so
+        // `match_errors` discards the rest of the frame and the connection
+        // survives a single malformed request.
+        return Err(Error::MaxElemLimit);
+    }
 
     // A zero-length write needs no buffer at all, so it never takes a pool slot.
     // Otherwise attempt a non-blocking allocation and fall back to a single
@@ -648,9 +674,6 @@ where
         },
     };
 
-    // Calculate necessary padding to maintain ALIGNMENT
-    let padding = (ALIGNMENT - (size % ALIGNMENT)) % ALIGNMENT;
-
     // The allocated buffer may be partial, so read only what it can hold and
     // discard the rest of the frame payload to keep the stream aligned.
     let to_read = size.min(buffer_data.len());
@@ -662,12 +685,19 @@ where
             .await?;
     }
 
+    // A fallback block can be larger than the payload; its tail still holds the
+    // bytes of whatever request owned the block before. Cut it off so nothing
+    // downstream can write those bytes to a file.
+    buffer_data.truncate(to_read);
+
     // Discard the unread data remainder and any trailing padding bytes.
     buffer.discard_bytes(size - to_read + padding).await.map_err(Error::IO)?;
     Ok(vfs::write::Args {
         file: part_arg.file,
         offset: part_arg.offset,
-        size: part_arg.size,
+        // `size` is the count the client asked to write; it must never promise
+        // the backend more bytes than the buffer actually carries.
+        size: part_arg.size.min(to_read as u32),
         stable: part_arg.stable,
         data: buffer_data,
     })
@@ -711,15 +741,21 @@ where
     let mut args = buffer.parse_with_retry(read::args).await?;
 
     let count = min(args.count as usize, alloc.capacity().get());
-    args.count = count as u32;
 
-    let data = match NonZeroUsize::new(count) {
+    let mut data = match NonZeroUsize::new(count) {
         None => A::Buffer::empty(),
         Some(size) => match alloc.try_allocate(size) {
             Some(buf) => buf,
             None => alloc.allocate_block().await,
         },
     };
+
+    // A fallback block may be either shorter than `count` (short read) or
+    // longer than it (the tail still holds another request's bytes). Cut the
+    // buffer down and report the same number back, so `count` and the buffer
+    // handed to the backend always agree.
+    data.truncate(count);
+    args.count = data.len() as u32;
 
     Ok((args, data))
 }

--- a/nfs-mamont/src/parser/parser_struct.rs
+++ b/nfs-mamont/src/parser/parser_struct.rs
@@ -609,6 +609,12 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
 /// 3. Reads the data from the buffer (handling both sync and async portions)
 /// 4. Discards any padding bytes
 ///
+/// The allocation is best-effort: a `try_allocate` that cannot be satisfied is
+/// followed by a blocking fallback for a single block, so a partial buffer that
+/// is smaller than the requested `size` may be returned. Only the bytes the
+/// buffer can actually hold are read from the frame; the remainder of the
+/// payload is discarded to keep the stream aligned.
+///
 /// # Arguments
 ///
 /// * `alloc` - The allocator to use for allocating the write data buffer
@@ -618,7 +624,6 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
 ///
 /// Returns the parsed [`vfs::write::Args`] with allocated data, or an error if:
 /// - Parsing fails
-/// - Memory allocation fails
 /// - Reading the data fails
 async fn adapter_for_write<A, S>(
     alloc: &Arc<A>,
@@ -633,25 +638,32 @@ where
     let size = buffer.parse_with_retry(u32_as_usize).await?;
 
     // A zero-length write needs no buffer at all, so it never takes a pool slot.
+    // Otherwise attempt a non-blocking allocation and fall back to a single
+    // blocking block when the pool cannot satisfy the request right now.
     let mut buffer_data = match NonZeroUsize::new(size) {
         None => A::Buffer::empty(),
-        Some(non_zero_size) => alloc.allocate(non_zero_size).await.ok_or_else(|| {
-            Error::IO(io::Error::new(ErrorKind::OutOfMemory, "cannot allocate memory"))
-        })?,
+        Some(non_zero_size) => match alloc.try_allocate(non_zero_size) {
+            Some(buf) => buf,
+            None => alloc.allocate_block().await,
+        },
     };
 
     // Calculate necessary padding to maintain ALIGNMENT
     let padding = (ALIGNMENT - (size % ALIGNMENT)) % ALIGNMENT;
 
+    // The allocated buffer may be partial, so read only what it can hold and
+    // discard the rest of the frame payload to keep the stream aligned.
+    let to_read = size.min(buffer_data.len());
+
     // Read synchronously what is available, then finish asynchronously if needed.
-    let bytes_read_sync = read_in_slice_sync(buffer, &mut buffer_data, size)?;
-    if bytes_read_sync < size {
-        read_in_slice_async(buffer, &mut buffer_data, bytes_read_sync, size - bytes_read_sync)
+    let bytes_read_sync = read_in_slice_sync(buffer, &mut buffer_data, to_read)?;
+    if bytes_read_sync < to_read {
+        read_in_slice_async(buffer, &mut buffer_data, bytes_read_sync, to_read - bytes_read_sync)
             .await?;
     }
 
-    // Discard any trailing padding bytes after the data.
-    buffer.discard_bytes(padding).await.map_err(Error::IO)?;
+    // Discard the unread data remainder and any trailing padding bytes.
+    buffer.discard_bytes(size - to_read + padding).await.map_err(Error::IO)?;
     Ok(vfs::write::Args {
         file: part_arg.file,
         offset: part_arg.offset,
@@ -683,8 +695,11 @@ where
 /// # Returns
 ///
 /// Returns the parsed [`vfs::read::Args`] together with the allocated output
-/// buffer, or an error if parsing fails or memory allocation fails. A zero-byte
-/// read yields an empty buffer without touching the allocator.
+/// buffer, or an error if parsing fails. A zero-byte read yields an empty
+/// buffer without touching the allocator. The allocation is best-effort: when
+/// the pool cannot satisfy the request right now a single block is allocated
+/// with a blocking fallback, which results in a short read — allowed by
+/// RFC 1813; the backend reports the actual number of bytes read.
 async fn adapter_for_read<A, S>(
     alloc: &Arc<A>,
     buffer: &mut CountBuffer<S>,
@@ -700,9 +715,10 @@ where
 
     let data = match NonZeroUsize::new(count) {
         None => A::Buffer::empty(),
-        Some(size) => alloc.allocate(size).await.ok_or_else(|| {
-            Error::IO(io::Error::new(ErrorKind::OutOfMemory, "cannot allocate memory"))
-        })?,
+        Some(size) => match alloc.try_allocate(size) {
+            Some(buf) => buf,
+            None => alloc.allocate_block().await,
+        },
     };
 
     Ok((args, data))

--- a/nfs-mamont/src/parser/read_buffer.rs
+++ b/nfs-mamont/src/parser/read_buffer.rs
@@ -229,8 +229,14 @@ impl<S: AsyncRead + Unpin> CountBuffer<S> {
 
         let mut actual = 0;
 
+        // Discarded bytes go nowhere, so they are read into the write buffer
+        // used as scratch space --- `write_slice` would not do: once the write
+        // position reaches the end of the buffer it yields an empty slice, and
+        // `read` would report `Ok(0)` as if the connection had closed. Both
+        // internal buffers are fully consumed whenever there is anything left
+        // to take from the socket, so overwriting this one loses nothing.
         loop {
-            let n = src.read(self.bufs[self.write].write_slice()).await?;
+            let n = src.read(self.bufs[self.write].scratch_slice()).await?;
             if n == 0 {
                 break;
             }
@@ -308,6 +314,15 @@ impl ReadBuffer {
     #[inline]
     fn write_slice(&mut self) -> &mut [u8] {
         &mut self.data[self.write_pos..]
+    }
+
+    /// Returns the whole backing storage, ignoring both positions.
+    ///
+    /// Only for data that is being thrown away: the contents are not tracked by
+    /// the read/write positions, so anything still unread would be lost.
+    #[inline]
+    fn scratch_slice(&mut self) -> &mut [u8] {
+        &mut self.data
     }
 
     /// Advances the read position by `n` bytes, consuming that many bytes.

--- a/nfs-mamont/src/parser/tests/allocator.rs
+++ b/nfs-mamont/src/parser/tests/allocator.rs
@@ -3,36 +3,61 @@ use std::sync::Mutex;
 
 use crate::allocator::{Allocator, Slice, UnownedBuffer};
 
+/// Mock allocator for parser tests.
+///
+/// Buffers are backed by leaked `Box<[u8]>` slices; `allocate_block` always
+/// yields a single block of `max_size` bytes. An optional per-allocation
+/// `limit` caps the size of `try_allocate` results, emulating a pool that can
+/// only satisfy part of the request.
 pub struct MockAllocator {
     max_size: usize,
+    limit: Option<usize>,
     _backing: Mutex<Vec<Box<[u8]>>>,
 }
 
 impl MockAllocator {
     pub fn new(max_size: usize) -> Self {
-        Self { max_size, _backing: Mutex::new(Vec::new()) }
+        Self { max_size, limit: None, _backing: Mutex::new(Vec::new()) }
+    }
+
+    /// Creates an allocator whose `try_allocate` returns buffers capped at
+    /// `limit` bytes even when more was requested.
+    pub fn partial(max_size: usize, limit: usize) -> Self {
+        Self { max_size, limit: Some(limit), _backing: Mutex::new(Vec::new()) }
+    }
+
+    fn make_slice(&self, len: usize, range_end: usize) -> Slice {
+        let buf = vec![0; len].into_boxed_slice();
+        let ptr = buf.as_ptr() as *mut u8;
+        self._backing.lock().unwrap().push(buf);
+        let buffer = unsafe { UnownedBuffer::from_raw_parts(ptr, len) };
+        Slice::new(vec![buffer], 0..range_end, None)
     }
 }
 
 impl Allocator for MockAllocator {
     type Buffer = Slice;
 
-    async fn allocate(&self, size: NonZeroUsize) -> Option<Slice> {
-        if size.get() <= self.max_size {
-            let buf = vec![0; size.get()].into_boxed_slice();
-            let len = buf.len();
-            let ptr = buf.as_ptr() as *mut u8;
-            self._backing.lock().unwrap().push(buf);
-            let buffer = unsafe { UnownedBuffer::from_raw_parts(ptr, len) };
-            Some(Slice::new(vec![buffer], 0..size.get(), None))
-        } else {
-            None
+    fn try_allocate(&self, size: NonZeroUsize) -> Option<Slice> {
+        if size.get() > self.max_size {
+            return None;
         }
+        let len = match self.limit {
+            Some(limit) => limit.min(size.get()),
+            None => size.get(),
+        };
+        Some(self.make_slice(len, len))
+    }
+
+    fn allocate_block(&self) -> impl std::future::Future<Output = Slice> + Send {
+        let len = self.max_size.max(1);
+        let slice = self.make_slice(len, len);
+        async move { slice }
     }
 
     /// `max_size == 0` means "every allocation fails"; it cannot be expressed as
     /// a [`NonZeroUsize`], so such a mock reports a capacity of one byte that
-    /// [`Self::allocate`] still refuses.
+    /// [`Self::try_allocate`] still refuses.
     fn capacity(&self) -> NonZeroUsize {
         NonZeroUsize::new(self.max_size).unwrap_or(NonZeroUsize::MIN)
     }

--- a/nfs-mamont/src/parser/tests/allocator.rs
+++ b/nfs-mamont/src/parser/tests/allocator.rs
@@ -6,28 +6,46 @@ use crate::allocator::{Allocator, Slice, UnownedBuffer};
 /// Mock allocator for parser tests.
 ///
 /// Buffers are backed by leaked `Box<[u8]>` slices; `allocate_block` always
-/// yields a single block of `max_size` bytes. An optional per-allocation
-/// `limit` caps the size of `try_allocate` results, emulating a pool that can
-/// only satisfy part of the request.
+/// yields a single block of `block_size` bytes, exactly like the real
+/// allocator, which means the block can be *larger* than what was requested.
+/// An optional per-allocation `limit` caps the size of `try_allocate` results,
+/// emulating a pool that can only satisfy part of the request.
 pub struct MockAllocator {
     max_size: usize,
+    block_size: usize,
     limit: Option<usize>,
+    /// Byte the blocks are pre-filled with, standing in for the leftovers of a
+    /// previous request in a recycled pool block.
+    stale: u8,
     _backing: Mutex<Vec<Box<[u8]>>>,
 }
 
 impl MockAllocator {
     pub fn new(max_size: usize) -> Self {
-        Self { max_size, limit: None, _backing: Mutex::new(Vec::new()) }
+        Self {
+            max_size,
+            block_size: max_size.max(1),
+            limit: None,
+            stale: 0,
+            _backing: Mutex::new(Vec::new()),
+        }
     }
 
     /// Creates an allocator whose `try_allocate` returns buffers capped at
     /// `limit` bytes even when more was requested.
     pub fn partial(max_size: usize, limit: usize) -> Self {
-        Self { max_size, limit: Some(limit), _backing: Mutex::new(Vec::new()) }
+        Self { limit: Some(limit), ..Self::new(max_size) }
+    }
+
+    /// Creates an allocator that never satisfies `try_allocate` and hands out
+    /// `block_size`-byte blocks pre-filled with `stale`, reproducing a pool
+    /// whose recycled blocks still hold another request's bytes.
+    pub fn stale_blocks(max_size: usize, block_size: usize, stale: u8) -> Self {
+        Self { block_size, limit: Some(0), stale, ..Self::new(max_size) }
     }
 
     fn make_slice(&self, len: usize, range_end: usize) -> Slice {
-        let buf = vec![0; len].into_boxed_slice();
+        let buf = vec![self.stale; len].into_boxed_slice();
         let ptr = buf.as_ptr() as *mut u8;
         self._backing.lock().unwrap().push(buf);
         let buffer = unsafe { UnownedBuffer::from_raw_parts(ptr, len) };
@@ -46,18 +64,19 @@ impl Allocator for MockAllocator {
             Some(limit) => limit.min(size.get()),
             None => size.get(),
         };
-        Some(self.make_slice(len, len))
+        // No memory at all is a failed attempt, not an empty buffer.
+        Some(self.make_slice(NonZeroUsize::new(len)?.get(), len))
     }
 
     fn allocate_block(&self) -> impl std::future::Future<Output = Slice> + Send {
-        let len = self.max_size.max(1);
-        let slice = self.make_slice(len, len);
+        let slice = self.make_slice(self.block_size, self.block_size);
         async move { slice }
     }
 
-    /// `max_size == 0` means "every allocation fails"; it cannot be expressed as
-    /// a [`NonZeroUsize`], so such a mock reports a capacity of one byte that
-    /// [`Self::try_allocate`] still refuses.
+    /// `max_size == 0` means "`try_allocate` always fails"; it cannot be
+    /// expressed as a [`NonZeroUsize`], so such a mock reports a capacity of
+    /// one byte. Callers still fall back to [`Self::allocate_block`], which
+    /// always succeeds --- just as the real allocator does.
     fn capacity(&self) -> NonZeroUsize {
         NonZeroUsize::new(self.max_size).unwrap_or(NonZeroUsize::MIN)
     }

--- a/nfs-mamont/src/parser/tests/parser_struct.rs
+++ b/nfs-mamont/src/parser/tests/parser_struct.rs
@@ -422,13 +422,14 @@ async fn parse_read_clamps_oversized_count() {
     assert_arg_wrapper(result, &header, assert_read_proc_result, (0, 1024, 1024));
 }
 
-/// Test: an allocation failure leaves the stream aligned, so the next frame still parses.
+/// Test: a WRITE payload larger than the allocator's pool is read as far as the
+/// available buffer allows, the rest is discarded and the stream stays aligned.
 ///
-/// Regression test: the failing frame used to be left half-consumed, which
-/// desynced the byte counter and made every subsequent frame fail with
-/// "Unparsed data remaining in frame".
+/// The allocator only ever hands out 4-byte blocks, so only the first 4 bytes
+/// of the 8-byte payload are read and the remainder of the frame is discarded;
+/// the following FSSTAT frame must still parse.
 #[tokio::test]
-async fn parse_after_allocation_failure() {
+async fn parse_write_with_small_pool_keeps_stream_aligned() {
     let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
     let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
 
@@ -454,16 +455,25 @@ async fn parse_after_allocation_failure() {
     buf.extend_from_slice(&second);
 
     let socket = MockSocket::new(buf.as_slice());
-    // Too small for the 8-byte WRITE payload, so allocation fails.
+    // Blocks of at most 4 bytes, so allocation falls back to a single block.
     let alloc = Arc::new(MockAllocator::new(4));
     let mut parser = RpcParser::with_capacity(socket, alloc, 80);
 
-    let result = parser.next_message().await;
-    assert!(matches!(
+    let result = parser.next_message().await.unwrap();
+    assert_arg_wrapper(
         result,
-        Err(ErrorWrapper { error: Error::IO(ref err), xid: Some(XID) })
-            if err.kind() == std::io::ErrorKind::OutOfMemory
-    ));
+        &header,
+        |proc, _opaque| {
+            let ProcArguments::Nfs3(args) = proc else {
+                panic!("Wrong program argument type");
+            };
+            let NfsArguments::Write(args) = args.as_ref() else {
+                panic!("Wrong NFS argument type");
+            };
+            assert_eq!(args.data, data[..4]);
+        },
+        &write,
+    );
 
     let result = parser.next_message().await.unwrap();
     assert_arg_wrapper(
@@ -517,6 +527,63 @@ async fn parse_write() {
     let result = parser.next_message().await.unwrap();
 
     assert_arg_wrapper(result, &header, |proc, arg| assert_write_proc_result(proc, arg), &write);
+}
+
+/// Test: WRITE with a partial write buffer — only the buffered prefix is read,
+/// the rest of the frame payload is discarded and the stream stays aligned.
+#[tokio::test]
+async fn parse_write_with_partial_buffer() {
+    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
+    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+
+    let write = WriteWrapper {
+        part: write::ArgsPartial {
+            file: Handle([1, 2, 3, 4, 5, 6, 7, 8]),
+            offset: 0x8000,
+            size: 0xFF,
+            stable: StableHow::Unstable,
+        },
+        data: &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C],
+    };
+
+    let first = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, WRITE, |buf| {
+        buf.extend_from_slice(&write_args(&write));
+    });
+    let second = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, WRITE, |buf| {
+        buf.extend_from_slice(&write_args(&write));
+    });
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&first);
+    buf.extend_from_slice(&second);
+
+    let socket = MockSocket::new(buf.as_slice());
+    // The allocator only hands out 8-byte buffers, so only the first 8 bytes
+    // of the 12-byte payload are read and the rest is discarded.
+    let alloc = Arc::new(MockAllocator::partial(0x24, 8));
+    let mut parser = RpcParser::with_capacity(socket, alloc, 72);
+
+    for _ in 0..2 {
+        let result = parser.next_message().await.unwrap();
+
+        assert_arg_wrapper(
+            result,
+            &header,
+            |proc, _opaque| {
+                let ProcArguments::Nfs3(args) = proc else {
+                    panic!("Wrong program argument type");
+                };
+                let NfsArguments::Write(args) = args.as_ref() else {
+                    panic!("Wrong NFS argument type");
+                };
+                assert_eq!(args.file, write.part.file);
+                assert_eq!(args.offset, write.part.offset);
+                assert_eq!(args.size, write.part.size);
+                assert_eq!(args.stable, write.part.stable);
+                assert_eq!(args.data, write.data[..8]);
+            },
+            &write,
+        );
+    }
 }
 
 /// Test: Parser recovers from an error on first WRITE frame and parses the next valid WRITE frame.

--- a/nfs-mamont/src/parser/tests/parser_struct.rs
+++ b/nfs-mamont/src/parser/tests/parser_struct.rs
@@ -218,7 +218,10 @@ fn assert_write_result<B: Buffer + PartialEq<[u8]> + std::fmt::Debug>(
     let NfsArguments::Write(args) = result else {
         panic!("Wrong NFS argument type");
     };
-    assert_eq!(expected_write.part.size, args.size);
+    // The parser never promises the backend more bytes than the buffer carries,
+    // so an announced `size` above the payload length is clamped down to it.
+    let expected_size = expected_write.part.size.min(expected_write.data.len() as u32);
+    assert_eq!(expected_size, args.size);
     assert_eq!(expected_write.part.file, args.file);
     assert_eq!(expected_write.part.stable, args.stable);
     assert_eq!(expected_write.part.offset, args.offset);
@@ -394,7 +397,8 @@ async fn parse_read_with_zero_count() {
     });
 
     let socket = MockSocket::new(frame.as_slice());
-    // An allocator that fails every request: a zero-count READ must not consult it.
+    // An allocator whose `try_allocate` fails every request: a zero-count READ
+    // must not consult it at all.
     let alloc = Arc::new(MockAllocator::new(0));
     let mut parser = RpcParser::with_capacity(socket, alloc, 96);
 
@@ -420,6 +424,39 @@ async fn parse_read_clamps_oversized_count() {
     let result = parser.next_message().await.unwrap();
     // `count` is rewritten so the backend never sees more than the buffer holds.
     assert_arg_wrapper(result, &header, assert_read_proc_result, (0, 1024, 1024));
+}
+
+/// Test: when the pool is exhausted and READ falls back to a single block, the
+/// reported `count` always matches the length of the buffer handed to the
+/// backend --- whether the block is shorter or longer than the request.
+#[tokio::test]
+async fn parse_read_count_matches_fallback_block() {
+    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
+    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+
+    let short = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, READ, |buf| {
+        buf.extend_from_slice(&read_args([1, 2, 3, 4, 5, 6, 7, 8], 0, 512));
+    });
+    let long = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, READ, |buf| {
+        buf.extend_from_slice(&read_args([1, 2, 3, 4, 5, 6, 7, 8], 0, 4));
+    });
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&short);
+    buf.extend_from_slice(&long);
+
+    let socket = MockSocket::new(buf.as_slice());
+    // Capacity is large enough that `count` is not clamped, but `try_allocate`
+    // never succeeds, so every request falls back to a 16-byte block.
+    let alloc = Arc::new(MockAllocator::stale_blocks(0x400, 16, 0xAA));
+    let mut parser = RpcParser::with_capacity(socket, alloc, 96);
+
+    // Block shorter than the request: a short read.
+    let result = parser.next_message().await.unwrap();
+    assert_arg_wrapper(result, &header, assert_read_proc_result, (0, 16, 16));
+
+    // Block longer than the request: the tail is cut off.
+    let result = parser.next_message().await.unwrap();
+    assert_arg_wrapper(result, &header, assert_read_proc_result, (0, 4, 4));
 }
 
 /// Test: a WRITE payload larger than the allocator's pool is read as far as the
@@ -577,13 +614,111 @@ async fn parse_write_with_partial_buffer() {
                 };
                 assert_eq!(args.file, write.part.file);
                 assert_eq!(args.offset, write.part.offset);
-                assert_eq!(args.size, write.part.size);
+                // Only 8 of the 12 payload bytes made it into the buffer, so
+                // the backend is told to write exactly those 8.
+                assert_eq!(args.size, 8);
                 assert_eq!(args.stable, write.part.stable);
                 assert_eq!(args.data, write.data[..8]);
             },
             &write,
         );
     }
+}
+
+/// Test: a fallback block larger than the payload is truncated, so none of the
+/// bytes the block still holds from a previous request reach the backend.
+#[tokio::test]
+async fn parse_write_truncates_oversized_fallback_block() {
+    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
+    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+
+    let data = [0x01_u8, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+    let write = WriteWrapper {
+        part: write::ArgsPartial {
+            file: Handle([1, 2, 3, 4, 5, 6, 7, 8]),
+            offset: 0x8000,
+            // The client announces far more than it actually sends.
+            size: 0xFF,
+            stable: StableHow::Unstable,
+        },
+        data: &data,
+    };
+
+    let frame = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, WRITE, |buf| {
+        buf.extend_from_slice(&write_args(&write));
+    });
+
+    let socket = MockSocket::new(frame.as_slice());
+    // `try_allocate` always fails, and the fallback block is 64 bytes of
+    // leftovers from whoever held the block before.
+    let alloc = Arc::new(MockAllocator::stale_blocks(0x400, 64, 0xAA));
+    let mut parser = RpcParser::with_capacity(socket, alloc, 96);
+
+    let result = parser.next_message().await.unwrap();
+    assert_arg_wrapper(
+        result,
+        &header,
+        |proc, _opaque| {
+            let ProcArguments::Nfs3(args) = proc else {
+                panic!("Wrong program argument type");
+            };
+            let NfsArguments::Write(args) = args.as_ref() else {
+                panic!("Wrong NFS argument type");
+            };
+            // Neither the buffer nor the announced size may expose the 56
+            // stale bytes left in the tail of the block.
+            assert_eq!(args.data.len(), data.len());
+            assert_eq!(args.size, data.len() as u32);
+            assert_eq!(args.data, data[..]);
+        },
+        &write,
+    );
+}
+
+/// Test: a WRITE announcing more opaque data than the frame can hold is
+/// rejected instead of making the parser pull that many bytes off the socket,
+/// and the rejection stays confined to that frame --- the rest of it is
+/// discarded, so the next request on the same connection still parses.
+#[tokio::test]
+async fn parse_write_rejects_size_beyond_frame() {
+    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
+    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+
+    let first = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, WRITE, |buf| {
+        push_opaque(buf, &[1, 2, 3, 4, 5, 6, 7, 8]);
+        push_u64(buf, 0x8000);
+        push_u32(buf, 0xFF);
+        push_u32(buf, StableHow::Unstable.to_u32().unwrap());
+        // Opaque length of ~4 GiB in a frame of less than a hundred bytes.
+        push_u32(buf, u32::MAX);
+        // Trailing payload that recovery has to discard before the next frame.
+        push_bytes(buf, &[0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF]);
+    });
+    let second = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, FSSTAT, |buf| {
+        buf.extend_from_slice(&fsstat_args([1, 2, 3, 4, 5, 6, 7, 8]));
+    });
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&first);
+    buf.extend_from_slice(&second);
+
+    let socket = MockSocket::new(buf.as_slice());
+    let alloc = Arc::new(MockAllocator::new(0x400));
+    let mut parser = RpcParser::with_capacity(socket, alloc, 96);
+
+    let result = parser.next_message().await;
+    assert!(
+        matches!(result, Err(ErrorWrapper { error: Error::MaxElemLimit, xid: Some(XID) })),
+        "expected the frame to be rejected as garbage arguments"
+    );
+
+    // The stream is still aligned: the following frame parses normally.
+    let result = parser.next_message().await.unwrap();
+    assert_arg_wrapper(
+        result,
+        &header,
+        |proc, opaque| assert_fsstat_proc_result(proc, opaque),
+        &[1, 2, 3, 4, 5, 6, 7, 8],
+    );
 }
 
 /// Test: Parser recovers from an error on first WRITE frame and parses the next valid WRITE frame.


### PR DESCRIPTION
Replace blocking Allocator::allocate with best-effort try_allocate and a separate allocate_block method. The default allocate implementation now attempts non-blocking allocation first, falling back to a single block when the pool is exhausted.

Update the RPC parser to handle partial allocations by reading only the available bytes and discarding the rest to maintain stream alignment. Eliminate OutOfMemory errors in favor of this best-effort approach.

BREAKING CHANGE: Allocator trait now requires implementing try_allocate and allocate_block. allocate is now a default method combining both.