### PR TITLE
feat: use stable commit for mirrofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ dependencies = [
  "byteorder",
  "clap",
  "crossbeam-queue",
- "nfs-mamont",
+ "nfs-mamont 0.0.0 (git+https://github.com/RMamonts/nfs-mamont.git?rev=bd67fa28155e182dd5b369a772eb1be541790ebf)",
  "num-derive",
  "num-traits",
  "serde",
@@ -391,6 +391,22 @@ dependencies = [
  "byteorder",
  "crossbeam-queue",
  "libc",
+ "num-derive",
+ "num-traits",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "trait-variant",
+]
+
+[[package]]
+name = "nfs-mamont"
+version = "0.0.0"
+source = "git+https://github.com/RMamonts/nfs-mamont.git?rev=bd67fa28155e182dd5b369a772eb1be541790ebf#bd67fa28155e182dd5b369a772eb1be541790ebf"
+dependencies = [
+ "async-channel",
+ "byteorder",
+ "crossbeam-queue",
  "num-derive",
  "num-traits",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,6 @@ crossbeam-queue = "0.3.12"
 trait-variant = "0.1.2"
 
 # Internal dependencies
-nfs-mamont.path = "nfs-mamont"
+# Bump `rev` when mirrorfs is ready to move to a newer library revision.
+# for local tests can be used nfs-mamont.path = "nfs-mamont"
+nfs-mamont = { git = "https://github.com/RMamonts/nfs-mamont.git", rev = "bd67fa28155e182dd5b369a772eb1be541790ebf" }


### PR DESCRIPTION
simple PR that allows not to change mirrofs immediately with nfs-mamont lib