### PR TITLE
feat: simplify parser

### DIFF
--- a/nfs-mamont/src/mount/mnt.rs
+++ b/nfs-mamont/src/mount/mnt.rs
@@ -7,7 +7,7 @@ use std::net::SocketAddr;
 
 use num_derive::{FromPrimitive, ToPrimitive};
 
-use crate::rpc::{AuthFlavor, OpaqueAuth};
+use crate::rpc::{AuthFlavor, Credential};
 use crate::vfs::file;
 
 #[derive(Debug, ToPrimitive, FromPrimitive)]
@@ -63,6 +63,6 @@ pub trait Mnt {
         &self,
         args: Args,
         client_addr: SocketAddr,
-        cred: OpaqueAuth,
+        cred: Credential,
     ) -> Result<Success, Fail>;
 }

--- a/nfs-mamont/src/parser/mod.rs
+++ b/nfs-mamont/src/parser/mod.rs
@@ -18,7 +18,7 @@ use crate::mount::{mnt, umnt};
 use crate::nlm::procedures::{
     cancel::Nlm4CancelArgs, lock::Nlm4LockArgs, test::Nlm4TestArgs, unlock::Nlm4UnlockArgs,
 };
-use crate::rpc::{Error, OpaqueAuth};
+use crate::rpc::{Credential, Error};
 use crate::vfs::{
     access, commit, create, fs_info, fs_stat, get_attr, link, lookup, mk_dir, mk_node, path_conf,
     read, read_dir, read_dir_plus, read_link, remove, rename, rm_dir, set_attr, symlink, write,
@@ -42,10 +42,12 @@ pub async fn proc_nested_errors<T>(error: Error, future: impl Future<Output = Re
 #[cfg_attr(test, derive(PartialEq, Debug, Clone))]
 pub struct RpcHeader {
     pub xid: u32,
-    pub cred: OpaqueAuth,
-    #[allow(dead_code)]
-    // TODO: use when auth will be provided
-    pub verf: OpaqueAuth,
+    /// Authenticated caller identity extracted from the RPC credential.
+    ///
+    /// The reply verifier is always `AUTH_NONE` for the accepted flavors
+    /// (`AUTH_NONE`/`AUTH_SYS`), so the request verifier is validated during
+    /// parsing and then dropped rather than stored here.
+    pub cred: Credential,
 }
 
 /// Wrapper for NFS procedure arguments along with the parsed RPC header.
@@ -106,8 +108,8 @@ pub enum NfsArguments<B: Buffer> {
     Access(access::Args),
     /// Arguments for the [`read_link`] operation.
     ReadLink(read_link::Args),
-    /// Arguments for the [`read`] operation together with the output buffer
-    /// the backend fills with the read result.
+    /// Arguments for the [`read`] operation, together with the server-side
+    /// output buffer allocated for the response data.
     Read(read::Args, B),
     /// Arguments for the [`mod@write`] operation.
     Write(write::Args<B>),

--- a/nfs-mamont/src/parser/parser_struct.rs
+++ b/nfs-mamont/src/parser/parser_struct.rs
@@ -1,17 +1,20 @@
 //! RPC message parser for NFS, MOUNT and NLM protocols.
 //!
-//! This module provides the [`RpcParser`] struct, which parses XDR-encoded RPC messages
+//! This module provides [`RpcParser`] struct, which parses XDR-encoded RPC messages
 //! according to RFC 5531 (RPC) and RFC 1813 (NFSv3). It handles:
 //!
 //! - RPC message framing and headers
-//! - Authentication (currently only AUTH_NONE)
+//! - Authentication (AUTH_NONE and AUTH_SYS)
 //! - NFSv3 procedure parsing (all 22 procedures)
 //! - MOUNT protocol procedure parsing
 //! - NLM procedure parsing
 //! - Error handling and message discarding on protocol errors
 //!
-//! The parser uses a [`CountBuffer`] to efficiently read from async streams while
-//! supporting retry logic for parsing operations that may need additional data.
+//! The parser uses a [`FrameReader`] which buffers head window of every
+//! RMS frame, so headers and procedure arguments are parsed synchronously
+//! without retries. Only opaque `WRITE` payloads that do not fit into
+//! buffered window are streamed from the socket directly into the allocated
+//! [`Buffer`].
 
 use std::cmp::min;
 use std::io::{self, ErrorKind};
@@ -43,21 +46,42 @@ use crate::parser::nfsv3::{
 };
 use crate::parser::nlm::{cancel::cancel, lock::lock, test::test, unlock::unlock};
 use crate::parser::primitive::{u32, u32_as_usize, ALIGNMENT};
-use crate::parser::read_buffer::CountBuffer;
-use crate::parser::rpc::{auth, RpcMessage};
+use crate::parser::read_buffer::FrameReader;
+use crate::parser::rpc::{auth, authsys_parms, RpcMessage};
 use crate::parser::{
     proc_nested_errors, ArgWrapper, Error, ErrorWrapper, MountArgWrapper, MountArguments,
     NfsArgWrapper, NfsArguments, NlmArguments, ProcArguments, Result, RpcHeader,
 };
-use crate::rpc::{AuthFlavor, AuthStat, OpaqueAuth, RpcBody, VersionMismatch, RPC_VERSION};
+use crate::rpc::{AuthFlavor, AuthStat, Credential, RpcBody, VersionMismatch, RPC_VERSION};
 use crate::vfs;
-
-const RMS_HEADER_SIZE: usize = size_of::<u32>();
 
 /// Minimum buffer size, that could hold complete RPC message
 /// with NFSv3 or Mount protocol arguments, except for NFSv3 `WRITE` procedure -
-/// this size is enough to hold only arguments without opaque data ([`Buffer`] in [`vfs::write::Args`])
+/// this size is enough to hold only arguments without opaque data ([`Buffer`] in [`vfs::write::Args`]).
+///
+/// The arguments of every procedure except for the opaque `WRITE` data MUST fit
+/// into the parser buffer: the parser reads at most `capacity` bytes of a
+/// frame into memory before parsing and fails with `InvalidData` if the
+/// arguments extend beyond that window.
 pub const DEFAULT_SIZE: usize = 2500;
+
+/// Maps an `UnexpectedEof` from synchronous argument parsing to `InvalidData`.
+///
+/// After [`FrameReader::begin_body`] the head window of the frame is fully
+/// buffered, so running out of data during synchronous parsing means either
+/// the frame is shorter than its arguments (truncated message) or the
+/// arguments do not fit into the parser buffer (legal only for `WRITE`
+/// payloads, which are streamed separately). Both cases are protocol
+/// violations rather than transient I/O conditions.
+fn map_eof(error: Error) -> Error {
+    match error {
+        Error::IO(err) if err.kind() == ErrorKind::UnexpectedEof => Error::IO(io::Error::new(
+            ErrorKind::InvalidData,
+            "RPC message arguments exceed frame or buffer bounds",
+        )),
+        other => other,
+    }
+}
 
 /// Parser for RPC messages over async streams.
 ///
@@ -74,9 +98,7 @@ pub const DEFAULT_SIZE: usize = 2500;
 /// * `S` - An async stream type that implements [`AsyncRead`] and [`Unpin`]
 pub struct RpcParser<A: Allocator, S: AsyncRead + Unpin> {
     allocator: Arc<A>,
-    buffer: CountBuffer<S>,
-    last: bool,
-    current_frame_size: usize,
+    reader: FrameReader<S>,
 }
 
 impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
@@ -91,12 +113,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     ///
     /// A new `RpcParser` instance ready to parse messages.
     pub fn new(socket: S, allocator: Arc<A>) -> Self {
-        Self {
-            allocator,
-            buffer: CountBuffer::new(DEFAULT_SIZE, socket),
-            last: false,
-            current_frame_size: 0,
-        }
+        Self { allocator, reader: FrameReader::new(DEFAULT_SIZE, socket) }
     }
 
     /// Creates a new `RpcParser` with the specified buffer size.
@@ -105,19 +122,15 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     ///
     /// * `socket` - The async stream to read RPC messages from
     /// * `allocator` - The allocator to use for dynamic memory allocation
-    /// * `size` - The size of the internal read buffer (used for each of the two buffers)
+    /// * `size` - The size of the internal frame buffer; arguments of any
+    ///   procedure (except opaque `WRITE` data) must fit into it
     ///
     /// # Returns
     ///
     /// A new `RpcParser` instance ready to parse messages.
     #[allow(dead_code)]
     pub fn with_capacity(socket: S, allocator: Arc<A>, size: usize) -> Self {
-        Self {
-            allocator,
-            buffer: CountBuffer::new(size, socket),
-            last: false,
-            current_frame_size: 0,
-        }
+        Self { allocator, reader: FrameReader::new(size, socket) }
     }
 
     /// Reads and parses the RPC message header.
@@ -127,19 +140,23 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     /// - The remaining 31 bits containing the fragment size
     /// - The transaction ID (XID)
     ///
+    /// After validating the header, the head window of the frame body
+    /// (`min(frame_size, capacity)` bytes) is buffered so that subsequent
+    /// header and argument parsing is fully synchronous.
+    ///
     /// Currently, fragmented messages are not supported and will return an error.
     ///
     /// # Returns
     ///
-    /// Returns `Ok(())` if the header was successfully parsed, or an error if:
+    /// Returns the XID if the header was successfully parsed, or an error if:
     /// - The message is fragmented (not supported)
     /// - An I/O error occurs
     async fn read_message_header(&mut self) -> Result<u32> {
-        let header = self.buffer.parse_with_retry(u32).await?;
-        self.last = header & 0x8000_0000 != 0;
-        self.current_frame_size = (header & 0x7FFF_FFFF) as usize;
+        let header = self.reader.read_frame_header().await.map_err(Error::IO)?;
+        let last = header & 0x8000_0000 != 0;
+        let frame_size = (header & 0x7FFF_FFFF) as usize;
 
-        if self.current_frame_size < std::mem::size_of::<u32>() {
+        if frame_size < std::mem::size_of::<u32>() {
             return Err(Error::IO(io::Error::new(
                 ErrorKind::InvalidData,
                 "Frame size must include XID",
@@ -148,14 +165,16 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
 
         //TODO("https://github.com/RMamonts/nfs-mamont/issues/124")
 
-        // this is temporal check, apparently this will go to separate object Validator
-        if !self.last {
+        // this is a temporal check, apparently this will go into a separate object Validator
+        if !last {
             return Err(Error::IO(io::Error::new(
                 ErrorKind::Unsupported,
                 "Fragmented messages not supported",
             )));
         }
-        self.buffer.parse_with_retry(u32).await
+
+        self.reader.begin_body(frame_size).await.map_err(Error::IO)?;
+        u32(&mut self.reader).map_err(map_eof)
     }
 
     /// Parses the RPC call header.
@@ -175,15 +194,19 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     /// - The message type is REPLY (not expected for incoming calls)
     /// - The RPC version doesn't match
     /// - Authentication fails
-    /// - An I/O error occurs
-    async fn parse_rpc_header(&mut self) -> Result<RpcMessage> {
-        let msg_type = self.buffer.parse_with_retry(u32).await?;
+    /// - The frame or the parser buffer is too small for the header
+    fn parse_rpc_header(&mut self) -> Result<RpcMessage> {
+        self.parse_rpc_header_inner().map_err(map_eof)
+    }
+
+    fn parse_rpc_header_inner(&mut self) -> Result<RpcMessage> {
+        let msg_type = u32(&mut self.reader)?;
         if msg_type != RpcBody::Call as u32 {
             error!(msg_type, "rpc parse reject: unexpected msg_type");
             return Err(Error::MessageTypeMismatch);
         }
 
-        let rpc_version = self.buffer.parse_with_retry(u32).await?;
+        let rpc_version = u32(&mut self.reader)?;
         if rpc_version != RPC_VERSION {
             error!(rpc_version, expected = RPC_VERSION, "rpc parse reject: rpc_version mismatch");
             return Err(Error::RpcVersionMismatch(VersionMismatch {
@@ -192,42 +215,61 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
             }));
         }
 
-        let program = self.buffer.parse_with_retry(u32).await?;
-        let version = self.buffer.parse_with_retry(u32).await?;
-        let procedure = self.buffer.parse_with_retry(u32).await?;
+        let program = u32(&mut self.reader)?;
+        let version = u32(&mut self.reader)?;
+        let procedure = u32(&mut self.reader)?;
         debug!(program, version, procedure, "rpc header parsed");
 
-        //TODO(https://github.com/RMamonts/nfs-mamont/issues/156)
-        let (cred, verf) = self.parse_authentication().await?;
+        let cred = self.parse_authentication()?;
 
-        Ok(RpcMessage { program, procedure, version, cred, verf })
+        Ok(RpcMessage { program, procedure, version, cred })
     }
 
-    /// Parses and validates RPC authentication.
+    /// Parses and validates RPC authentication, returning the caller identity.
     ///
-    /// NFS clients commonly send AUTH_SYS credentials, so both AUTH_NONE and
-    /// AUTH_SYS are accepted for credentials. Verifier must remain AUTH_NONE.
+    /// Both `AUTH_NONE` (anonymous) and `AUTH_SYS` (UNIX uid/gid) credentials are
+    /// accepted; the `AUTH_SYS` body is decoded into an [`AuthSysParams`]. Any
+    /// other credential flavor is rejected with [`AuthStat::BadCred`]. For both
+    /// accepted flavors, the verifier must be `AUTH_NONE` with an empty body
+    /// (RFC 5531 §8.2); anything else is rejected with [`AuthStat::BadVerf`].
+    ///
+    /// [`AuthSysParams`]: crate::rpc::AuthSysParams
     ///
     /// # Returns
     ///
-    /// Returns a pair of [`OpaqueAuth`] if authentication succeeds, or an error
+    /// Returns the parsed [`Credential`] if authentication succeeds, or an error
     /// if authentication fails or an I/O error occurs.
-    async fn parse_authentication(&mut self) -> Result<(OpaqueAuth, OpaqueAuth)> {
-        let cred = self.buffer.parse_with_retry(auth).await?;
-        let verf = self.buffer.parse_with_retry(auth).await?;
-        let cred_ok = match cred.flavor {
-            AuthFlavor::None => cred.body.is_empty(),
-            AuthFlavor::Sys => true,
-            _ => false,
+    fn parse_authentication(&mut self) -> Result<Credential> {
+        let cred = auth(&mut self.reader)?;
+        let verf = auth(&mut self.reader)?;
+
+        let credential = match cred.flavor {
+            AuthFlavor::None if cred.body.is_empty() => Credential::None,
+            AuthFlavor::Sys => {
+                // The AUTH_SYS parameters live inside the already-extracted
+                // opaque body, so parse over that slice and never past it.
+                match authsys_parms(&mut cred.body.as_slice()) {
+                    Ok(params) => Credential::Sys(params),
+                    Err(err) => {
+                        error!(
+                            cred_len=%cred.body.len(),
+                            error=?err,
+                            "rpc auth reject: malformed AUTH_SYS credential",
+                        );
+                        return Err(Error::Auth(AuthStat::BadCred));
+                    }
+                }
+            }
+            _ => {
+                error!(
+                    cred_flavor=?cred.flavor,
+                    cred_len=%cred.body.len(),
+                    "rpc auth reject: unsupported credential flavor",
+                );
+                return Err(Error::Auth(AuthStat::BadCred));
+            }
         };
-        if !cred_ok {
-            error!(
-                cred_flavor=?cred.flavor,
-                cred_len=%cred.body.len(),
-                "rpc auth reject: unsupported credential flavor",
-            );
-            return Err(Error::Auth(AuthStat::BadCred));
-        }
+
         if !matches!(verf.flavor, AuthFlavor::None) || !verf.body.is_empty() {
             error!(
                 verf_flavor=?verf.flavor,
@@ -236,64 +278,64 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
             );
             return Err(Error::Auth(AuthStat::BadVerf));
         }
+
         debug!(
             cred_flavor=?cred.flavor,
             cred_len=%cred.body.len(),
-            verf_flavor=?verf.flavor,
-            verf_len=%verf.body.len(),
             "rpc auth accepted",
         );
-        Ok((cred, verf))
+        Ok(credential)
     }
 
     /// Parses NFSv3 procedure arguments from the current frame.
+    ///
+    /// All arguments are parsed synchronously from the buffered head window,
+    /// except for the opaque `WRITE` payload which is streamed via
+    /// [`adapter_for_write`].
     async fn parse_nfs_proc(&mut self, procedure: u32) -> Result<NfsArguments<A::Buffer>> {
+        if procedure == WRITE {
+            return Ok(NfsArguments::Write(
+                adapter_for_write(&self.allocator, &mut self.reader).await?,
+            ));
+        }
+        if procedure == READ {
+            let (args, data) = adapter_for_read(&self.allocator, &mut self.reader).await?;
+            return Ok(NfsArguments::Read(args, data));
+        }
+        let src = &mut self.reader;
         let args = match procedure {
             NULL => NfsArguments::Null,
-            GETATTR => NfsArguments::GetAttr(self.buffer.parse_with_retry(get_attr::args).await?),
-            SETATTR => NfsArguments::SetAttr(self.buffer.parse_with_retry(set_attr::args).await?),
-            LOOKUP => NfsArguments::LookUp(self.buffer.parse_with_retry(lookup::args).await?),
-            ACCESS => NfsArguments::Access(self.buffer.parse_with_retry(access::args).await?),
-            READLINK => {
-                NfsArguments::ReadLink(self.buffer.parse_with_retry(read_link::args).await?)
-            }
-            READ => {
-                let (args, data) = adapter_for_read(&self.allocator, &mut self.buffer).await?;
-                NfsArguments::Read(args, data)
-            }
-            WRITE => {
-                NfsArguments::Write(adapter_for_write(&self.allocator, &mut self.buffer).await?)
-            }
-            CREATE => NfsArguments::Create(self.buffer.parse_with_retry(create::args).await?),
-            MKDIR => NfsArguments::MkDir(self.buffer.parse_with_retry(mk_dir::args).await?),
-            SYMLINK => NfsArguments::SymLink(self.buffer.parse_with_retry(symlink::args).await?),
-            MKNOD => NfsArguments::MkNod(self.buffer.parse_with_retry(mk_node::args).await?),
-            REMOVE => NfsArguments::Remove(self.buffer.parse_with_retry(remove::args).await?),
-            RMDIR => NfsArguments::RmDir(self.buffer.parse_with_retry(rm_dir::args).await?),
-            RENAME => NfsArguments::Rename(self.buffer.parse_with_retry(rename::args).await?),
-            LINK => NfsArguments::Link(self.buffer.parse_with_retry(link::args).await?),
-            READDIR => NfsArguments::ReadDir(self.buffer.parse_with_retry(read_dir::args).await?),
-            READDIRPLUS => {
-                NfsArguments::ReadDirPlus(self.buffer.parse_with_retry(read_dir_plus::args).await?)
-            }
-            FSSTAT => NfsArguments::FsStat(self.buffer.parse_with_retry(fs_stat::args).await?),
-            FSINFO => NfsArguments::FsInfo(self.buffer.parse_with_retry(fs_info::args).await?),
-            PATHCONF => {
-                NfsArguments::PathConf(self.buffer.parse_with_retry(path_conf::args).await?)
-            }
-            COMMIT => NfsArguments::Commit(self.buffer.parse_with_retry(commit::args).await?),
+            GETATTR => NfsArguments::GetAttr(get_attr::args(src).map_err(map_eof)?),
+            SETATTR => NfsArguments::SetAttr(set_attr::args(src).map_err(map_eof)?),
+            LOOKUP => NfsArguments::LookUp(lookup::args(src).map_err(map_eof)?),
+            ACCESS => NfsArguments::Access(access::args(src).map_err(map_eof)?),
+            READLINK => NfsArguments::ReadLink(read_link::args(src).map_err(map_eof)?),
+            CREATE => NfsArguments::Create(create::args(src).map_err(map_eof)?),
+            MKDIR => NfsArguments::MkDir(mk_dir::args(src).map_err(map_eof)?),
+            SYMLINK => NfsArguments::SymLink(symlink::args(src).map_err(map_eof)?),
+            MKNOD => NfsArguments::MkNod(mk_node::args(src).map_err(map_eof)?),
+            REMOVE => NfsArguments::Remove(remove::args(src).map_err(map_eof)?),
+            RMDIR => NfsArguments::RmDir(rm_dir::args(src).map_err(map_eof)?),
+            RENAME => NfsArguments::Rename(rename::args(src).map_err(map_eof)?),
+            LINK => NfsArguments::Link(link::args(src).map_err(map_eof)?),
+            READDIR => NfsArguments::ReadDir(read_dir::args(src).map_err(map_eof)?),
+            READDIRPLUS => NfsArguments::ReadDirPlus(read_dir_plus::args(src).map_err(map_eof)?),
+            FSSTAT => NfsArguments::FsStat(fs_stat::args(src).map_err(map_eof)?),
+            FSINFO => NfsArguments::FsInfo(fs_info::args(src).map_err(map_eof)?),
+            PATHCONF => NfsArguments::PathConf(path_conf::args(src).map_err(map_eof)?),
+            COMMIT => NfsArguments::Commit(commit::args(src).map_err(map_eof)?),
             _ => return Err(Error::ProcedureMismatch),
         };
         Ok(args)
     }
 
     /// Parses MOUNT procedure arguments from the current frame.
-    async fn parse_mount_proc(&mut self, procedure: u32) -> Result<MountArguments> {
+    fn parse_mount_proc(&mut self, procedure: u32) -> Result<MountArguments> {
         let args = match procedure {
             MOUNT_NULL => MountArguments::Null,
-            MOUNT_MNT => MountArguments::Mount(self.buffer.parse_with_retry(mount).await?),
+            MOUNT_MNT => MountArguments::Mount(mount(&mut self.reader).map_err(map_eof)?),
             MOUNT_DUMP => MountArguments::Dump,
-            MOUNT_UMNT => MountArguments::Unmount(self.buffer.parse_with_retry(unmount).await?),
+            MOUNT_UMNT => MountArguments::Unmount(unmount(&mut self.reader).map_err(map_eof)?),
             MOUNT_UMNTALL => MountArguments::UnmountAll,
             MOUNT_EXPORT => MountArguments::Export,
             _ => return Err(Error::ProcedureMismatch),
@@ -302,13 +344,13 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     }
 
     /// Parses NLM procedure arguments from the current frame.
-    async fn parse_nlm_proc(&mut self, procedure: u32) -> Result<NlmArguments> {
+    fn parse_nlm_proc(&mut self, procedure: u32) -> Result<NlmArguments> {
         let args = match procedure {
             NLMPROC4_NULL => NlmArguments::Null,
-            NLMPROC4_LOCK => NlmArguments::Lock(self.buffer.parse_with_retry(lock).await?),
-            NLMPROC4_UNLOCK => NlmArguments::Unlock(self.buffer.parse_with_retry(unlock).await?),
-            NLMPROC4_TEST => NlmArguments::Test(self.buffer.parse_with_retry(test).await?),
-            NLMPROC4_CANCEL => NlmArguments::Cancel(self.buffer.parse_with_retry(cancel).await?),
+            NLMPROC4_LOCK => NlmArguments::Lock(lock(&mut self.reader).map_err(map_eof)?),
+            NLMPROC4_UNLOCK => NlmArguments::Unlock(unlock(&mut self.reader).map_err(map_eof)?),
+            NLMPROC4_TEST => NlmArguments::Test(test(&mut self.reader).map_err(map_eof)?),
+            NLMPROC4_CANCEL => NlmArguments::Cancel(cancel(&mut self.reader).map_err(map_eof)?),
             _ => return Err(Error::ProcedureMismatch),
         };
         Ok(args)
@@ -317,23 +359,22 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     /// Parses a complete NFSv3 RPC message from the stream.
     ///
     /// This is the main entry point for parsing. It performs the following steps:
-    /// 1. Reads the message header (framing)
+    /// 1. Reads the message header (framing) and buffers the frame head window
     /// 2. Parses the RPC call header
     /// 3. Parses NFSv3 procedure-specific arguments
     /// 4. Validates that all data in the frame was consumed
-    /// 5. Cleans up internal state for the next message
     ///
     /// If a protocol error occurs (version mismatch, auth error, etc.), the parser
     /// will attempt to discard the remaining message data to maintain stream alignment.
     ///
     /// # Returns
     ///
-    /// Returns parsed NFSv3 procedure arguments,
+    /// Returns the parsed NFSv3 procedure arguments,
     /// or an error if parsing fails at any stage.
     #[allow(dead_code)]
     pub async fn parse_nfs_message(&mut self) -> Result<NfsArgWrapper<A::Buffer>> {
         let xid = self.read_message_header().await?;
-        let rpc_header = match self.parse_rpc_header().await {
+        let rpc_header = match self.parse_rpc_header() {
             Ok(arg) => arg,
             Err(err) => return Err(self.match_errors(err).await),
         };
@@ -344,10 +385,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
 
         // finalize_parsing() is only called after successful header and procedure parsing; it is not run on error paths
         self.finalize_parsing()?;
-        Ok(NfsArgWrapper {
-            header: RpcHeader { xid, cred: rpc_header.cred, verf: rpc_header.verf },
-            proc,
-        })
+        Ok(NfsArgWrapper { header: RpcHeader { xid, cred: rpc_header.cred }, proc })
     }
 
     /// Parses the next RPC message and returns typed arguments for its program.
@@ -361,7 +399,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
             Ok(xid) => xid,
             Err(error) => return Err(ErrorWrapper { xid: None, error }),
         };
-        let rpc_header = match self.parse_rpc_header().await {
+        let rpc_header = match self.parse_rpc_header() {
             Ok(arg) => arg,
             Err(err) => {
                 return Err(ErrorWrapper { xid: Some(xid), error: self.match_errors(err).await })
@@ -376,10 +414,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
 
         // finalize_parsing() is only called after successful header and procedure parsing; it is not run on error paths
         match self.finalize_parsing() {
-            Ok(_) => Ok(ArgWrapper {
-                header: RpcHeader { xid, cred: rpc_header.cred, verf: rpc_header.verf },
-                proc,
-            }),
+            Ok(_) => Ok(ArgWrapper { header: RpcHeader { xid, cred: rpc_header.cred }, proc }),
             Err(error) => Err(ErrorWrapper { xid: Some(xid), error }),
         }
     }
@@ -388,21 +423,18 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     #[allow(dead_code)]
     pub async fn parse_mount_message(&mut self) -> Result<MountArgWrapper> {
         let xid = self.read_message_header().await?;
-        let rpc_header = match self.parse_rpc_header().await {
+        let rpc_header = match self.parse_rpc_header() {
             Ok(arg) => arg,
             Err(err) => return Err(self.match_errors(err).await),
         };
-        let proc = match self.parse_mount_message_with_header(&rpc_header).await {
+        let proc = match self.parse_mount_message_with_header(&rpc_header) {
             Ok(arg) => Box::new(arg),
             Err(err) => return Err(self.match_errors(err).await),
         };
 
         // finalize_parsing() is only called after successful header and procedure parsing; it is not run on error paths
         self.finalize_parsing()?;
-        Ok(MountArgWrapper {
-            header: RpcHeader { xid, cred: rpc_header.cred, verf: rpc_header.verf },
-            proc,
-        })
+        Ok(MountArgWrapper { header: RpcHeader { xid, cred: rpc_header.cred }, proc })
     }
 
     async fn parse_next_message_with_header(
@@ -415,11 +447,11 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
                 Ok(ProcArguments::Nfs3(Box::new(args)))
             }
             MOUNT_PROGRAM => {
-                let args = self.parse_mount_message_with_header(head).await?;
+                let args = self.parse_mount_message_with_header(head)?;
                 Ok(ProcArguments::Mount(Box::new(args)))
             }
             NLM_PROGRAM => {
-                let args = self.parse_nlm_message_with_header(head).await?;
+                let args = self.parse_nlm_message_with_header(head)?;
                 Ok(ProcArguments::Nlm4(Box::new(args)))
             }
             _ => {
@@ -455,10 +487,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
         self.parse_nfs_proc(head.procedure).await
     }
 
-    async fn parse_mount_message_with_header(
-        &mut self,
-        head: &RpcMessage,
-    ) -> Result<MountArguments> {
+    fn parse_mount_message_with_header(&mut self, head: &RpcMessage) -> Result<MountArguments> {
         if head.program != MOUNT_PROGRAM {
             error!(
                 got = head.program,
@@ -478,10 +507,10 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
                 high: MOUNT_VERSION,
             }));
         }
-        self.parse_mount_proc(head.procedure).await
+        self.parse_mount_proc(head.procedure)
     }
 
-    async fn parse_nlm_message_with_header(&mut self, head: &RpcMessage) -> Result<NlmArguments> {
+    fn parse_nlm_message_with_header(&mut self, head: &RpcMessage) -> Result<NlmArguments> {
         if head.program != NLM_PROGRAM {
             error!(
                 got = head.program,
@@ -501,39 +530,22 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
                 high: NLM_VERSION,
             }));
         }
-        self.parse_nlm_proc(head.procedure).await
+        self.parse_nlm_proc(head.procedure)
     }
 
     /// Finalizes parsing by validating that all frame data was consumed.
-    ///
-    /// This method is called after successful parsing to ensure that:
-    /// - All bytes in the message frame were consumed
-    /// - Internal buffer state is reset for the next message
     ///
     /// # Returns
     ///
     /// Returns `Ok(())` if validation passes, or an error if unparsed data
     /// remains in the frame (indicating a parsing bug or malformed message).
     fn finalize_parsing(&mut self) -> Result<()> {
-        // CountBuffer keep count of bytes, read from it,
-        // but first u32 of message - header that shouldn't be counted
-        // https://datatracker.ietf.org/doc/html/rfc5531#section-11
-        let bytes_consumed = self.buffer.total_bytes().checked_sub(RMS_HEADER_SIZE).ok_or(
-            Error::IO(io::Error::new(
-                ErrorKind::InvalidData,
-                "Consumed bytes are less than RMS header size",
-            )),
-        )?;
-        if bytes_consumed != self.current_frame_size {
+        if self.reader.frame_remaining() != 0 {
             return Err(Error::IO(io::Error::new(
                 ErrorKind::InvalidData,
                 "Unparsed data remaining in frame",
             )));
         }
-
-        self.buffer.clean();
-        self.current_frame_size = 0;
-        self.last = false;
         Ok(())
     }
 
@@ -543,11 +555,6 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     /// this method discards the remaining message data to maintain stream alignment
     /// for subsequent messages. For other errors, it returns them as-is.
     ///
-    /// Allocation failures are discarded as well: the frame itself is well-formed,
-    /// so leaving it half-consumed would desync [`CountBuffer::total_bytes`] and
-    /// make every later [`Self::finalize_parsing`] fail with "Unparsed data
-    /// remaining in frame".
-    ///
     /// # Arguments
     ///
     /// * `error` - The error that occurred during parsing
@@ -556,18 +563,13 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     ///
     /// Returns the error, potentially after attempting to discard the message.
     async fn match_errors(&mut self, error: Error) -> Error {
-        let recoverable = match &error {
-            Error::RpcVersionMismatch(_)
-            | Error::ProgramMismatch
-            | Error::ProcedureMismatch
-            | Error::Auth(_)
-            | Error::MessageTypeMismatch
-            | Error::ProgramVersionMismatch(_) => true,
-            Error::IO(err) => err.kind() == ErrorKind::OutOfMemory,
-            _ => false,
-        };
-
-        if recoverable {
+        if let Error::RpcVersionMismatch(_)
+        | Error::ProgramMismatch
+        | Error::ProcedureMismatch
+        | Error::Auth(_)
+        | Error::MessageTypeMismatch
+        | Error::ProgramVersionMismatch(_) = &error
+        {
             proc_nested_errors(error, self.discard_current_message()).await
         } else {
             error
@@ -585,18 +587,7 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
     /// Returns `Ok(())` if the message was successfully discarded, or an error
     /// if an I/O error occurs while discarding.
     async fn discard_current_message(&mut self) -> Result<()> {
-        // CountBuffer keep count of bytes, read from it,
-        // but first u32 of message - header that shouldn't be counted
-        // https://datatracker.ietf.org/doc/html/rfc5531#section-11
-        let remaining = (self.current_frame_size + RMS_HEADER_SIZE)
-            .checked_sub(self.buffer.total_bytes())
-            .ok_or(Error::IO(io::Error::new(
-                ErrorKind::InvalidData,
-                "Consumed more bytes than RMS header suggests",
-            )))?;
-        self.buffer.discard_bytes(remaining).await.map_err(Error::IO)?;
-        self.finalize_parsing()?;
-        Ok(())
+        self.reader.discard_rest_of_frame().await.map_err(Error::IO)
     }
 }
 
@@ -604,54 +595,76 @@ impl<A: Allocator, S: AsyncRead + Unpin> RpcParser<A, S> {
 ///
 /// The WRITE procedure requires special handling because it includes variable-length
 /// data that must be allocated. This function:
-/// 1. Parses the fixed portion of the WRITE arguments
-/// 2. Allocates memory for the write data
-/// 3. Reads the data from the buffer (handling both sync and async portions)
-/// 4. Discards any padding bytes
+/// 1. Parses the fixed portion of the WRITE arguments from the buffered head window
+/// 2. Validates that the declared data length fits into the frame
+/// 3. Allocates memory for the write data
+/// 4. Fills the allocated buffer (from the buffered window first, then directly
+///    from the socket)
+/// 5. Discards any padding bytes
 ///
 /// # Arguments
 ///
 /// * `alloc` - The allocator to use for allocating the write data buffer
-/// * `buffer` - The buffer to read from
+/// * `reader` - The frame reader to read from
 ///
 /// # Returns
 ///
-/// Returns the parsed [`vfs::write::Args`] with allocated data, or an error if:
+/// Returns the parsed [`vfs::write::Args`] with the allocated data, or an error if:
 /// - Parsing fails
+/// - The declared data length does not fit into the frame
 /// - Memory allocation fails
 /// - Reading the data fails
 async fn adapter_for_write<A, S>(
     alloc: &Arc<A>,
-    buffer: &mut CountBuffer<S>,
+    reader: &mut FrameReader<S>,
 ) -> Result<vfs::write::Args<A::Buffer>>
 where
     A: Allocator,
     S: AsyncRead + Unpin,
 {
-    // Parse arguments for WRITE procedure.
-    let part_arg = buffer.parse_with_retry(write::args).await?;
-    let size = buffer.parse_with_retry(u32_as_usize).await?;
+    // Parse arguments for the WRITE procedure.
+    let part_arg = write::args(reader).map_err(map_eof)?;
+    let size = u32_as_usize(reader).map_err(map_eof)?;
 
-    // A zero-length write needs no buffer at all, so it never takes a pool slot.
-    let mut buffer_data = match NonZeroUsize::new(size) {
-        None => A::Buffer::empty(),
-        Some(non_zero_size) => alloc.allocate(non_zero_size).await.ok_or_else(|| {
-            Error::IO(io::Error::new(ErrorKind::OutOfMemory, "cannot allocate memory"))
-        })?,
-    };
-
-    // Calculate necessary padding to maintain ALIGNMENT
+    // Calculate the necessary padding to maintain ALIGNMENT
     let padding = (ALIGNMENT - (size % ALIGNMENT)) % ALIGNMENT;
 
-    // Read synchronously what is available, then finish asynchronously if needed.
-    let bytes_read_sync = read_in_slice_sync(buffer, &mut buffer_data, size)?;
-    if bytes_read_sync < size {
-        read_in_slice_async(buffer, &mut buffer_data, bytes_read_sync, size - bytes_read_sync)
-            .await?;
+    // The opaque data with its padding must lie within the current frame;
+    // otherwise, the declared length is bogus and reading it would consume
+    // bytes of the next message, misaligning the stream.
+    if size + padding > reader.frame_remaining() {
+        return Err(Error::IO(io::Error::new(
+            ErrorKind::InvalidData,
+            "WRITE data length exceeds frame size",
+        )));
+    }
+
+    // Attempt allocation with the given size, or fallback to NonZeroUsize::MIN.
+    let non_zero_size = NonZeroUsize::new(size).unwrap_or(NonZeroUsize::MIN);
+    let mut buffer_data = alloc.allocate(non_zero_size).await.ok_or_else(|| {
+        Error::IO(io::Error::new(ErrorKind::OutOfMemory, "cannot allocate memory"))
+    })?;
+
+    // Fill the allocated buffer chunk by chunk; `read_body_exact` consumes the
+    // buffered window first and reads the rest directly from the socket.
+    let mut left = size;
+    for chunk in buffer_data.chunks_mut() {
+        if left == 0 {
+            break;
+        }
+        let take = min(chunk.len(), left);
+        reader.read_body_exact(&mut chunk[..take]).await.map_err(Error::IO)?;
+        left -= take;
+    }
+    if left != 0 {
+        return Err(Error::IO(io::Error::new(
+            ErrorKind::InvalidInput,
+            "allocated buffer is smaller than WRITE data",
+        )));
     }
 
     // Discard any trailing padding bytes after the data.
-    buffer.discard_bytes(padding).await.map_err(Error::IO)?;
+    reader.discard_body(padding).await.map_err(Error::IO)?;
     Ok(vfs::write::Args {
         file: part_arg.file,
         offset: part_arg.offset,
@@ -669,16 +682,10 @@ where
 /// allocator serving both READ and WRITE and removes the allocator from the
 /// VFS worker pool.
 ///
-/// A `count` larger than the allocator can ever serve is clamped instead of
-/// rejected: RFC 1813 allows the server to answer with fewer bytes than
-/// requested, so an oversized request becomes a short read rather than an
-/// error. The clamped value is written back into the returned arguments so the
-/// backend never sees a `count` larger than the buffer it is handed.
-///
 /// # Arguments
 ///
 /// * `alloc` - The allocator to use for allocating the read output buffer
-/// * `buffer` - The buffer to read the fixed arguments from
+/// * `reader` - The frame reader to read the fixed arguments from
 ///
 /// # Returns
 ///
@@ -687,123 +694,22 @@ where
 /// read yields an empty buffer without touching the allocator.
 async fn adapter_for_read<A, S>(
     alloc: &Arc<A>,
-    buffer: &mut CountBuffer<S>,
+    reader: &mut FrameReader<S>,
 ) -> Result<(vfs::read::Args, A::Buffer)>
 where
     A: Allocator,
     S: AsyncRead + Unpin,
 {
-    let mut args = buffer.parse_with_retry(read::args).await?;
+    let args = read::args(reader).map_err(map_eof)?;
 
-    let count = min(args.count as usize, alloc.capacity().get());
-    args.count = count as u32;
-
-    let data = match NonZeroUsize::new(count) {
-        None => A::Buffer::empty(),
-        Some(size) => alloc.allocate(size).await.ok_or_else(|| {
+    let data = if args.count == 0 {
+        A::Buffer::empty()
+    } else {
+        let size = NonZeroUsize::new(args.count as usize).unwrap();
+        alloc.allocate(size).await.ok_or_else(|| {
             Error::IO(io::Error::new(ErrorKind::OutOfMemory, "cannot allocate memory"))
-        })?,
+        })?
     };
 
     Ok((args, data))
-}
-
-/// Reads data into a slice asynchronously from the `CountBuffer`.
-///
-/// This function attempts to fill the provided `slice` with `to_write` bytes
-/// from the `src` buffer, skipping `to_skip` bytes at the beginning of the slice.
-///
-/// # Arguments
-///
-/// * `src` - The `CountBuffer` to read data from.
-/// * `slice` - The buffer to write the read data into.
-/// * `to_skip` - The number of bytes to skip in the buffer before writing.
-/// * `to_write` - The number of bytes to write into the buffer.
-///
-/// # Returns
-///
-/// Returns `Ok(usize)` indicating the number of bytes successfully written,
-/// or an error if an I/O error occurs or buffer sizes are invalid.
-pub async fn read_in_slice_async<S, B>(
-    src: &mut CountBuffer<S>,
-    buffer: &mut B,
-    to_skip: usize,
-    to_write: usize,
-) -> Result<usize>
-where
-    S: AsyncRead + Unpin,
-    B: Buffer,
-{
-    let mut left_skip = to_skip;
-    let mut left_write = to_write;
-    for buf in buffer.chunks_mut() {
-        let in_cur = min(left_skip, buf.len());
-        if left_skip > 0 && in_cur == buf.len() {
-            left_skip = left_skip
-                .checked_sub(in_cur)
-                .ok_or(Error::IO(io::Error::new(ErrorKind::InvalidInput, "invalid buffer size")))?;
-            continue;
-        }
-        let cur_write = min(left_write, buf.len() - left_skip);
-        if cur_write == 0 {
-            left_skip = 0;
-            continue;
-        }
-        src.read_from_async(&mut buf[left_skip..left_skip + cur_write]).await.map_err(Error::IO)?;
-        left_write = left_write
-            .checked_sub(cur_write)
-            .ok_or(Error::IO(io::Error::new(ErrorKind::InvalidInput, "invalid buffer size")))?;
-        left_skip = 0;
-    }
-    Ok(to_write - left_write)
-}
-
-/// Reads data into a slice synchronously from the `CountBuffer`.
-///
-/// This function attempts to fill the provided `slice` with `left_size` bytes
-/// from the `src` buffer. It reads synchronously until `left_size` bytes are read
-/// or an I/O error occurs.
-///
-/// # Arguments
-///
-/// * `src` - The `CountBuffer` to read data from.
-/// * `slice` - The [`Buffer`] to write the read data into.
-/// * `left_size` - The number of bytes expected to be read into the slice.
-///
-/// # Returns
-///
-/// Returns `Ok(usize)` indicating the number of bytes successfully read,
-/// or an error if an I/O error occurs or the amount of data read is not as expected.
-pub fn read_in_slice_sync<S, B>(
-    src: &mut CountBuffer<S>,
-    buffer: &mut B,
-    left_size: usize,
-) -> Result<usize>
-where
-    S: AsyncRead + Unpin,
-    B: Buffer,
-{
-    let mut real_size = 0;
-    for buf in buffer.chunks_mut() {
-        let block_size = min(buf.len(), left_size - real_size);
-        let mut read_count = 0;
-        // for my further notice:
-        // this is done in maner of cyclic read, because we don't know, when we would fail
-        while read_count < block_size {
-            let n = match src.read_from_inner(&mut buf[read_count..block_size]) {
-                Ok(0) => return Ok(real_size),
-                Ok(n) => n,
-                Err(e) => return Err(Error::IO(e)),
-            };
-            read_count += n;
-            real_size += n;
-        }
-    }
-    if real_size != left_size {
-        return Err(Error::IO(io::Error::new(
-            ErrorKind::InvalidInput,
-            "invalid amount of data read",
-        )));
-    }
-    Ok(real_size)
 }

--- a/nfs-mamont/src/parser/read_buffer.rs
+++ b/nfs-mamont/src/parser/read_buffer.rs
@@ -1,362 +1,190 @@
-//! Buffered reading utilities for parsing XDR-encoded RPC messages.
+//! Buffered frame reading for parsing XDR-encoded RPC messages.
 //!
-//! This module provides a double-buffered reader that efficiently handles
-//! asynchronous reading from network sockets while supporting retry logic
-//! for parsing operations that may require additional data.
+//! This module provides [`FrameReader`] --- a buffered reader that exposes the
+//! bodies of RMS frames (RFC 5531, section 11) of an async stream to
+//! synchronous parsing code.
 //!
-//! The main component is [`CountBuffer`], which wraps an [`AsyncRead`] stream
-//! and provides a [`Read`] interface for synchronous parsing functions. It uses
-//! two internal buffers to allow reading new data while
-//! still being able to retry parsing from a previous position if needed.
+//! The reader guarantees that after [`FrameReader::begin_body`] the first
+//! `min(frame_size, capacity)` bytes of the frame body (the "head window") are
+//! buffered in memory, so procedure arguments are parsed synchronously via the
+//! [`Read`] implementation without any retries or awaits. Only opaque payloads
+//! that do not fit into the head window (NFSv3 `WRITE` data) are read from the
+//! socket directly via [`FrameReader::read_body_exact`].
+//!
+//! Synchronous reads never cross the frame boundary: [`Read::read`] is limited
+//! by the number of unconsumed frame body bytes, so a parser can never consume
+//! bytes of the next frame. Bytes of the next frame that were buffered while
+//! refilling are consumed by the next [`FrameReader::read_frame_header`] call.
 
 use std::cmp::min;
-use std::io;
-use std::io::{ErrorKind, Read};
+use std::io::{self, ErrorKind, Read};
 
 use tokio::io::{AsyncRead, AsyncReadExt};
 
-use crate::parser::{Error, Result};
+/// Size of an RMS frame header in bytes.
+const RMS_HEADER_SIZE: usize = 4;
 
-/// A buffered reader that wraps an async stream and provides synchronous reading
-/// with retry capability.
+/// A buffered reader exposing RMS frame bodies of an async stream.
 ///
-/// `CountBuffer` uses a double-buffering strategy with two internal [`ReadBuffer`]
-/// instances. This allows the parser to:
-/// - Read new data from the socket into one buffer while parsing from another
-/// - Retry parsing operations by resetting read positions when more data is needed
-/// - Track the total number of bytes consumed from the stream
-///
-/// The buffer implements [`Read`] to work with synchronous parsing functions,
-/// while internally managing asynchronous I/O operations.
-pub struct CountBuffer<S: AsyncRead + Unpin> {
-    // actually, there are definitely two
-    bufs: Vec<ReadBuffer>,
-    read: usize,
-    write: usize,
-    retry_mode: bool,
+/// The internal buffer holds a sliding window of unconsumed stream bytes.
+/// Invariant: direct socket reads ([`FrameReader::read_body_exact`],
+/// [`FrameReader::discard_body`]) are only performed when the buffer is empty,
+/// so stream bytes are always consumed in order.
+pub struct FrameReader<S: AsyncRead + Unpin> {
     socket: S,
-    total_bytes: usize,
+    buf: Vec<u8>,
+    /// Start of the unconsumed bytes in `buf`.
+    start: usize,
+    /// End of the valid bytes in `buf`.
+    end: usize,
+    /// Bytes of the current frame body not yet consumed.
+    frame_remaining: usize,
 }
 
-impl<S: AsyncRead + Unpin> CountBuffer<S> {
-    /// Creates a new `CountBuffer` with the specified capacity for each internal buffer.
+impl<S: AsyncRead + Unpin> FrameReader<S> {
+    /// Creates a new `FrameReader` with the given buffer capacity.
     ///
-    /// # Arguments
+    /// The capacity bounds the head window of a frame: the arguments of every
+    /// procedure (except opaque `WRITE` data, which is streamed) must fit into
+    /// `capacity` bytes, otherwise parsing fails with `InvalidData`.
     ///
-    /// * `capacity` - The size in bytes for each of the two internal buffers
-    /// * `socket` - The async stream to read from
-    pub fn new(capacity: usize, socket: S) -> CountBuffer<S> {
-        Self {
-            bufs: vec![ReadBuffer::new(capacity), ReadBuffer::new(capacity)],
-            read: 0,
-            write: 1,
-            retry_mode: false,
-            socket,
-            total_bytes: 0,
-        }
+    /// # Panics
+    ///
+    /// If `capacity` is less than the RMS header size (4 bytes).
+    pub fn new(capacity: usize, socket: S) -> FrameReader<S> {
+        assert!(capacity >= RMS_HEADER_SIZE, "capacity must hold at least an RMS header");
+        Self { socket, buf: vec![0u8; capacity], start: 0, end: 0, frame_remaining: 0 }
     }
 
-    /// Fills the write buffer by reading data from the socket.
-    ///
-    /// This method reads available data from the async stream into the current
-    /// write buffer. It returns the number of bytes read, or an error if the
-    /// connection is closed or an I/O error occurs.
-    ///
-    /// Returns `Ok(0)` if the write buffer is full and no more data can be read.
-    async fn fill_internal(&mut self) -> io::Result<usize> {
-        if self.bufs[self.write].available_write() == 0 {
-            return Ok(0);
-        }
+    /// Number of buffered unconsumed bytes.
+    #[inline]
+    fn buffered(&self) -> usize {
+        self.end - self.start
+    }
 
-        let bytes_read = self.socket.read(self.bufs[self.write].write_slice()).await?;
+    /// Number of unconsumed bytes of the current frame body.
+    #[inline]
+    pub fn frame_remaining(&self) -> usize {
+        self.frame_remaining
+    }
+
+    /// Reads more data from the socket into the buffer, compacting it first
+    /// if the write area is exhausted.
+    async fn fill(&mut self) -> io::Result<usize> {
+        if self.end == self.buf.len() {
+            self.buf.copy_within(self.start..self.end, 0);
+            self.end -= self.start;
+            self.start = 0;
+        }
+        let bytes_read = self.socket.read(&mut self.buf[self.end..]).await?;
         if bytes_read == 0 {
             return Err(io::Error::new(ErrorKind::UnexpectedEof, "Connection closed"));
         }
-
-        self.bufs[self.write].extend(bytes_read);
-
+        self.end += bytes_read;
         Ok(bytes_read)
     }
 
-    /// Parses a value using the provided parsing function, with automatic retry on EOF.
+    /// Fills the buffer until at least `n` unconsumed bytes are available.
     ///
-    /// This method attempts to parse a value using a synchronous parsing function.
-    /// If the parsing function encounters an `UnexpectedEof` error, this method will:
-    /// 1. Read more data from the socket into the write buffer
-    /// 2. Reset read positions to allow retrying from the same point
-    /// 3. Retries the parsing operation in loop until it succeeds or encounters a non-EOF error
-    ///
-    /// After successful parsing, if retry mode was used, the buffers are swapped
-    /// to prepare for the next parsing operation.
-    ///
-    /// # Arguments
-    ///
-    /// * `caller` - A function that takes a `&mut dyn Read` and returns a `Result<T>`
-    ///
-    /// # Returns
-    ///
-    /// Returns the parsed value, or an error if parsing fails or I/O errors occur.
-    pub async fn parse_with_retry<T>(
-        &mut self,
-        caller: impl Fn(&mut Self) -> Result<T>,
-    ) -> Result<T> {
-        let retry_start_read = self.bufs[self.read].bytes_read();
-        let retry_start_write = self.bufs[self.write].bytes_read();
-        let retry_total = self.total_bytes;
-        // there is no need to check if we reach end of buffer while appending data to buffer since we have buffer, that would
-        // definitely be enough to read what we are planning
-        loop {
-            match caller(self) {
-                Err(Error::IO(err)) if err.kind() == ErrorKind::UnexpectedEof => {
-                    self.retry_mode = true;
-                    // called whenever we need to read more data
-                    match self.fill_internal().await {
-                        Ok(_) => {
-                            self.bufs[self.read].reset_read(retry_start_read);
-                            self.bufs[self.write].reset_read(retry_start_write);
-                            self.total_bytes = retry_total;
-                            continue;
-                        }
-                        Err(e) => return Err(Error::IO(e)),
-                    }
-                }
-                Ok(val) => {
-                    if self.retry_mode {
-                        self.bufs[self.read].clean();
-                        self.write = (self.write + 1) % 2;
-                        self.read = (self.read + 1) % 2;
-                    }
-                    if self.read == self.write {
-                        return Err(Error::IO(io::Error::other(
-                            "Cannot read and write to one buffer simultaneously",
-                        )));
-                    }
-                    self.retry_mode = false;
-                    return Ok(val);
-                }
-                Err(err) => return Err(err),
-            }
+    /// `n` must not exceed the buffer capacity.
+    async fn ensure_buffered(&mut self, n: usize) -> io::Result<()> {
+        debug_assert!(n <= self.buf.len());
+        while self.buffered() < n {
+            self.fill().await?;
         }
-    }
-
-    /// Reads an exact number of bytes from the socket into the provided buffer.
-    ///
-    /// This method uses `read_exact` to ensure the entire buffer is filled.
-    /// The total byte count is updated to reflect the bytes read.
-    ///
-    /// # Arguments
-    ///
-    /// * `dest` - The destination buffer to fill
-    ///
-    /// # Returns
-    ///
-    /// Returns the number of bytes read (equal to `dest.len()`), or an error
-    /// if the connection is closed before the buffer can be filled.
-    pub async fn read_from_async(&mut self, dest: &mut [u8]) -> io::Result<usize> {
-        self.socket.read_exact(dest).await?;
-        self.total_bytes += dest.len();
-        Ok(dest.len())
-    }
-
-    /// Resets the total byte counter to zero.
-    ///
-    /// This is typically called after successfully parsing a complete message
-    /// to prepare for parsing the next message.
-    #[inline]
-    pub fn clean(&mut self) {
-        self.total_bytes = 0;
-    }
-
-    /// Reads data from the internal buffers into the provided destination buffer.
-    ///
-    /// This method reads from internal buffers,
-    /// filling the destination buffer with available data.
-    ///
-    /// # Arguments
-    ///
-    /// * `dest` - The destination buffer to fill
-    ///
-    /// # Returns
-    ///
-    /// Returns the number of bytes read, which may be less than `dest.len()`
-    /// if not enough data is available in the internal buffers.
-    pub fn read_from_inner(&mut self, dest: &mut [u8]) -> io::Result<usize> {
-        if dest.is_empty() {
-            return Ok(0);
-        }
-        self.read(dest)
-    }
-
-    /// Returns the total number of bytes consumed from the stream since the last reset.
-    ///
-    /// This count includes all bytes that have been read from the socket,
-    /// whether they were consumed by parsing operations or discarded.
-    #[inline]
-    pub fn total_bytes(&self) -> usize {
-        self.total_bytes
-    }
-
-    /// Discards the specified number of bytes from the stream.
-    ///
-    /// This method is used to skip over unparsed or unwanted data. It first
-    /// consumes available bytes from the internal buffers, then reads and discards
-    /// any remaining bytes directly from the socket.
-    ///
-    /// # Arguments
-    ///
-    /// * `n` - The number of bytes to discard
-    ///
-    /// # Returns
-    ///
-    /// Returns `Ok(())` if exactly `n` bytes were discarded, or an error if
-    /// the connection is closed before all bytes can be discarded.
-    pub async fn discard_bytes(&mut self, n: usize) -> io::Result<()> {
-        let from_inner = {
-            let from_inner1 = min(self.bufs[self.read].available_read(), n);
-            self.bufs[self.read].consume(from_inner1);
-            let from_inner2 = min(self.bufs[self.write].available_read(), n - from_inner1);
-            self.bufs[self.write].consume(from_inner2);
-            from_inner1 + from_inner2
-        };
-
-        self.total_bytes += from_inner;
-        let from_socket = n - from_inner;
-        if from_socket == 0 {
-            return Ok(());
-        }
-
-        let mut src = (&mut self.socket).take(from_socket as u64);
-
-        let mut actual = 0;
-
-        loop {
-            let n = src.read(self.bufs[self.write].write_slice()).await?;
-            if n == 0 {
-                break;
-            }
-            actual += n;
-        }
-
-        self.total_bytes += actual;
-
-        // probably useless, since we have guarantees from Take
-        if actual != from_socket {
-            return Err(io::Error::new(
-                ErrorKind::InvalidData,
-                "Discarded not valid amount of bytes",
-            ));
-        }
-
         Ok(())
     }
-}
 
-impl<S: AsyncRead + Unpin> Read for CountBuffer<S> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let n1 = self.bufs[self.read].read(buf)?;
-        let n2 = self.bufs[self.write].read(&mut buf[n1..])?;
-        self.total_bytes += n1 + n2;
-        Ok(n1 + n2)
+    /// Reads the 4-byte RMS frame header from the stream.
+    ///
+    /// The header is not part of the frame body and is not accounted for in
+    /// [`FrameReader::frame_remaining`].
+    pub async fn read_frame_header(&mut self) -> io::Result<u32> {
+        self.ensure_buffered(RMS_HEADER_SIZE).await?;
+        let bytes: [u8; RMS_HEADER_SIZE] =
+            self.buf[self.start..self.start + RMS_HEADER_SIZE].try_into().unwrap();
+        self.start += RMS_HEADER_SIZE;
+        Ok(u32::from_be_bytes(bytes))
+    }
+
+    /// Starts a frame body of `size` bytes and buffers its head window
+    /// (`min(size, capacity)` bytes), so subsequent synchronous parsing does
+    /// not run out of data before the window is exhausted.
+    pub async fn begin_body(&mut self, size: usize) -> io::Result<()> {
+        self.frame_remaining = size;
+        let head = min(size, self.buf.len());
+        self.ensure_buffered(head).await
+    }
+
+    /// Reads exactly `dest.len()` bytes of the frame body, first from the
+    /// buffer, then directly from the socket.
+    ///
+    /// Used for opaque payloads (NFSv3 `WRITE` data) that may not fit into
+    /// the buffered head window.
+    pub async fn read_body_exact(&mut self, dest: &mut [u8]) -> io::Result<()> {
+        if dest.len() > self.frame_remaining {
+            return Err(io::Error::new(ErrorKind::InvalidData, "Read beyond frame bounds"));
+        }
+        let from_buf = min(dest.len(), self.buffered());
+        dest[..from_buf].copy_from_slice(&self.buf[self.start..self.start + from_buf]);
+        self.start += from_buf;
+        self.frame_remaining -= from_buf;
+
+        let rest = &mut dest[from_buf..];
+        if !rest.is_empty() {
+            // from_buf < dest.len() implies the buffer is empty, so a direct
+            // socket read preserves stream ordering.
+            self.socket.read_exact(rest).await?;
+            self.frame_remaining -= rest.len();
+        }
+        Ok(())
+    }
+
+    /// Discards `n` bytes of the frame body, first from the buffer, then from
+    /// the socket (reusing the buffer as scratch space).
+    pub async fn discard_body(&mut self, n: usize) -> io::Result<()> {
+        if n > self.frame_remaining {
+            return Err(io::Error::new(ErrorKind::InvalidData, "Discard beyond frame bounds"));
+        }
+        let from_buf = min(n, self.buffered());
+        self.start += from_buf;
+        self.frame_remaining -= from_buf;
+
+        let mut left = n - from_buf;
+        if left > 0 {
+            // left > 0 implies the buffer is empty; reuse it as scratch space.
+            self.start = 0;
+            self.end = 0;
+            while left > 0 {
+                let take = min(left, self.buf.len());
+                self.socket.read_exact(&mut self.buf[..take]).await?;
+                left -= take;
+                self.frame_remaining -= take;
+            }
+        }
+        Ok(())
+    }
+
+    /// Discards all unconsumed bytes of the current frame body, aligning the
+    /// stream to the next frame after a protocol-level error.
+    pub async fn discard_rest_of_frame(&mut self) -> io::Result<()> {
+        let remaining = self.frame_remaining;
+        self.discard_body(remaining).await
     }
 }
 
-/// An internal buffer for managing read and write positions.
-///
-/// `ReadBuffer` maintains a fixed-size buffer with separate read and write
-/// positions, allowing efficient tracking of available data and available space.
-/// It implements [`Read`] to provide a standard interface for consuming data.
-pub struct ReadBuffer {
-    data: Vec<u8>,
-    read_pos: usize,
-    write_pos: usize,
-}
-
-impl ReadBuffer {
-    /// Creates a new `ReadBuffer` with the specified capacity.
+impl<S: AsyncRead + Unpin> Read for FrameReader<S> {
+    /// Reads buffered frame body bytes.
     ///
-    /// The buffer is initialized with zeros and both read and write positions
-    /// start at the beginning.
-    fn new(capacity: usize) -> Self {
-        Self { data: vec![0u8; capacity], read_pos: 0, write_pos: 0 }
-    }
-
-    /// Returns the current read position (number of bytes consumed).
-    #[inline]
-    fn bytes_read(&self) -> usize {
-        self.read_pos
-    }
-
-    /// Returns the number of bytes available to read.
-    ///
-    /// This is the difference between the write position and read position.
-    #[inline]
-    fn available_read(&self) -> usize {
-        self.write_pos - self.read_pos
-    }
-
-    /// Returns the number of bytes available for writing.
-    ///
-    /// This is the remaining space in the buffer from the write position to the end.
-    #[inline]
-    fn available_write(&self) -> usize {
-        self.data.len() - self.write_pos
-    }
-
-    /// Returns a mutable slice of the buffer starting from the write position.
-    ///
-    /// This slice can be used to write data directly into the buffer.
-    #[inline]
-    fn write_slice(&mut self) -> &mut [u8] {
-        &mut self.data[self.write_pos..]
-    }
-
-    /// Advances the read position by `n` bytes, consuming that many bytes.
-    ///
-    /// # Arguments
-    ///
-    /// * `n` - The number of bytes to consume
-    #[inline]
-    fn consume(&mut self, n: usize) {
-        self.read_pos += n;
-    }
-
-    /// Advances the write position by `n` bytes, indicating that data has been written.
-    ///
-    /// # Arguments
-    ///
-    /// * `n` - The number of bytes that were written
-    #[inline]
-    fn extend(&mut self, n: usize) {
-        self.write_pos += n;
-    }
-
-    /// Resets the read position to a specific value.
-    ///
-    /// This is used during retry operations to allow re-reading from a previous position.
-    ///
-    /// # Arguments
-    ///
-    /// * `n` - The new read position
-    #[inline]
-    fn reset_read(&mut self, n: usize) {
-        self.read_pos = n;
-    }
-
-    /// Resets both read and write positions to zero, clearing the buffer.
-    ///
-    /// This prepares the buffer for reuse after a complete message has been processed.
-    #[inline]
-    fn clean(&mut self) {
-        self.read_pos = 0;
-        self.write_pos = 0;
-    }
-}
-
-impl Read for ReadBuffer {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let len = min(buf.len(), self.available_read());
-        buf[..len].copy_from_slice(&self.data[self.read_pos..self.read_pos + len]);
-        self.consume(len);
-        Ok(len)
+    /// The read is limited both by the buffered data and by the frame
+    /// boundary; `Ok(0)` with a non-empty `dest` means either the frame body
+    /// is fully consumed or the head window is exhausted (arguments larger
+    /// than the buffer).
+    fn read(&mut self, dest: &mut [u8]) -> io::Result<usize> {
+        let n = min(dest.len(), min(self.buffered(), self.frame_remaining));
+        dest[..n].copy_from_slice(&self.buf[self.start..self.start + n]);
+        self.start += n;
+        self.frame_remaining -= n;
+        Ok(n)
     }
 }

--- a/nfs-mamont/src/parser/rpc.rs
+++ b/nfs-mamont/src/parser/rpc.rs
@@ -1,18 +1,54 @@
 use std::io::Read;
 
-use crate::parser::primitive::{variant, vec_max_size};
-use crate::parser::Result;
-use crate::rpc::{AuthFlavor, OpaqueAuth, MAX_AUTH_SIZE};
+use crate::parser::primitive::{string_max_size, u32, u32_as_usize, variant, vec_max_size};
+use crate::parser::{Error, Result};
+use crate::rpc::{
+    AuthFlavor, AuthSysParams, Credential, OpaqueAuth, AUTH_SYS_MAX_GIDS,
+    AUTH_SYS_MAX_MACHINE_NAME, MAX_AUTH_SIZE,
+};
 
 #[derive(Debug)]
 pub struct RpcMessage {
     pub program: u32,
     pub procedure: u32,
     pub version: u32,
-    pub cred: OpaqueAuth,
-    pub verf: OpaqueAuth,
+    pub cred: Credential,
 }
 
+/// Reads a raw `opaque_auth` (flavor + opaque body) from the stream.
 pub fn auth(src: &mut impl Read) -> Result<OpaqueAuth> {
     Ok(OpaqueAuth { flavor: variant::<AuthFlavor>(src)?, body: vec_max_size(src, MAX_AUTH_SIZE)? })
+}
+
+/// Parses an `AUTH_SYS` credential body (`authsys_parms`, RFC 5531 appendix A):
+///
+/// ```text
+/// struct authsys_parms {
+///     unsigned int stamp;
+///     string machinename<255>;
+///     unsigned int uid;
+///     unsigned int gid;
+///     unsigned int gids<16>;
+/// };
+/// ```
+///
+/// `src` reads over the already-extracted opaque credential body, so it cannot
+/// over-read into the rest of the RPC frame. Returns an error if the body is
+/// truncated or violates the `machinename`/`gids` length limits.
+pub fn authsys_parms(src: &mut impl Read) -> Result<AuthSysParams> {
+    let stamp = u32(src)?;
+    let machine_name = string_max_size(src, AUTH_SYS_MAX_MACHINE_NAME)?;
+    let uid = u32(src)?;
+    let gid = u32(src)?;
+
+    let count = u32_as_usize(src)?;
+    if count > AUTH_SYS_MAX_GIDS {
+        return Err(Error::MaxElemLimit);
+    }
+    let mut gids = Vec::with_capacity(count);
+    for _ in 0..count {
+        gids.push(u32(src)?);
+    }
+
+    Ok(AuthSysParams { stamp, machine_name, uid, gid, gids })
 }

--- a/nfs-mamont/src/parser/tests/parser_struct.rs
+++ b/nfs-mamont/src/parser/tests/parser_struct.rs
@@ -3,14 +3,16 @@ use std::sync::Arc;
 
 use crate::allocator::Buffer;
 use crate::consts::mount::{MOUNT_PROGRAM, MOUNT_VERSION};
-use crate::consts::nfsv3::{FSSTAT, NFS_PROGRAM, NFS_VERSION, READ, WRITE};
+use crate::consts::nfsv3::{FSSTAT, NFS_PROGRAM, NFS_VERSION, WRITE};
 use crate::parser::parser_struct::RpcParser;
 use crate::parser::tests::allocator::MockAllocator;
 use crate::parser::tests::socket::MockSocket;
 use crate::parser::{
     ArgWrapper, Error, ErrorWrapper, MountArguments, NfsArguments, ProcArguments, RpcHeader,
 };
-use crate::rpc::{AuthFlavor, AuthStat, OpaqueAuth, RpcBody, RPC_VERSION};
+use crate::rpc::{
+    AuthFlavor, AuthStat, AuthSysParams, Credential, OpaqueAuth, RpcBody, RPC_VERSION,
+};
 use crate::vfs::file::Handle;
 use crate::vfs::write;
 use crate::vfs::write::StableHow;
@@ -24,7 +26,7 @@ struct WriteWrapper<'a> {
 /// Constants for mock RPC/NFS test input construction.
 const XID: u32 = 1;
 
-/// Mask for the fragment header flag in the message header.
+/// Mask for fragment header flag in the message header.
 const FRAGMENT_HEADER_MASK: u32 = 0x8000_0000;
 
 /// Writes a 32-bit big-endian integer to a buffer.
@@ -39,13 +41,13 @@ pub fn push_u64(buf: &mut Vec<u8>, value: u64) {
     buf.extend_from_slice(&value.to_be_bytes());
 }
 
-/// Appends raw bytes to the buffer.
+/// Appends raw bytes to a buffer.
 #[inline]
 pub fn push_bytes(buf: &mut Vec<u8>, bytes: &[u8]) {
     buf.extend_from_slice(bytes);
 }
 
-/// Pads the buffer with zeros to ensure 4-byte alignment.
+/// Pads a buffer with zeros to ensure 4-byte alignment.
 ///
 /// # Parameters
 ///
@@ -75,8 +77,62 @@ fn push_opaque(buf: &mut Vec<u8>, bytes: &[u8]) {
     pad_to_alignment(buf, bytes.len());
 }
 
-/// Constructs a complete NFS RPC call frame for the given procedure and arguments.
-/// Returns the serialized byte buffer suitable for testing the parser.
+/// Writes a wire `opaque_auth`: the flavor discriminant followed by an opaque body.
+fn push_auth(buf: &mut Vec<u8>, flavor: AuthFlavor, body: &[u8]) {
+    push_u32(buf, flavor.to_u32().unwrap());
+    push_opaque(buf, body);
+}
+
+/// Serializes a [`Credential`] into its wire `opaque_auth` form.
+fn push_credential(buf: &mut Vec<u8>, cred: &Credential) {
+    match cred {
+        Credential::None => push_auth(buf, AuthFlavor::None, &[]),
+        Credential::Sys(params) => {
+            let mut body = Vec::new();
+            push_u32(&mut body, params.stamp);
+            push_opaque(&mut body, params.machine_name.as_bytes());
+            push_u32(&mut body, params.uid);
+            push_u32(&mut body, params.gid);
+            push_u32(&mut body, params.gids.len().try_into().unwrap());
+            for gid in &params.gids {
+                push_u32(&mut body, *gid);
+            }
+            push_auth(buf, AuthFlavor::Sys, &body);
+        }
+    }
+}
+
+/// Constructs an NFS RPC call frame with explicit wire credential and verifier.
+/// Used by tests that need to inject malformed authentication.
+fn nfs_call_frame_wire(
+    msg_type: u32,
+    rpc_version: u32,
+    xid: u32,
+    cred: &OpaqueAuth,
+    verf: &OpaqueAuth,
+    procedure: u32,
+    args_builder: impl FnOnce(&mut Vec<u8>),
+) -> Vec<u8> {
+    let mut payload = Vec::new();
+    push_u32(&mut payload, xid);
+    push_u32(&mut payload, msg_type);
+    push_u32(&mut payload, rpc_version);
+    push_u32(&mut payload, NFS_PROGRAM);
+    push_u32(&mut payload, NFS_VERSION);
+    push_u32(&mut payload, procedure);
+    push_auth(&mut payload, cred.flavor.clone(), &cred.body);
+    push_auth(&mut payload, verf.flavor.clone(), &verf.body);
+    args_builder(&mut payload);
+
+    let mut frame = Vec::with_capacity(payload.len());
+    let payload_len: u32 = payload.len().try_into().unwrap();
+    push_u32(&mut frame, FRAGMENT_HEADER_MASK | payload_len);
+    frame.extend_from_slice(&payload);
+    frame
+}
+
+/// Constructs a complete NFS RPC call frame for a given procedure and arguments.
+/// Returns a serialized byte buffer suitable for testing the parser.
 fn nfs_call_frame(
     msg_type: u32,
     rpc_version: u32,
@@ -93,19 +149,15 @@ fn nfs_call_frame(
     push_u32(&mut payload, NFS_VERSION);
     push_u32(&mut payload, procedure);
     // cred
-    // Auth body length (0 for AUTH_NONE/SYS in tests)
-    push_u32(&mut payload, header.cred.flavor.to_u32().unwrap());
-    push_opaque(&mut payload, &header.cred.body);
-
-    // verf
-    push_u32(&mut payload, header.verf.flavor.to_u32().unwrap());
-    push_opaque(&mut payload, &header.verf.body);
+    push_credential(&mut payload, &header.cred);
+    // verf: always AUTH_NONE with an empty body
+    push_auth(&mut payload, AuthFlavor::None, &[]);
     // Append procedure-specific arguments
     args_builder(&mut payload);
 
     let mut frame = Vec::with_capacity(payload.len());
 
-    // Construct fragment header: set last fragment flag and include header size
+    // Construct fragment header: set the last fragment flag and include header size
     let payload_len: u32 = payload.len().try_into().unwrap();
     let fragment_header = FRAGMENT_HEADER_MASK | (payload_len);
 
@@ -114,7 +166,7 @@ fn nfs_call_frame(
     frame
 }
 
-/// Constructs a complete MOUNT RPC call frame for the given procedure and arguments.
+/// Constructs a complete MOUNT RPC call frame for a given procedure and arguments.
 fn mount_call_frame(
     msg_type: u32,
     rpc_version: u32,
@@ -131,21 +183,18 @@ fn mount_call_frame(
     push_u32(&mut payload, MOUNT_VERSION);
     push_u32(&mut payload, procedure);
     // cred
-    push_u32(&mut payload, header.cred.flavor.to_u32().unwrap());
-    push_opaque(&mut payload, &header.cred.body);
-
-    // verf
-    push_u32(&mut payload, header.verf.flavor.to_u32().unwrap());
-    push_opaque(&mut payload, &header.verf.body);
+    push_credential(&mut payload, &header.cred);
+    // verf: always AUTH_NONE with an empty body
+    push_auth(&mut payload, AuthFlavor::None, &[]);
 
     // Append procedure-specific arguments
     args_builder(&mut payload);
 
     let mut frame = Vec::with_capacity(payload.len());
 
-    // Construct fragment header: set last fragment flag and include header size
+    // Construct fragment header: set the last fragment flag and include header size
     let payload_len: u32 = payload.len().try_into().unwrap();
-    let fragment_header = FRAGMENT_HEADER_MASK | payload_len;
+    let fragment_header = FRAGMENT_HEADER_MASK | (payload_len);
 
     push_u32(&mut frame, fragment_header);
     frame.extend_from_slice(&payload);
@@ -157,29 +206,6 @@ fn fsstat_args(root: [u8; 8]) -> Vec<u8> {
     let mut args = Vec::new();
     push_opaque(&mut args, &root);
     args
-}
-
-/// Serializes read (NFS procedure 6) arguments: file handle, offset and count.
-fn read_args(file: [u8; 8], offset: u64, count: u32) -> Vec<u8> {
-    let mut args = Vec::new();
-    push_opaque(&mut args, &file);
-    push_u64(&mut args, offset);
-    push_u32(&mut args, count);
-    args
-}
-
-/// Helper to assert parsed READ arguments and the size of the attached output buffer.
-fn assert_read_proc_result<B: Buffer>(result: &ProcArguments<B>, expected: (u64, u32, usize)) {
-    let (expected_offset, expected_count, expected_len) = expected;
-    let ProcArguments::Nfs3(args) = result else {
-        panic!("Wrong program argument type");
-    };
-    let NfsArguments::Read(args, data) = args.as_ref() else {
-        panic!("Wrong NFS argument type");
-    };
-    assert_eq!(args.offset, expected_offset);
-    assert_eq!(args.count, expected_count);
-    assert_eq!(data.len(), expected_len);
 }
 
 /// Serializes write (NFS procedure 7) arguments, including count, offset, stable, and data.
@@ -248,8 +274,7 @@ fn assert_arg_wrapper<B: Buffer, F, T: Fn(&ProcArguments<B>, F)>(
 /// Test: Parses a valid MOUNT call and returns mount-specific arguments.
 #[tokio::test]
 async fn parse_mount_call() {
-    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
-    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+    let header = RpcHeader { xid: XID, cred: Credential::None };
 
     let frame = mount_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, 1, |buf| {
         push_opaque(buf, b"/mnt/vol");
@@ -266,11 +291,10 @@ async fn parse_mount_call() {
     assert!(matches!(mount_args.as_ref(), MountArguments::Mount(_)));
 }
 
-/// Test: After a MOUNT procedure mismatch, parser can parse the next valid MOUNT call.
+/// Test: After a MOUNT procedure mismatch, the parser can parse the next valid MOUNT call.
 #[tokio::test]
 async fn parse_mount_after_error() {
-    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
-    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+    let header = RpcHeader { xid: XID, cred: Credential::None };
 
     let first = mount_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, 99, |_| {});
     let second = mount_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, 1, |buf| {
@@ -301,8 +325,7 @@ async fn parse_mount_after_error() {
 /// Test: Parses two correct NFS FSSTAT frames back-to-back.
 #[tokio::test]
 async fn parse_two_correct() {
-    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
-    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+    let header = RpcHeader { xid: XID, cred: Credential::None };
 
     let first = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, FSSTAT, |buf| {
         buf.extend_from_slice(&fsstat_args([1, 2, 3, 4, 5, 6, 7, 8]));
@@ -337,8 +360,7 @@ async fn parse_two_correct() {
 /// Test: After a version mismatch error, parses the next valid FSSTAT frame.
 #[tokio::test]
 async fn parse_after_error() {
-    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
-    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+    let header = RpcHeader { xid: XID, cred: Credential::None };
 
     let first = nfs_call_frame(RpcBody::Call as u32, 3, &header, FSSTAT, |buf| {
         buf.extend_from_slice(&fsstat_args([1, 2, 3, 4, 5, 6, 7, 8]));
@@ -365,124 +387,14 @@ async fn parse_after_error() {
     );
 }
 
-/// Test: READ parsing allocates an output buffer of the requested size.
-#[tokio::test]
-async fn parse_read() {
-    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
-    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
-
-    let frame = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, READ, |buf| {
-        buf.extend_from_slice(&read_args([1, 2, 3, 4, 5, 6, 7, 8], 0x8000, 512));
-    });
-
-    let socket = MockSocket::new(frame.as_slice());
-    let alloc = Arc::new(MockAllocator::new(4096));
-    let mut parser = RpcParser::with_capacity(socket, alloc, 96);
-
-    let result = parser.next_message().await.unwrap();
-    assert_arg_wrapper(result, &header, assert_read_proc_result, (0x8000, 512, 512));
-}
-
-/// Test: READ with `count == 0` yields an empty buffer without touching the allocator.
-#[tokio::test]
-async fn parse_read_with_zero_count() {
-    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
-    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
-
-    let frame = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, READ, |buf| {
-        buf.extend_from_slice(&read_args([1, 2, 3, 4, 5, 6, 7, 8], 0, 0));
-    });
-
-    let socket = MockSocket::new(frame.as_slice());
-    // An allocator that fails every request: a zero-count READ must not consult it.
-    let alloc = Arc::new(MockAllocator::new(0));
-    let mut parser = RpcParser::with_capacity(socket, alloc, 96);
-
-    let result = parser.next_message().await.unwrap();
-    assert_arg_wrapper(result, &header, assert_read_proc_result, (0, 0, 0));
-}
-
-/// Test: a `count` the allocator can never serve is clamped into a short read
-/// instead of failing the request.
-#[tokio::test]
-async fn parse_read_clamps_oversized_count() {
-    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
-    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
-
-    let frame = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, READ, |buf| {
-        buf.extend_from_slice(&read_args([1, 2, 3, 4, 5, 6, 7, 8], 0, u32::MAX));
-    });
-
-    let socket = MockSocket::new(frame.as_slice());
-    let alloc = Arc::new(MockAllocator::new(1024));
-    let mut parser = RpcParser::with_capacity(socket, alloc, 96);
-
-    let result = parser.next_message().await.unwrap();
-    // `count` is rewritten so the backend never sees more than the buffer holds.
-    assert_arg_wrapper(result, &header, assert_read_proc_result, (0, 1024, 1024));
-}
-
-/// Test: an allocation failure leaves the stream aligned, so the next frame still parses.
-///
-/// Regression test: the failing frame used to be left half-consumed, which
-/// desynced the byte counter and made every subsequent frame fail with
-/// "Unparsed data remaining in frame".
-#[tokio::test]
-async fn parse_after_allocation_failure() {
-    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
-    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
-
-    let data = [0x01_u8, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
-    let write = WriteWrapper {
-        part: write::ArgsPartial {
-            file: Handle([1, 2, 3, 4, 5, 6, 7, 8]),
-            offset: 0x8000,
-            size: 0xFF,
-            stable: StableHow::Unstable,
-        },
-        data: &data,
-    };
-
-    let first = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, WRITE, |buf| {
-        buf.extend_from_slice(&write_args(&write));
-    });
-    let second = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, FSSTAT, |buf| {
-        buf.extend_from_slice(&fsstat_args([1, 2, 3, 4, 5, 6, 7, 8]));
-    });
-    let mut buf = Vec::new();
-    buf.extend_from_slice(&first);
-    buf.extend_from_slice(&second);
-
-    let socket = MockSocket::new(buf.as_slice());
-    // Too small for the 8-byte WRITE payload, so allocation fails.
-    let alloc = Arc::new(MockAllocator::new(4));
-    let mut parser = RpcParser::with_capacity(socket, alloc, 80);
-
-    let result = parser.next_message().await;
-    assert!(matches!(
-        result,
-        Err(ErrorWrapper { error: Error::IO(ref err), xid: Some(XID) })
-            if err.kind() == std::io::ErrorKind::OutOfMemory
-    ));
-
-    let result = parser.next_message().await.unwrap();
-    assert_arg_wrapper(
-        result,
-        &header,
-        |proc, opaque| assert_fsstat_proc_result(proc, opaque),
-        &[1, 2, 3, 4, 5, 6, 7, 8],
-    );
-}
-
 /// Test: Parses two correct NFS WRITE frames with data.
 #[tokio::test]
 async fn parse_write() {
-    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
-    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+    let header = RpcHeader { xid: XID, cred: Credential::None };
 
     #[rustfmt::skip]
     let data = [
-        0x01_u8, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
         0x00, 0x00, 0x00, 0x08, 0x01, 0x02, 0x03, 0x04,
         0x01, 0x02,
     ];
@@ -519,11 +431,10 @@ async fn parse_write() {
     assert_arg_wrapper(result, &header, |proc, arg| assert_write_proc_result(proc, arg), &write);
 }
 
-/// Test: Parser recovers from an error on first WRITE frame and parses the next valid WRITE frame.
+/// Test: The parser recovers from an error on the first WRITE frame and parses the next valid WRITE frame.
 #[tokio::test]
 async fn parse_write_after_error() {
-    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
-    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+    let header = RpcHeader { xid: XID, cred: Credential::None };
 
     #[rustfmt::skip]
     let data = [
@@ -631,7 +542,7 @@ async fn parse_rejects_any_non_call_message_type() {
     ));
 }
 
-/// Ensures parser rejects fragments with size below XID width.
+/// Ensures the parser rejects fragments with size below XID width.
 #[tokio::test]
 async fn parse_rejects_frame_smaller_than_xid() {
     #[rustfmt::skip]
@@ -647,11 +558,10 @@ async fn parse_rejects_frame_smaller_than_xid() {
     assert!(matches!(error, Error::IO(err) if err.kind() == std::io::ErrorKind::InvalidData));
 }
 
-/// Verifies parser handles WRITE with zero opaque payload.
+/// Verifies the parser handles WRITE with zero opaque payload.
 #[tokio::test]
 async fn parse_write_with_empty_payload() {
-    let auth = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
-    let header = RpcHeader { xid: XID, cred: auth.clone(), verf: auth };
+    let header = RpcHeader { xid: XID, cred: Credential::None };
 
     let write = WriteWrapper {
         part: write::ArgsPartial {
@@ -666,6 +576,7 @@ async fn parse_write_with_empty_payload() {
     let first = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, WRITE, |buf| {
         buf.extend_from_slice(&write_args(&write));
     });
+
     let mut buf = Vec::new();
     buf.extend_from_slice(&first);
     let socket = MockSocket::new(buf.as_slice());
@@ -677,12 +588,12 @@ async fn parse_write_with_empty_payload() {
 
 #[tokio::test]
 async fn parse_rejects_non_none_cred_auth() {
-    let verf = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
     let cred = OpaqueAuth { flavor: AuthFlavor::Short, body: vec![] };
-    let header = RpcHeader { xid: XID, cred, verf };
-    let frame = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, FSSTAT, |buf| {
-        buf.extend_from_slice(&fsstat_args([1, 2, 3, 4, 5, 6, 7, 8]));
-    });
+    let verf = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
+    let frame =
+        nfs_call_frame_wire(RpcBody::Call as u32, RPC_VERSION, XID, &cred, &verf, FSSTAT, |buf| {
+            buf.extend_from_slice(&fsstat_args([1, 2, 3, 4, 5, 6, 7, 8]));
+        });
     let socket = MockSocket::new(frame.as_slice());
     let alloc = Arc::new(MockAllocator::new(0));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x40);
@@ -698,10 +609,10 @@ async fn parse_rejects_non_none_cred_auth() {
 async fn parse_rejects_non_none_verf_auth() {
     let cred = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
     let verf = OpaqueAuth { flavor: AuthFlavor::None, body: vec![0, 1, 3] };
-    let header = RpcHeader { xid: XID, cred, verf };
-    let frame = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, FSSTAT, |buf| {
-        buf.extend_from_slice(&fsstat_args([1, 2, 3, 4, 5, 6, 7, 8]));
-    });
+    let frame =
+        nfs_call_frame_wire(RpcBody::Call as u32, RPC_VERSION, XID, &cred, &verf, FSSTAT, |buf| {
+            buf.extend_from_slice(&fsstat_args([1, 2, 3, 4, 5, 6, 7, 8]));
+        });
     let socket = MockSocket::new(frame.as_slice());
     let alloc = Arc::new(MockAllocator::new(0));
     let mut parser = RpcParser::with_capacity(socket, alloc, 0x40);
@@ -710,5 +621,55 @@ async fn parse_rejects_non_none_verf_auth() {
     assert!(matches!(
         result,
         Err(ErrorWrapper { error: Error::Auth(AuthStat::BadVerf), xid: Some(XID) })
+    ));
+}
+
+/// Parses a FSSTAT call carrying an AUTH_SYS credential and checks that the
+/// UNIX identity is decoded into the parsed header.
+#[tokio::test]
+async fn parse_accepts_auth_sys_credentials() {
+    let params = AuthSysParams {
+        stamp: 0xDEAD_BEEF,
+        machine_name: "client-host".to_string(),
+        uid: 1000,
+        gid: 1000,
+        gids: vec![4, 27, 1000],
+    };
+    let header = RpcHeader { xid: XID, cred: Credential::Sys(params) };
+
+    let frame = nfs_call_frame(RpcBody::Call as u32, RPC_VERSION, &header, FSSTAT, |buf| {
+        buf.extend_from_slice(&fsstat_args([1, 2, 3, 4, 5, 6, 7, 8]));
+    });
+    let socket = MockSocket::new(frame.as_slice());
+    let alloc = Arc::new(MockAllocator::new(0));
+    let mut parser = RpcParser::with_capacity(socket, alloc, 0x60);
+
+    let result = parser.next_message().await.unwrap();
+    assert_eq!(result.header, header);
+}
+
+/// Rejects an AUTH_SYS credential whose body is truncated (missing gids array).
+#[tokio::test]
+async fn parse_rejects_truncated_auth_sys() {
+    let mut body = Vec::new();
+    push_u32(&mut body, 0); // stamp
+    push_opaque(&mut body, b"host"); // machinename
+    push_u32(&mut body, 1000); // uid
+                               // gid and gids omitted -> truncated
+    let cred = OpaqueAuth { flavor: AuthFlavor::Sys, body };
+    let verf = OpaqueAuth { flavor: AuthFlavor::None, body: vec![] };
+
+    let frame =
+        nfs_call_frame_wire(RpcBody::Call as u32, RPC_VERSION, XID, &cred, &verf, FSSTAT, |buf| {
+            buf.extend_from_slice(&fsstat_args([1, 2, 3, 4, 5, 6, 7, 8]));
+        });
+    let socket = MockSocket::new(frame.as_slice());
+    let alloc = Arc::new(MockAllocator::new(0));
+    let mut parser = RpcParser::with_capacity(socket, alloc, 0x60);
+
+    let result = parser.next_message().await;
+    assert!(matches!(
+        result,
+        Err(ErrorWrapper { error: Error::Auth(AuthStat::BadCred), xid: Some(XID) })
     ));
 }

--- a/nfs-mamont/src/rpc.rs
+++ b/nfs-mamont/src/rpc.rs
@@ -7,6 +7,12 @@ pub const RPC_VERSION: u32 = 2;
 
 pub const MAX_AUTH_SIZE: usize = 400;
 
+/// Maximum length of the `machinename` field in `AUTH_SYS` credentials (RFC 5531, appendix A).
+pub const AUTH_SYS_MAX_MACHINE_NAME: usize = 255;
+
+/// Maximum number of auxiliary GIDs in `AUTH_SYS` credentials (RFC 5531, appendix A).
+pub const AUTH_SYS_MAX_GIDS: usize = 16;
+
 #[derive(ToPrimitive, FromPrimitive)]
 pub enum AcceptStat {
     Success = 0,
@@ -63,6 +69,36 @@ pub enum AuthFlavor {
 pub struct OpaqueAuth {
     pub flavor: AuthFlavor,
     pub body: Vec<u8>,
+}
+
+/// Parsed `AUTH_SYS` credential body (`authsys_parms`, RFC 5531 appendix A).
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct AuthSysParams {
+    /// Arbitrary ID the caller stamps on the credential; meaningful only to the caller.
+    pub stamp: u32,
+    /// Name of the caller's machine (at most [`AUTH_SYS_MAX_MACHINE_NAME`] bytes).
+    pub machine_name: String,
+    /// Effective user ID of the caller.
+    pub uid: u32,
+    /// Effective group ID of the caller.
+    pub gid: u32,
+    /// Auxiliary group IDs of the caller (at most [`AUTH_SYS_MAX_GIDS`] entries).
+    pub gids: Vec<u32>,
+}
+
+/// Authenticated caller identity extracted from an RPC credential.
+///
+/// Only the flavors the server accepts are represented: `AUTH_NONE` (anonymous)
+/// and `AUTH_SYS` (UNIX-style uid/gid). Any other flavor is rejected during
+/// parsing with [`AuthStat::BadCred`].
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+pub enum Credential {
+    /// `AUTH_NONE`: anonymous caller, no identity provided.
+    None,
+    /// `AUTH_SYS`: UNIX-style caller identity.
+    Sys(AuthSysParams),
 }
 
 pub enum RejectedReply {

--- a/nfs-mamont/src/service/mount/mnt.rs
+++ b/nfs-mamont/src/service/mount/mnt.rs
@@ -6,7 +6,7 @@ use tracing::warn;
 
 use crate::mount::mnt::{Args, Fail, Mnt, Success};
 use crate::mount::{HostName, MountEntry};
-use crate::rpc::OpaqueAuth;
+use crate::rpc::Credential;
 
 use super::MountService;
 use super::AUTH;
@@ -16,7 +16,7 @@ impl Mnt for MountService {
         &self,
         args: Args,
         client_addr: SocketAddr,
-        _cred: OpaqueAuth,
+        _cred: Credential,
     ) -> Result<Success, Fail> {
         let Some(export) = self.export_entry(&args.dirpath).await else {
             let configured = self


### PR DESCRIPTION
This pr introduced changes to the structure of parser object.

Previous version used two-buffer logic, when parser buffers each next request in different one, that was used in previous request; also that required special (and quite complicated) logic to handle partial request receiving, when parser had to restore it's state to read missing part and try again.

New version basically implies the same logic, but uses single buffer; instead of "retrying" to parse incomplete request, it ensures, that request is fully received, and then starts to parse request. 


PR copies specific of parsing changes form `next` branch

Resolves: #292 